### PR TITLE
Various fixes

### DIFF
--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -1601,12 +1601,13 @@
 
 # sent_id = mst-0717
 # text = O son a Hülya'yı oturtup kaç gece uykumdan fırlamıştım.
+# Change 2.2/dev: mark 'kaç' as NUM
 1	O	o	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	2	det	_	_
 2	son	son	ADJ	Adj	_	5	amod	_	_
 3	a	a	INTJ	Interj	_	5	discourse	_	_
 4	Hülya'yı	Hülya	PROPN	Prop	Case=Acc|Number=Sing|Person=3	5	obj	_	_
 5	oturtup	otur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	9	nmod	_	_
-6	kaç	kaç	ADJ	Adj	_	7	amod	_	_
+6	kaç	kaç	NUM	Adj	NumType=Card	7	nummod	_	_
 7	gece	gece	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
 8	uykumdan	uyku	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	9	obl	_	_
 9	fırlamıştım	fırla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
@@ -7115,9 +7116,10 @@
 
 # sent_id = mst-3018
 # text = Yemek boyunca kaç hayvanın doğum yapacağı hesaplanıyor.
+# Change 2.2/dev: mark 'kaç' as NUM
 1	Yemek	yemek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
 2	boyunca	boyunca	ADP	PCNom	_	1	case	_	_
-3	kaç	kaç	ADJ	Adj	_	4	det	_	_
+3	kaç	kaç	NUM	Adj	NumType=Card	4	nummod	_	_
 4	hayvanın	hayvan	ADJ	NAdj	Case=Gen|Number=Sing|Person=3	6	nsubj	_	_
 5	doğum	doğum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 6	yapacağı	yap	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	7	obj	_	_
@@ -12239,9 +12241,10 @@
 
 # sent_id = mst-5256
 # text = Ama otobüsünün kaçta kalktığını sormayı unuttum.
+# Change 2.2/dev: mark 'kaç' as NUM
 1	Ama	ama	CCONJ	Conj	_	0	root	_	_
 2	otobüsünün	otobüs	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nmod:poss	_	_
-3	kaçta	kaç	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	4	amod	_	_
+3	kaçta	kaç	NUM	NAdj	Case=Loc|Number=Sing|NumType=Card|Person=3	4	obl	_	_
 4	kalktığını	kalk	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	5	obj	_	_
 5	sormayı	sor	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	obj	_	_
 6	unuttum	unut	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -2712,6 +2712,7 @@
 
 # sent_id = mst-1176
 # text = ' haberine göre hükümet iki ikramiyenin ödenmemesi konusunda karar verirse ikibinüç yılında sadece bu kalemden üçyüzon trilyon liralık tasarruf sağlamış olacak.
+# Fix 2.2/dev: form with '_'
 1	'	'	PUNCT	Punc	_	2	punct	_	_
 2	haberine	haber	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	22	obl	_	_
 3	göre	göre	ADP	PCDat	_	2	case	_	_
@@ -2730,8 +2731,8 @@
 16	üçyüzon	üçyüzon	NUM	ANum	NumType=Card	19	nummod	_	_
 17	trilyon	trilyon	NUM	ANum	NumType=Card	16	flat	_	_
 18-19	liralık	_	_	_	_	_	_	_	_
-18	_	lira	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	flat	_	_
-19	liralık	_	ADJ	Adj	_	20	amod	_	_
+18	lira	lira	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	flat	_	_
+19	lık	lik	ADP	Ness	_	18	case	_	_
 20	tasarruf	tasarruf	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	obj	_	_
 21	sağlamış	sağla	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	22	obj	_	_
 22	olacak	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	SpaceAfter=No
@@ -3176,8 +3177,8 @@
 11	dörtyüzseksensekiz	dörtyüzseksensekiz	NUM	ANum	NumType=Card	9	flat	_	_
 12	bin	bin	NUM	ANum	NumType=Card	9	flat	_	_
 13-14	liralık	_	_	_	_	_	_	_	_
-13	_	lira	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	flat	_	_
-14	liralık	_	ADJ	Adj	_	15	amod	_	_
+13	lira	lira	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	flat	_	_
+14	lık	lik	ADP	Ness	_	13	case	_	_
 15	zam	zam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	obj	_	_
 16	anlamına	anlam	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 17	gelecek	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	16	compound	_	SpaceAfter=No
@@ -8663,6 +8664,7 @@
 
 # sent_id = mst-3667
 # text = Hükümet Ramazan Bayramı öncesinde yoksullara Sosyal Yardımlaşma ve Dayanışma Vakıfları tarafından dağıtılmak üzere onsekiz trilyonluk kaynak ayrıldığını duyurdu.
+# Fix 2.2/dev: form with '_'
 1	Hükümet	hükümet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	nsubj	_	_
 2	Ramazan	ramazan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod	_	_
 3	Bayramı	bayram	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	flat	_	_
@@ -8678,8 +8680,8 @@
 13	üzere	üzere	ADP	PCNom	_	12	case	_	_
 14	onsekiz	onsekiz	NUM	ANum	NumType=Card	16	nummod	_	_
 15-16	trilyonluk	_	_	_	_	_	_	_	_
-15	_	trilyon	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	14	flat	_	_
-16	trilyonluk	_	ADJ	Adj	_	17	amod	_	_
+15	trilyon	trilyon	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	14	flat	_	_
+16	luk	lik	ADP	Ness	_	15	case	_	_
 17	kaynak	kaynak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	obj	_	_
 18	ayrıldığını	ayrıl	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	19	obj	_	_
 19	duyurdu	duyur	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -11565,24 +11567,23 @@
 
 # sent_id = mst-4922
 # text = Hatırladığım kadarıyla gene ikimizin de meslektaşı olan Yüksel Hanım, komşu evin balkonundan bizi seyrediyordu.
-1	Hatırladığım	hatırla	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	3	nmod	_	_
-2-3	kadarıyla	_	_	_	_	_	_	_	_
-2	_	kadar	ADP	PCNom	_	1	case	_	_
-3	kadarıyla	_	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obl	_	_
-4	gene	gene	ADV	Adverb	_	16	advmod	_	_
-5	ikimizin	iki	NUM	NNum	Case=Gen|Number=Sing|Number[psor]=Plur|NumType=Card|Person=3|Person[psor]=1	7	nmod:poss	_	_
-6	de	de	CCONJ	Conj	_	5	advmod:emph	_	_
-7	meslektaşı	meslektaş	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
-8	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	acl	_	_
-9	Yüksel	Yüksel	PROPN	Prop	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
-10	Hanım	hanım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nmod	_	SpaceAfter=No
-11	,	,	PUNCT	Punc	_	16	punct	_	_
-12	komşu	komşu	ADJ	Adj	_	13	amod	_	_
-13	evin	ev	NOUN	Noun	Case=Gen|Number=Sing|Person=3	14	nmod:poss	_	_
-14	balkonundan	balkon	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obl	_	_
-15	bizi	biz	PRON	Pers	Case=Acc|Number=Plur|Person=1|PronType=Prs	16	obj	_	_
-16	seyrediyordu	seyret	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
-17	.	.	PUNCT	Punc	_	16	punct	_	_
+# Fix 2.2/dev: form with '_'
+1	Hatırladığım	hatırla	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	2	nmod:poss	_	_
+2	kadarıyla	kadar	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obl	_	_
+3	gene	gene	ADV	Adverb	_	16	advmod	_	_
+4	ikimizin	iki	NUM	NNum	Case=Gen|Number=Sing|Number[psor]=Plur|NumType=Card|Person=3|Person[psor]=1	7	nmod:poss	_	_
+5	de	de	CCONJ	Conj	_	5	advmod:emph	_	_
+6	meslektaşı	meslektaş	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
+7	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	acl	_	_
+8	Yüksel	Yüksel	PROPN	Prop	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
+9	Hanım	hanım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nmod	_	SpaceAfter=No
+10	,	,	PUNCT	Punc	_	16	punct	_	_
+11	komşu	komşu	ADJ	Adj	_	13	amod	_	_
+12	evin	ev	NOUN	Noun	Case=Gen|Number=Sing|Person=3	14	nmod:poss	_	_
+13	balkonundan	balkon	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obl	_	_
+14	bizi	biz	PRON	Pers	Case=Acc|Number=Plur|Person=1|PronType=Prs	16	obj	_	_
+15	seyrediyordu	seyret	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
+16	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-4928
 # text = Aklımızdan çıktığı yok ki.

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -544,7 +544,7 @@
 8	kimi	kimi	DET	Det	_	9	det	_	_
 9	tepelerde	tepe	NOUN	Noun	Case=Loc|Number=Plur|Person=3	1	conj	_	_
 10	oturup	otur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	14	nmod	_	_
-11	DYP'ye	Dyp	NOUN	Abr	Abbr=Yes|Case=Dat|Number=Sing|Person=3	14	obl	_	_
+11	DYP'ye	DYP	PROPN	Abr	Abbr=Yes|Case=Dat|Number=Sing|Person=3	14	obl	_	_
 12	icazetle	icazet	NOUN	Noun	Case=Ins|Number=Sing|Person=3	14	obl	_	_
 13	başkan	başkan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	obj	_	_
 14	olma	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	15	nmod:poss	_	_
@@ -714,10 +714,11 @@
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-0327
-# text = İMKB'nin orta ve uzun vadeli getiri potansiyelinden yararlanmak isteyen yatırımcılar için iki alternatif var: Risk alabilen yatırımcılar için A tipi endeks ve hisse fonlar veya İmkb'deki potansiyelden yararlanırken fazla risk almak istemiyorum diyenler için ise A tipi karma ve değişken fonlar.
+# text = İMKB'nin orta ve uzun vadeli getiri potansiyelinden yararlanmak isteyen yatırımcılar için iki alternatif var: Risk alabilen yatırımcılar için A tipi endeks ve hisse fonlar veya İMKB'deki potansiyelden yararlanırken fazla risk almak istemiyorum diyenler için ise A tipi karma ve değişken fonlar.
 # Change 2.2/dev: merge -(y)An
 # Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
-1	İMKB'nin	İmkb	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	8	nmod:poss	_	_
+# Change 2.2/dev: fix 'lowercasing' of İMKB
+1	İMKB'nin	İMKB	PROPN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	8	nmod:poss	_	_
 2	orta	orta	ADJ	Adj	_	5	amod	_	_
 3	ve	ve	CCONJ	Conj	_	4	cc	_	_
 4	uzun	uzun	ADJ	Adj	_	2	conj	_	_
@@ -745,8 +746,8 @@
 25	hisse	hisse	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	conj	_	_
 26	fonlar	fon	NOUN	Noun	Case=Nom|Number=Plur|Person=3	23	compound	_	_
 27	veya	veya	CCONJ	Conj	_	44	cc	_	_
-28-29	İmkb'deki	_	_	_	_	_	_	_	_
-28	İmkb'de	İmkb	PROPN	Prop	Case=Loc|Number=Sing|Person=3	30	nmod	_	_
+28-29	İMKB'deki	_	_	_	_	_	_	_	_
+28	İMKB'de	İMKB	PROPN	Prop	Case=Loc|Number=Sing|Person=3	30	nmod	_	_
 29	ki	ki	ADP	Rel	_	28	case	_	_
 30	potansiyelden	potansiyel	NOUN	Noun	Case=Abl|Number=Sing|Person=3	31	obl	_	_
 31	yararlanırken	yararlan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	33	nmod	_	_
@@ -2784,10 +2785,11 @@
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1204
-# text = Ben bir tutsakım, dedi.
+# text = Ben bir tutsağım, dedi.
+# Change 2.2/dev: fix 'tutsa*k*ım' - original is 'tutsağım'
 1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 2	bir	bir	NUM	ANum	NumType=Card	3	det	_	_
-3-4	tutsakım	_	_	_	_	_	_	_	SpaceAfter=No
+3-4	tutsağım	_	_	_	_	_	_	_	SpaceAfter=No
 3	tutsak	tutsak	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	6	ccomp	_	_
 4	ım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	3	cop	_	_
 5	,	,	PUNCT	Punc	_	6	punct	_	_
@@ -8404,12 +8406,13 @@
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-3560
-# text = Rallici Behzat ', yedideeki Diyarbakır uçağını uyuyakaldığı için kaçırdı ve akşam düşen uçağa bindi.
+# text = Rallici Behzat ', yedideki Diyarbakır uçağını uyuyakaldığı için kaçırdı ve akşam düşen uçağa bindi.
+# Change 2.2/dev: fix typo (not in the original, introduced later)
 1	Rallici	rallici	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod	_	_
 2	Behzat	Behzat	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
 3	'	'	PUNCT	Punc	_	2	punct	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	11	punct	_	_
-5-6	yedideeki	_	_	_	_	_	_	_	_
+5-6	yedideki	_	_	_	_	_	_	_	_
 5	yedide	yedi	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	8	nmod:poss	_	_
 6	eki	ki	ADP	Rel	_	5	case	_	_
 7	Diyarbakır	Diyarbakır	PROPN	Prop	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
@@ -10508,16 +10511,18 @@
 
 # sent_id = mst-4437
 # text = -Evet, ben de üstün zekalıyım.
+# Change 2.2/dev: split -lI
 1	-	-	PUNCT	Punc	_	0	root	_	SpaceAfter=No
 2	Evet	evet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	7	punct	_	_
 4	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	_	_
 5	de	de	CCONJ	Conj	_	4	advmod:emph	_	_
 6	üstün	üstün	ADJ	Adj	_	7	amod	_	_
-7-8	zekalıyım	_	_	_	_	_	_	_	SpaceAfter=No
+7-9	zekalıyım	_	_	_	_	_	_	_	SpaceAfter=No
 7	zekalı	zekâlı	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	1	conj	_	_
-8	yım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	7	cop	_	_
-9	.	.	PUNCT	Punc	_	7	punct	_	_
+8	lı	li	ADP	With	_	7	case	_	_
+9	yım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	7	cop	_	_
+10	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-4441
 # text = Böylece hem yalan söylememiş olduk, hem de Harbiyelinin işini kolaylaştırdık.
@@ -10807,10 +10812,11 @@
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4567
-# text = Yeni İhale kanunundaaki " yerlilik " tanımı, Türkiye'de yıllardır faaliyet gösteren, yerleşik yabancı sermayeli şirketlerin faaliyetini sınırlandırdı.
+# text = Yeni İhale kanunundaki " yerlilik " tanımı, Türkiye'de yıllardır faaliyet gösteren, yerleşik yabancı sermayeli şirketlerin faaliyetini sınırlandırdı.
+# Change 2.2/dev: fix typo (not in the original, introduced later)
 1	Yeni	yeni	ADJ	Adj	_	2	amod	_	_
 2	İhale	ihale	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nmod	_	_
-3-4	kanunundaaki	_	_	_	_	_	_	_	_
+3-4	kanunundaki	_	_	_	_	_	_	_	_
 3	kanununda	kanun	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	compound	_	_
 4	aki	ki	ADP	Rel	_	2	case	_	_
 5	"	"	PUNCT	Punc	_	6	punct	_	_
@@ -12786,10 +12792,11 @@
 2	nakil	nakil	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 3	girişimlerinden	girişim	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	5	obl	_	_
 4	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
-5-6	haberliyim	_	_	_	_	_	_	_	SpaceAfter=No
+5-7	haberliyim	_	_	_	_	_	_	_	SpaceAfter=No
 5	haberli	haberli	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
-6	yim	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	5	cop	_	_
-7	...	...	PUNCT	Punc	_	5	conj	_	_
+6	li	li		ADP	With	_	5	case	_	_
+7	yim	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	5	cop	_	_
+8	...	...	PUNCT	Punc	_	5	conj	_	_
 
 # sent_id = mst-5464
 # text = Kendisini gönülden kutluyorum.
@@ -12864,7 +12871,8 @@
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-5499
-# text = Gördüğünüz gibi, hiçbir zaman kurtulamayacak, özgür olamayacak bir tutsakım ben.
+# text = Gördüğünüz gibi, hiçbir zaman kurtulamayacak, özgür olamayacak bir tutsağım ben.
+# Change 2.2/dev: fix 'tutsa*k*ım' - original is 'tutsağım'
 1	Gördüğünüz	gör	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	0	root	_	_
 2	gibi	gibi	ADP	PCNom	_	1	case	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	13	punct	_	_
@@ -12875,7 +12883,7 @@
 8	özgür	özgür	ADJ	Adj	_	9	obj	_	_
 9	olamayacak	ol	VERB	Verb	Aspect=Perf|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Fut	6	conj	_	_
 10	bir	bir	NUM	ANum	NumType=Card	11	det	_	_
-11-12	tutsakım	_	_	_	_	_	_	_	_
+11-12	tutsağım	_	_	_	_	_	_	_	_
 11	tutsak	tutsak	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	13	ccomp	_	_
 12	ım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	11	cop	_	_
 13	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	1	conj	_	SpaceAfter=No

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -2320,11 +2320,12 @@
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1007
-# text = -?edenmişo?
-1	-	-	PUNCT	Punc	_	0	root	_	SpaceAfter=No
-2-3	?edenmiş	_	_	_	_	_	_	_	SpaceAfter=No
-2	?	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	1	conj	_	_
-3	edenmiş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	2	cop	_	_
+# text = - Nedenmiş o?
+# Fixed 2.2/dev: original sentence ID: 00048220573/1
+1	-	-	PUNCT	Punc	_	0	root	_	_
+2-3	Nedenmiş	_	_	_	_	_	_	_	_
+2	Neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	1	conj	_	_
+3	miş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	2	cop	_	_
 4	o	o	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	2	nsubj	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	2	punct	_	_
 
@@ -3015,11 +3016,12 @@
 19	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-1303
-# text = Özer'lerin ?ithatpaşa'dakibahçe içindeki evindeydik.
+# text = Özer'lerin Mithatpaşa'daki bahçe içindeki evindeydik.
+# Fixed 2.2/dev: original sentence ID: 00131260886/2
 1	Özer'lerin	Özer	PROPN	Prop	Case=Gen|Number=Plur|Person=3	7	nmod:poss	_	_
-2-3	?ithatpaşa'daki	_	_	_	_	_	_	_	SpaceAfter=No
-2	?	Mithatpaşa	PROPN	Prop	Case=Loc|Number=Sing|Person=3	7	nmod	_	_
-3	ithatpaşa'daki	ki	ADP	Rel	_	2	case	_	_
+2-3	Mithatpaşa'daki	_	_	_	_	_	_	_	_
+2	Mithatpaşa'da	Mithatpaşa	PROPN	Prop	Case=Loc|Number=Sing|Person=3	7	nmod	_	_
+3	ki	ki	ADP	Rel	_	2	case	_	_
 4	bahçe	bahçe	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
 5-6	içindeki	_	_	_	_	_	_	_	_
 5	içinde	iç	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	amod	_	_
@@ -3635,11 +3637,12 @@
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-1555
-# text = Sen ?usevisin, değil mi Maryline.
+# text = Sen Musevisin, değil mi Maryline.
+# Fixed 2.2/dev: original sentence ID: 0000613059/1
 1	Sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	2	nsubj	_	_
-2-3	?usevisin	_	_	_	_	_	_	_	SpaceAfter=No
-2	?	Musevi	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	5	amod	_	_
-3	usevisin	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Pres	2	cop	_	_
+2-3	Musevisin	_	_	_	_	_	_	_	SpaceAfter=No
+2	Musevi	Musevi	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	5	amod	_	_
+3	sin	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Pres	2	cop	_	_
 4	,	,	PUNCT	Punc	_	5	punct	_	_
 5	değil	değil	CCONJ	Conj	_	0	root	_	_
 6	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	5	aux:q	_	_
@@ -5317,10 +5320,11 @@
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-2245
-# text = ?imsiniz?
-1-2	?imsiniz	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	imsiniz	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	1	cop	_	_
+# text = Kimsiniz?
+# Fixed 2.2/dev: original sentence ID: 00099161431/1
+1-2	Kimsiniz	_	_	_	_	_	_	_	SpaceAfter=No
+1	Kim	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
+2	siniz	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	1	cop	_	_
 3	?	?	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-2248
@@ -5828,10 +5832,11 @@
 17	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-2490
-# text = ?imsekim?
-1-2	?imse	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	3	advmod:emph	_	_
-2	imse	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	1	cop	_	_
+# text = Kimse kim?
+# Fixed 2.2/dev: original sentence ID: 001422111078/6
+1-2	Kimse	_	_	_	_	_	_	_	_
+1	Kim	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	3	advmod:emph	_	_
+2	se	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	1	cop	_	_
 3	kim	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 4	?	?	PUNCT	Punc	_	3	punct	_	_
 
@@ -7343,14 +7348,15 @@
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-3119
-# text = İMKB ikibiniki yılını yüzde ?irmibeş'likkayıpla kapatırken dolar bazlı yıllık kayıp ise yüzde otuzbeş oldu.
+# text = İMKB ikibiniki yılını yüzde yirmibeş'lik kayıpla kapatırken dolar bazlı yıllık kayıp ise yüzde otuzbeş oldu.
+# Fixed 2.2/dev: original sentence ID: 21040000-29/1
 1	İMKB	İmkb	PROPN	Prop	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
 2	ikibiniki	ikibiniki	NUM	ANum	NumType=Card	3	nummod	_	_
 3	yılını	yıl	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
 4	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	7	nummod	_	_
-5-6	?irmibeş'lik	_	_	_	_	_	_	_	SpaceAfter=No
-5	?	yirmibeş	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	4	flat	_	_
-6	irmibeş'lik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	4	case	_	_
+5-6	yirmibeş'lik	_	_	_	_	_	_	_	_
+5	yirmibeş	yirmibeş	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	4	flat	_	_
+6	'lik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	4	case	_	_
 7	kayıpla	kayıp	ADJ	NAdj	Case=Ins|Number=Sing|Person=3	8	amod	_	_
 8	kapatırken	kapa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv|Voice=Cau	17	nmod	_	_
 9	dolar	dolar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod	_	_

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -320,8 +320,9 @@
 
 # sent_id = mst-0161
 # text = Alışveriş ise hayatın temelinde yatar.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Alışveriş	alışveriş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+2	ise	i	AUX	Conj	_	1	discourse	_	_
 3	hayatın	hayat	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
 4	temelinde	temel	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	amod	_	_
 5	yatar	yat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
@@ -349,7 +350,7 @@
 1	Başbakan	başbakan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod	_	_
 2	Abdullah	Abdullah	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	_
 3	Gül	Gül	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	flat	_	_
-4	ise	ise	CCONJ	Conj	_	2	discourse	_	_
+4	ise	i	AUX	Conj	_	2	discourse	_	_
 5	"	"	PUNCT	Punc	_	4	punct	_	_
 6	Bizim	biz	PRON	Pers	Case=Gen|Number=Plur|Person=1|PronType=Prs	8	nmod:poss	_	_
 7	her	her	DET	Det	_	8	det	_	_
@@ -715,6 +716,7 @@
 # sent_id = mst-0327
 # text = İMKB'nin orta ve uzun vadeli getiri potansiyelinden yararlanmak isteyen yatırımcılar için iki alternatif var: Risk alabilen yatırımcılar için A tipi endeks ve hisse fonlar veya İmkb'deki potansiyelden yararlanırken fazla risk almak istemiyorum diyenler için ise A tipi karma ve değişken fonlar.
 # Change 2.2/dev: merge -(y)An
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	İMKB'nin	İmkb	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	8	nmod:poss	_	_
 2	orta	orta	ADJ	Adj	_	5	amod	_	_
 3	ve	ve	CCONJ	Conj	_	4	cc	_	_
@@ -754,7 +756,7 @@
 35	istemiyorum	iste	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Polite=Infm|Tense=Pres	36	obj	_	_
 36	diyenler	de	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	44	acl	_	_
 37	için	için	ADP	PCNom	_	36	case	_	_
-38	ise	ise	CCONJ	Conj	_	36	discourse	_	_
+38	ise	i	AUX	Conj	_	36	discourse	_	_
 39	A	a	INTJ	Interj	_	15	discourse	_	_
 40	tipi	tip	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	39	compound	_	_
 41	karma	karma	ADJ	Adj	_	44	amod	_	_
@@ -1000,11 +1002,12 @@
 
 # sent_id = mst-0445
 # text = Öteki masalardakiler ise balıklarını daha yeni yiyorlardı.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Öteki	öteki	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	det	_	_
 2-3	masalardakiler	_	_	_	_	_	_	_	_
 2	masalarda	masa	NOUN	Noun	Case=Loc|Number=Plur|Person=3	8	nsubj	_	_
 3	kiler	ki	ADP	Rel	Case=Nom|Number=Plur|Person=3	2	case	_	_
-4	ise	ise	CCONJ	Conj	_	2	discourse	_	_
+4	ise	i	AUX	Conj	_	2	discourse	_	_
 5	balıklarını	balık	ADJ	NAdj	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	8	obj	_	_
 6	daha	daha	ADV	Adverb	_	7	advmod	_	_
 7	yeni	yeni	ADJ	Adj	_	8	amod	_	_
@@ -2007,11 +2010,12 @@
 
 # sent_id = mst-0882
 # text = Dip seviyelerde seyreden borsada ise yükselişin başlaması durumunda ciddi bir getiri imkanı bulunuyor.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Dip	dip	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod	_	_
 2	seviyelerde	seviye	NOUN	Noun	Case=Loc|Number=Plur|Person=3	4	nmod	_	_
 3	seyreden	seyret	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	acl	_	_
 4	borsada	borsa	NOUN	Noun	Case=Loc|Number=Sing|Person=3	13	obl	_	_
-5	ise	ise	CCONJ	Conj	_	4	discourse	_	_
+5	ise	i	AUX	Conj	_	4	discourse	_	_
 6	yükselişin	yükseliş	NOUN	Noun	Case=Gen|Number=Sing|Person=3	7	nmod:poss	_	_
 7	başlaması	başla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nmod:poss	_	_
 8	durumunda	durum	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	obl	_	_
@@ -2064,9 +2068,10 @@
 
 # sent_id = mst-0902
 # text = Anadolu'nun peynirleri ise çok çeşitli: Tulum peynirleri, otlu peynirler.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Anadolu'nun	Anadolu	PROPN	Prop	Case=Gen|Number=Sing|Person=3	2	nmod:poss	_	_
 2	peynirleri	peynir	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	5	nsubj	_	_
-3	ise	ise	CCONJ	Conj	_	2	discourse	_	_
+3	ise	i	AUX	Conj	_	2	discourse	_	_
 4	çok	çok	ADV	Adverb	_	5	advmod	_	_
 5	çeşitli	çeşitli	ADJ	Adj	_	0	root	_	SpaceAfter=No
 6	:	:	PUNCT	Punc	_	8	punct	_	_
@@ -2884,8 +2889,9 @@
 
 # sent_id = mst-1249
 # text = Piyaz ise kendi başına yarışamayacağını bilir.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Piyaz	piyaz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+2	ise	i	AUX	Conj	_	1	discourse	_	_
 3	kendi	kendi	PRON	Reflex	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	5	obl	_	_
 4	başına	baş	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	compound	_	_
 5	yarışamayacağını	yarış	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Fut|VerbForm=Part	6	obj	_	_
@@ -3059,9 +3065,10 @@
 
 # sent_id = mst-1325
 # text = Antropolojinin temelinde ise insan, insan davranışları, çevreyle etkileşimi yatar.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Antropolojinin	antropoloji	NOUN	Noun	Case=Gen|Number=Sing|Person=3	2	nmod:poss	_	_
 2	temelinde	temel	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	amod	_	_
-3	ise	ise	CCONJ	Conj	_	2	discourse	_	_
+3	ise	i	AUX	Conj	_	2	discourse	_	_
 4	insan	insan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nsubj	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	7	punct	_	_
 6	insan	insan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod:poss	_	_
@@ -3466,6 +3473,7 @@
 
 # sent_id = mst-1494
 # text = Tabi ki, ev yapmak olanaklı ise.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Tabi	tabi	INTJ	Interj	_	6	discourse	_	_
 2	ki	ki	CCONJ	Conj	_	1	advmod:emph	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	6	punct	_	_
@@ -3474,7 +3482,7 @@
 6-7	olanaklı	_	_	_	_	_	_	_	_
 6	olanak	olanak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 7	lı	li	ADP	With	_	6	case	_	_
-8	ise	ise	CCONJ	Conj	_	6	discourse	_	SpaceAfter=No
+8	ise	i	AUX	Conj	_	6	discourse	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-1501
@@ -4250,6 +4258,7 @@
 
 # sent_id = mst-1818
 # text = Haberin yayımlandığı günle ilgili olarak Arınç'ın Akyol'a böyle yansıttığı Milliyet temsilcileriyle diyalogları ise şöyle gelişti:.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Haberin	haber	NOUN	Noun	Case=Gen|Number=Sing|Person=3	2	nmod:poss	_	_
 2	yayımlandığı	yayımla	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	3	acl	_	_
 3	günle	gün	NOUN	Noun	Case=Ins|Number=Sing|Person=3	4	nmod	_	_
@@ -4262,7 +4271,7 @@
 10	Milliyet	milliyet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nmod:poss	_	_
 11	temsilcileriyle	temsilci	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	12	obj	_	_
 12	diyalogları	diyalog	NOUN	Noun	Case=Acc|Number=Plur|Person=3	15	nsubj	_	_
-13	ise	ise	CCONJ	Conj	_	12	discourse	_	_
+13	ise	i	AUX	Conj	_	12	discourse	_	_
 14	şöyle	şöyle	ADV	Adverb	_	15	advmod	_	_
 15	gelişti	geliş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 16	:	:	PUNCT	Punc	_	15	punct	_	SpaceAfter=No
@@ -6421,13 +6430,14 @@
 
 # sent_id = mst-2723
 # text = Hemen ardından kasabadan gelen kamyonun sesi ise kervanda paniğe neden oluyor.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Hemen	hemen	ADV	Adverb	_	4	advmod	_	_
 2	ardından	ardından	ADV	Adverb	_	4	advmod	_	_
 3	kasabadan	kasaba	NOUN	Noun	Case=Abl|Number=Sing|Person=3	4	obl	_	_
 4	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	acl	_	_
 5	kamyonun	kamyon	NOUN	Noun	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
 6	sesi	ses	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nsubj	_	_
-7	ise	ise	CCONJ	Conj	_	6	discourse	_	_
+7	ise	i	AUX	Conj	_	6	discourse	_	_
 8	kervanda	kervan	NOUN	Noun	Case=Loc|Number=Sing|Person=3	10	nmod	_	_
 9	paniğe	panik	NOUN	Noun	Case=Dat|Number=Sing|Person=3	10	nmod	_	_
 10	neden	neden	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
@@ -6582,8 +6592,9 @@
 
 # sent_id = mst-2791
 # text = Alev ise babası tarafından (kız çocuk olduğu için) önemsenmiyor ve teyzesinin kızı tarafından büyütülüyor.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Alev	Alev	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	obj	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+2	ise	i	AUX	Conj	_	1	discourse	_	_
 3	babası	baba	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nmod:poss	_	_
 4	tarafından	taraf	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obl	_	_
 5	(	(	PUNCT	Punc	_	8	punct	_	SpaceAfter=No
@@ -7308,9 +7319,10 @@
 
 # sent_id = mst-3111
 # text = ) Bazıları ise muadil ya da alternatif kavramlar üretti.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	)	)	PUNCT	Punc	_	0	root	_	_
 2	Bazıları	bazı	PRON	Quant	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	9	nsubj	_	_
-3	ise	ise	CCONJ	Conj	_	2	discourse	_	_
+3	ise	i	AUX	Conj	_	2	discourse	_	_
 4	muadil	muadil	ADJ	Adj	_	8	amod	_	_
 5	ya	ya	CCONJ	Conj	_	4	compound	_	_
 6	da	da	CCONJ	Conj	_	4	compound	_	_
@@ -7340,6 +7352,7 @@
 # sent_id = mst-3119
 # text = İMKB ikibiniki yılını yüzde yirmibeş'lik kayıpla kapatırken dolar bazlı yıllık kayıp ise yüzde otuzbeş oldu.
 # Fixed 2.2/dev: original sentence ID: 21040000-29/1
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	İMKB	İmkb	PROPN	Prop	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
 2	ikibiniki	ikibiniki	NUM	ANum	NumType=Card	3	nummod	_	_
 3	yılını	yıl	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
@@ -7355,7 +7368,7 @@
 11	lı	li	ADP	With	_	10	case	_	_
 12	yıllık	yıllık	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	13	amod	_	_
 13	kayıp	kayıp	ADJ	Adj	_	17	nsubj	_	_
-14	ise	ise	CCONJ	Conj	_	13	discourse	_	_
+14	ise	i	AUX	Conj	_	13	discourse	_	_
 15	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	17	nummod	_	_
 16	otuzbeş	otuzbeş	NUM	ANum	NumType=Card	15	flat	_	_
 17	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -8734,6 +8747,7 @@
 
 # sent_id = mst-3691
 # text = Çocukları pek sevmem, ama onlarla konuşmaktan hoşlanırım; çünkü bence insanların en ilginç fikirleri aslında söylemeyip kendilerine sakladıkları fikirleridir, çocuklar ise hiçbir düşüncelerini kendilerine saklamazlar hemen söylerler, onun için onlarla konuşurken daima ilginç bir şeyler duyabilirsiniz.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Çocukları	çocuk	NOUN	Noun	Case=Acc|Number=Plur|Person=3	3	obj	_	_
 2	pek	pek	ADV	Adverb	_	3	advmod	_	_
 3	sevmem	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
@@ -8758,7 +8772,7 @@
 21	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	20	cop	_	_
 22	,	,	PUNCT	Punc	_	28	punct	_	_
 23	çocuklar	çocuk	NOUN	Noun	Case=Nom|Number=Plur|Person=3	30	nsubj	_	_
-24	ise	ise	CCONJ	Conj	_	23	discourse	_	_
+24	ise	i	AUX	Conj	_	23	discourse	_	_
 25	hiçbir	hiçbir	DET	Det	_	26	det	_	_
 26	düşüncelerini	düşünce	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	28	obj	_	_
 27	kendilerine	kendi	PRON	Reflex	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|Reflex=Yes	28	obl	_	_
@@ -10069,6 +10083,7 @@
 
 # sent_id = mst-4265
 # text = Bu tarihe kadar satılan besyuzelli bin araç ise, Japonya'da ithal edilmişti.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	tarihe	tarih	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
 3	kadar	kadar	ADP	PCDat	_	2	case	_	_
@@ -10076,7 +10091,7 @@
 5	besyuzelli	besyuzelli	NUM	ANum	NumType=Card	7	nummod	_	_
 6	bin	bin	NUM	ANum	NumType=Card	5	flat	_	_
 7	araç	araç	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
-8	ise	ise	CCONJ	Conj	_	7	discourse	_	SpaceAfter=No
+8	ise	i	AUX	Conj	_	7	discourse	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	11	punct	_	_
 10	Japonya'da	Japonya	PROPN	Prop	Case=Loc|Number=Sing|Person=3	11	nmod	_	_
 11	ithal	ithal	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
@@ -11332,6 +11347,7 @@
 
 # sent_id = mst-4827
 # text = Pilot Yunak'ın sinir krizleri geçiren annesi Rüveyde Yunak ile ablası Asuman Taran ise doktor '..
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Pilot	pilot	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod	_	_
 2	Yunak'ın	Yunak	PROPN	Prop	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
 3	sinir	sinir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
@@ -11344,7 +11360,7 @@
 10	ablası	abla	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	conj	_	_
 11	Asuman	Asuman	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	conj	_	_
 12	Taran	Taran	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	flat	_	_
-13	ise	ise	CCONJ	Conj	_	11	discourse	_	_
+13	ise	i	AUX	Conj	_	11	discourse	_	_
 14	doktor	doktor	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 15	'	'	PUNCT	Punc	_	14	punct	_	SpaceAfter=No
 16	..	..	PUNCT	Punc	_	14	punct	_	_
@@ -11610,6 +11626,7 @@
 
 # sent_id = mst-4941
 # text = THY Uçuş İşletme Başkanı Kaptan Pilot İlhami Rojda ise, ailenin verdiği bilginin aksine Ulusu'nun kaza günü stand Rojda (nöbetçi) olmadığını söyledi.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	THY	Thy	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	2	compound	_	_
 2	Uçuş	uçuş	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	6	nmod	_	_
 3	İşletme	işletme	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound	_	_
@@ -11618,7 +11635,7 @@
 6	Pilot	pilot	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
 7	İlhami	İlhami	PROPN	Prop	Case=Nom|Number=Sing|Person=3	24	nsubj	_	_
 8	Rojda	Rojda	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	flat	_	_
-9	ise	ise	CCONJ	Conj	_	7	discourse	_	SpaceAfter=No
+9	ise	i	AUX	Conj	_	7	discourse	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	24	punct	_	_
 11	ailenin	aile	NOUN	Noun	Case=Gen|Number=Sing|Person=3	12	nmod:poss	_	_
 12	verdiği	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	13	acl	_	_

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -3665,9 +3665,10 @@
 
 # sent_id = mst-1572
 # text = Çok sık mı aşık olur Mahmut? diye sordum.
+# Change 2.2/dev: fix incorrect -mI annotation
 1	Çok	çok	ADV	Adverb	_	2	advmod	_	_
 2	sık	sık	ADV	Adverb	_	4	advmod	_	_
-3	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	2	advmod:emph	_	_
+3	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	2	aux:q	_	_
 4	aşık	aşık	ADJ	Adj	_	9	amod	_	_
 5	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	4	compound:lvc	_	_
 6	Mahmut	Mahmut	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nsubj	_	SpaceAfter=No

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -325,7 +325,7 @@
 2	ise	i	AUX	Conj	_	1	discourse	_	_
 3	hayatın	hayat	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
 4	temelinde	temel	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	amod	_	_
-5	yatar	yat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	yatar	yat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-0165
@@ -337,7 +337,7 @@
 5	kaş	kaş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
 6	göz	göz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	compound	_	_
 7	hareketleriyle	hareket	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	5	compound	_	_
-8	sanırım	san	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	13	nmod	_	_
+8	sanırım	san	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	13	nmod	_	_
 9	bağırmama	bağır	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	10	nmod	_	_
 10	gerek	gerek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
 11	olmadığını	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	12	obj	_	_
@@ -374,7 +374,7 @@
 2	kendisine	kendi	PRON	Reflex	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	3	nmod	_	_
 3	rakip	rakip	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obl	_	_
 4	sevgili	sevgili	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	5	obj	_	_
-5	tanımaz	tanı	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+5	tanımaz	tanı	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-0193
@@ -509,7 +509,7 @@
 # sent_id = mst-0258
 # text = Fransız böbürlenir.
 1	Fransız	Fransız	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
-2	böbürlenir	böbürlen	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	böbürlenir	böbürlen	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0262
@@ -558,7 +558,7 @@
 22	partinin	parti	NOUN	Noun	Case=Gen|Number=Sing|Person=3	23	nmod:poss	_	_
 23	tabanı	taban	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	25	nsubj	_	_
 24	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	25	obj	_	_
-25	derse	de	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	27	obj	_	_
+25	derse	de	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	27	obj	_	_
 26	o	o	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	27	nsubj	_	_
 27	olacak	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	18	conj	_	SpaceAfter=No
 28	.	.	PUNCT	Punc	_	27	punct	_	_
@@ -602,7 +602,7 @@
 10	hisse	hisse	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
 11	senedine	senet	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	compound	_	_
 12	kayacağı	kay	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	13	nsubj	_	_
-13	söylenebilir	söyle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+13	söylenebilir	söyle	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-0300
@@ -614,7 +614,7 @@
 5	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	_	_
 6	ne	ne	CCONJ	Conj	_	8	cc	_	_
 7	şiir	şiir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8	okuyabilirim	oku	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+8	okuyabilirim	oku	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	12	punct	_	_
 10	ne	ne	CCONJ	Conj	_	12	cc	_	_
 11	de	de	CCONJ	Conj	_	10	advmod:emph	_	_
@@ -638,7 +638,7 @@
 # text = Ne kadar özlersem özleyeyim, yaşadığım ve işte şimdi bile büyük bir zevkle heyecan veren yaşadığım şu an, geçmişin acısı, donanımsız olduğumuz o günlere, bu yüzden çocuksu olan, bu yüzden çıplak olan, bu yüzden o anda hiç bilmesek de mutlu olduğumuz o günlere özlemimden doğuyor.
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	3	obl	_	_
 2	kadar	kadar	ADP	PCNom	_	1	case	_	_
-3	özlersem	özle	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	51	nmod	_	_
+3	özlersem	özle	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	51	nmod	_	_
 4	özleyeyim	özle	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	compound	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	3	punct	_	_
 6	yaşadığım	yaşa	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	17	acl	_	_
@@ -699,7 +699,7 @@
 5	,	,	PUNCT	Punc	_	6	punct	_	_
 6	defterleri	defter	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	4	conj	_	_
 7	ne	ne	ADV	Adverb	_	8	advmod	_	_
-8	yaparım	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	10	nmod	_	_
+8	yaparım	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	10	nmod	_	_
 9	diye	diye	ADP	PCNom	_	10	case	_	_
 10	düşünüyorum	düşün	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
@@ -750,7 +750,7 @@
 28	İMKB'de	İMKB	PROPN	Prop	Case=Loc|Number=Sing|Person=3	30	nmod	_	_
 29	ki	ki	ADP	Rel	_	28	case	_	_
 30	potansiyelden	potansiyel	NOUN	Noun	Case=Abl|Number=Sing|Person=3	31	obl	_	_
-31	yararlanırken	yararlan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	33	nmod	_	_
+31	yararlanırken	yararlan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	33	nmod	_	_
 32	fazla	fazla	ADJ	Adj	_	33	amod	_	_
 33	risk	risk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	35	obj	_	_
 34	almak	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	33	compound	_	_
@@ -778,7 +778,7 @@
 7	sonrasında	sonra	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	nmod	_	_
 8	ki	ki	ADP	Rel	_	7	case	_	_
 9	gerilimi	gerilim	NOUN	Noun	Case=Acc|Number=Sing|Person=3	10	obj	_	_
-10	hissederken	hisset	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	17	nmod	_	_
+10	hissederken	hisset	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	17	nmod	_	_
 11	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	17	obl	_	_
 12	bir	bir	ADV	Adverb	_	16	advmod	_	_
 13	de	de	CCONJ	Conj	_	12	compound	_	_
@@ -1069,7 +1069,7 @@
 4	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	6	obl	_	_
 5	da	da	CCONJ	Conj	_	4	advmod:emph	_	_
 6	musallat	musallat	ADJ	Adj	_	0	root	_	_
-7	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	compound:lvc	_	SpaceAfter=No
+7	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	compound:lvc	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-0473
@@ -1089,7 +1089,7 @@
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	2	nmod	_	_
 2	ilgisi	ilgi	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	nsubj	_	_
 3	varsa	var	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	obj	_	_
-4	bilmem	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	bilmem	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	10	punct	_	_
 6	Kaymakam	kaymakam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
 7	Arif	Arif	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nmod:poss	_	_
@@ -1408,7 +1408,7 @@
 # sent_id = mst-0624
 # text = Hep benzer laflar duydum.
 1	Hep	hep	ADV	Adverb	_	4	advmod	_	_
-2	benzer	benze	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	3	acl	_	_
+2	benzer	benze	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	acl	_	_
 3	laflar	laf	NOUN	Noun	Case=Nom|Number=Plur|Person=3	4	obj	_	_
 4	duydum	duy	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
@@ -1459,18 +1459,18 @@
 4	öngörüler	öngörü	NOUN	Noun	Case=Nom|Number=Plur|Person=3	5	nmod:poss	_	_
 5	doğrultusunda	doğrultu	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obl	_	_
 6	sonuçlar	sonuç	NOUN	Noun	Case=Nom|Number=Plur|Person=3	7	obj	_	_
-7	verirse	ver	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	11	nmod	_	SpaceAfter=No
+7	verirse	ver	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	kuram	kuram	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
 10	kanıtlandı	kanıtla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	11	nsubj	_	_
-11	denmez	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+11	denmez	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	17	punct	_	_
 13	kuram	kuram	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	nsubj	_	_
 14	gözlemlerle	gözlem	NOUN	Noun	Case=Ins|Number=Plur|Person=3	15	obl	_	_
 15-16	tutarlıdır	_	_	_	_	_	_	_	_
 15	tutarlı	tutarlı	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	17	csubj	_	_
 16	dır	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	15	cop	_	_
-17	denir	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	11	conj	_	SpaceAfter=No
+17	denir	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	11	conj	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-0653
@@ -1655,7 +1655,7 @@
 
 # sent_id = mst-0739
 # text = Çarpılırsın.
-1	Çarpılırsın	çarp	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+1	Çarpılırsın	çarp	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-0741
@@ -1663,7 +1663,7 @@
 1	İyi	iyi	ADJ	Adj	_	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	4	punct	_	_
 3	iyi	iyi	ADJ	Adj	_	1	compound	_	_
-4	yeter	yet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+4	yeter	yet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-0743
@@ -1747,7 +1747,7 @@
 # text = ' DUYURU YAPAMAZSIN '.
 1	'	'	PUNCT	Punc	_	0	root	_	_
 2	DUYURU	duyuru	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
-3	YAPAMAZSIN	yap	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Tense=Aor	2	compound:lvc	_	_
+3	YAPAMAZSIN	yap	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	2	compound:lvc	_	_
 4	'	'	PUNCT	Punc	_	2	punct	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -1844,7 +1844,7 @@
 39	belleğime	bellek	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	40	obl	_	_
 40	girip	gir	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	44	nmod	_	_
 41	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	44	obl	_	_
-42	inanılmaz	inan	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	43	acl	_	_
+42	inanılmaz	inan	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	43	acl	_	_
 43	sevişmeler	seviş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	44	obj	_	_
 44	çıkartıyorlardı	çıkar	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Cau	17	conj	_	SpaceAfter=No
 45	.	.	PUNCT	Punc	_	44	punct	_	_
@@ -1967,12 +1967,12 @@
 4	anlattığın	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	5	acl	_	_
 5	kişi	kişi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
 6	seninle	sen	PRON	Pers	Case=Ins|Number=Sing|Person=2|PronType=Prs	7	obl	_	_
-7	tartışır	tartış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+7	tartışır	tartış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	12	punct	_	_
 9	oysa	oysa	CCONJ	Conj	_	8	cc	_	_
 10	rahip	rahip	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
 11	yalnız	yalnız	ADV	Adverb	_	12	advmod	_	_
-12	dinler	dinle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	conj	_	SpaceAfter=No
+12	dinler	dinle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	conj	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-0872
@@ -1999,7 +1999,7 @@
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10	kırlangıcından	kırlangıç	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	nmod	_	_
 11	kırlangıcına	kırlangıç	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	conj	_	_
-12	değişmez	değiş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+12	değişmez	değiş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	12	punct	_	_
 14	onlar	o	PRON	Demons	Case=Nom|Number=Plur|Person=3|PronType=Dem	17	nsubj	_	_
 15	yalnızca	yalnızca	ADV	Adverb	_	17	advmod	_	_
@@ -2047,23 +2047,23 @@
 5	bir	bir	ADV	Adverb	_	7	advmod	_	_
 6	daha	daha	ADV	Adverb	_	5	advmod	_	_
 7	görmek	gör	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	obj	_	_
-8	istemez	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	3	conj	_	_
+8	istemez	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	3	conj	_	_
 9	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	7	obj	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	7	punct	_	_
 11	görse	gör	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	13	nmod	_	_
 12	de	de	CCONJ	Conj	_	11	advmod:emph	_	_
-13	konuşmaz	konuş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	3	conj	_	SpaceAfter=No
+13	konuşmaz	konuş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	3	conj	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	20	punct	_	_
 15	konuşsa	konuş	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	20	nmod	_	_
 16	da	da	CCONJ	Conj	_	15	advmod:emph	_	_
 17	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	20	obl	_	_
 18	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	obl	_	_
 19	gibi	gibi	ADP	PCNom	_	18	case	_	_
-20	bakmaz	bak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	3	conj	_	SpaceAfter=No
+20	bakmaz	bak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	3	conj	_	SpaceAfter=No
 21	,	,	PUNCT	Punc	_	24	punct	_	_
 22	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	24	obj	_	_
 23	kendinden	kendi	PRON	Reflex	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	25	obl	_	_
-24	saymaz	say	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	3	conj	_	_
+24	saymaz	say	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	3	conj	_	_
 25	sanmıştım	san	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
 26	.	.	PUNCT	Punc	_	25	punct	_	_
 
@@ -2337,7 +2337,7 @@
 5	olduğumuz	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	6	acl	_	_
 6	ölçüde	ölçü	NOUN	Noun	Case=Loc|Number=Sing|Person=3	7	nmod	_	_
 7	gerek	gerek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-8	duyulur	duy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	7	compound	_	SpaceAfter=No
+8	duyulur	duy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	7	compound	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-1013
@@ -2531,7 +2531,7 @@
 15	yönünün	yön	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	nmod:poss	_	_
 16	üstünde	üst	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	nsubj	_	_
 17	durmak	dur	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	16	compound	_	_
-18	gerekir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+18	gerekir	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 19	:	:	PUNCT	Punc	_	47	punct	_	_
 20	Bilim	bilim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	46	nsubj	_	SpaceAfter=No
 21	,	,	PUNCT	Punc	_	18	punct	_	_
@@ -2702,7 +2702,7 @@
 # sent_id = mst-1167
 # text = Belki oynarken kafanı boşaltan, sıradan bir kumar makinesi.
 1	Belki	belki	ADV	Adverb	_	0	root	_	_
-2	oynarken	oyna	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	4	nmod	_	_
+2	oynarken	oyna	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	4	nmod	_	_
 3	kafanı	kafa	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	4	obj	_	_
 4	boşaltan	boşal	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	9	acl	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	4	punct	_	_
@@ -2724,7 +2724,7 @@
 7	ödenmemesi	öde	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun|Voice=Pass	8	nmod:poss	_	_
 8	konusunda	konu	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	nmod	_	_
 9	karar	karar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	obl	_	_
-10	verirse	ver	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	9	compound	_	_
+10	verirse	ver	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	compound	_	_
 11	ikibinüç	ikibinüç	NUM	ANum	NumType=Card	12	nummod	_	_
 12	yılında	yıl	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	det	_	_
 13	sadece	sadece	ADV	Adverb	_	21	advmod	_	_
@@ -2818,11 +2818,11 @@
 1	Dil	dil	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	4	punct	_	_
 3	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
-4	doğar	doğ	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	doğar	doğ	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	6	punct	_	_
-6	büyür	büyü	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	4	conj	_	SpaceAfter=No
+6	büyür	büyü	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	conj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	8	punct	_	_
-8	serpilir	serp	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	4	conj	_	SpaceAfter=No
+8	serpilir	serp	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	4	conj	_	SpaceAfter=No
 9	...	...	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-1223
@@ -2841,7 +2841,7 @@
 11	çıkarılan	çıkar	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	12	acl	_	_
 12	haliyle	hal	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	obl	_	_
 13	tamamen	tamamen	ADV	Adverb	_	14	advmod	_	_
-14	kaldırılırken	kal	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv|Voice=CauPass	43	nmod	_	SpaceAfter=No
+14	kaldırılırken	kal	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=CauPass	43	nmod	_	SpaceAfter=No
 15	,	,	PUNCT	Punc	_	14	punct	_	_
 16	TOBB	Tobb	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	43	nsubj	_	SpaceAfter=No
 17	,	,	PUNCT	Punc	_	43	punct	_	_
@@ -2886,7 +2886,7 @@
 
 # sent_id = mst-1247
 # text = Bilirsiniz...
-1	Bilirsiniz	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+1	Bilirsiniz	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 2	...	...	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-1249
@@ -2897,7 +2897,7 @@
 3	kendi	kendi	PRON	Reflex	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	5	obl	_	_
 4	başına	baş	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	compound	_	_
 5	yarışamayacağını	yarış	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Fut|VerbForm=Part	6	obj	_	_
-6	bilir	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	bilir	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-1254
@@ -3012,7 +3012,7 @@
 14	vurma	vur	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	13	compound	_	_
 15	yeteneği	yetenek	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obj	_	_
 16	gösterebilenler	göster	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	17	csubj	_	_
-17	anlayabilir	anla	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	SpaceAfter=No
+17	anlayabilir	anla	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	conj	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-1303
@@ -3046,7 +3046,7 @@
 5	satrancında	satranç	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	_
 6	yerini	yer	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
 7	zeytinyağlıya	zeytinyağlı	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	8	amod	_	_
-8	bırakır	bırak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+8	bırakır	bırak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-1318
@@ -3078,7 +3078,7 @@
 8	,	,	PUNCT	Punc	_	10	punct	_	_
 9	çevreyle	çevre	NOUN	Noun	Case=Ins|Number=Sing|Person=3	10	nmod	_	_
 10	etkileşimi	etkileşim	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	conj	_	_
-11	yatar	yat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+11	yatar	yat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-1332
@@ -3088,12 +3088,12 @@
 3	bir	bir	NUM	ANum	NumType=Card	6	nummod	_	_
 4	kez	kez	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	compound	_	_
 5	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
-6	uğrar	uğra	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	uğrar	uğra	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-1337
 # text = Kurtulamazsın.
-1	Kurtulamazsın	kurtul	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+1	Kurtulamazsın	kurtul	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-1339
@@ -3130,7 +3130,7 @@
 6	fırınında	fırın	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
 7	eşşek	eşşek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
 8	gibi	gibi	ADP	PCNom	_	7	compound	_	_
-9	çalışırken	çalış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	16	nmod	_	_
+9	çalışırken	çalış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	16	nmod	_	_
 10	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
 11	hayta	hayta	ADJ	Adj	_	12	nsubj	_	_
 12	hayta	hayta	ADJ	Adj	_	16	amod	_	_
@@ -3173,7 +3173,7 @@
 3	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	5	nummod	_	_
 4	on	on	NUM	ANum	NumType=Card	3	flat	_	_
 5	oranında	oran	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	_
-6	artırılırsa	artır	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	16	nmod	_	SpaceAfter=No
+6	artırılırsa	artır	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	16	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
 8	bu	bu	DET	Det	_	16	nsubj	_	_
 9	otuzaltı	otuzaltı	NUM	ANum	NumType=Card	15	nummod	_	_
@@ -3191,7 +3191,7 @@
 # sent_id = mst-1383
 # text = Ben içmem.
 1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
-2	içmem	iç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+2	içmem	iç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-1386
@@ -3376,7 +3376,7 @@
 1	kırk	kırk	NUM	ANum	NumType=Card	3	nummod	_	_
 2	çeşit	çeşit	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
 3	yemeği	yemek	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
-4	yapılır	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	_
+4	yapılır	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	_
 5	patlıcanın	patlıcan	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -3411,8 +3411,8 @@
 12	diyor	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	18	obj	_	_
 13	ya	ya	CCONJ	Conj	_	12	advmod:emph	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	12	punct	_	_
-15	ister	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	18	nmod	_	_
-16	istemez	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	15	compound	_	_
+15	ister	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	nmod	_	_
+16	istemez	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	15	compound	_	_
 17	moralin	moral	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	18	nsubj	_	_
 18	bozuluyor	boz	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Pass	5	conj	_	SpaceAfter=No
 19	.	.	PUNCT	Punc	_	18	punct	_	_
@@ -3433,7 +3433,7 @@
 
 # sent_id = mst-1473
 # text = Düşünmezsin tabii.
-1	Düşünmezsin	düşün	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Neg|Tense=Aor	0	root	_	_
+1	Düşünmezsin	düşün	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	0	root	_	_
 2	tabii	tabii	ADJ	Adj	_	1	amod	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
@@ -3618,7 +3618,7 @@
 
 # sent_id = mst-1548
 # text = Ederim ben böyle yaşamanın içine!
-1	Ederim	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Ederim	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 2	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	1	nsubj	_	_
 3	böyle	böyle	ADV	Adverb	_	4	advmod	_	_
 4	yaşamanın	yaşa	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	1	nmod	_	_
@@ -3685,7 +3685,7 @@
 2	sık	sık	ADV	Adverb	_	4	advmod	_	_
 3	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	2	aux:q	_	_
 4	aşık	aşık	ADJ	Adj	_	9	amod	_	_
-5	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	4	compound:lvc	_	_
+5	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	compound:lvc	_	_
 6	Mahmut	Mahmut	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nsubj	_	SpaceAfter=No
 7	?	?	PUNCT	Punc	_	9	punct	_	_
 8	diye	diye	ADP	PCNom	_	4	case	_	_
@@ -3719,7 +3719,7 @@
 3	,	,	PUNCT	Punc	_	2	punct	_	_
 4	at	at	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	6	obj	_	_
 5	kurtul	kurtul	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	4	compound	_	_
-6	der	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+6	der	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 7	o	o	DET	Det	_	8	det	_	_
 8-9	sessiz	_	_	_	_	_	_	_	_
 8	ses	ses	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod	_	_
@@ -3844,7 +3844,7 @@
 
 # sent_id = mst-1637
 # text = İçmez misin?
-1	İçmez	iç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	_
+1	İçmez	iç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
 2	misin	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Pres	1	aux:q	_	SpaceAfter=No
 3	?	?	PUNCT	Punc	_	1	punct	_	_
 
@@ -3858,7 +3858,7 @@
 6	,	,	PUNCT	Punc	_	12	punct	_	_
 7	bu	bu	DET	Det	_	8	det	_	_
 8	arayışa	arayış	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
-9	benzer	benze	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	11	acl	_	_
+9	benzer	benze	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	acl	_	_
 10	bir	bir	NUM	ANum	NumType=Card	11	det	_	_
 11	şeyi	şey	NOUN	Noun	Case=Acc|Number=Sing|Person=3	12	obj	_	_
 12	anlatıyordu	anlat	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
@@ -3870,7 +3870,7 @@
 2	delikanlı	delikanlı	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
 3	eğer	eğer	CCONJ	Conj	_	5	nmod	_	_
 4	yaşamayı	yaşa	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	obj	_	_
-5	becerebilirse	becer	VERB	Verb	Aspect=Imp|Mood=CndPot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	nmod	_	_
+5	becerebilirse	becer	VERB	Verb	Aspect=Hab|Mood=CndPot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	nmod	_	_
 6	yarın	yarın	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
 7	evlenecek	evlen	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
 8	de	de	CCONJ	Conj	_	7	advmod:emph	_	SpaceAfter=No
@@ -3878,7 +3878,7 @@
 10	muhtemelen	muhtemelen	ADV	Adverb	_	17	advmod	_	_
 11	kız	kız	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	17	nsubj	_	_
 12	da	da	CCONJ	Conj	_	11	advmod:emph	_	_
-13	benzer	benze	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	16	acl	_	_
+13	benzer	benze	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	16	acl	_	_
 14	bir	bir	NUM	ANum	NumType=Card	15	det	_	_
 15	aile	aile	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nmod:poss	_	_
 16	yapısından	yapı	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	obl	_	_
@@ -3908,7 +3908,7 @@
 2	çıkıp	çık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	5	obj	_	_
 3	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
 4	doğru	doğru	ADP	PCDat	_	3	case	_	_
-5	koşarken	koş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	7	nmod	_	_
+5	koşarken	koş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	_
 6	hepsi	hepsi	PRON	Quant	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	7	obj	_	_
 7-8	aklımdaydı	_	_	_	_	_	_	_	SpaceAfter=No
 7	aklımda	akıl	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	0	root	_	_
@@ -3963,7 +3963,7 @@
 21	gözlem	gözlem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	24	obl	_	_
 22	ve	ve	CCONJ	Conj	_	23	cc	_	_
 23	deneylerle	deney	NOUN	Noun	Case=Ins|Number=Plur|Person=3	21	conj	_	_
-24	sınanamaz	sına	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	11	conj	_	SpaceAfter=No
+24	sınanamaz	sına	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Pass	11	conj	_	SpaceAfter=No
 25	.	.	PUNCT	Punc	_	24	punct	_	_
 
 # sent_id = mst-1692
@@ -4005,7 +4005,7 @@
 # text = Beni çok sever ve mutlu olmam için elinden gelen her şeyi yapar.
 1	Beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	3	obj	_	_
 2	çok	çok	ADV	Adverb	_	3	advmod	_	_
-3	sever	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+3	sever	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 4	ve	ve	CCONJ	Conj	_	10	cc	_	_
 5	mutlu	mutlu	ADJ	Adj	_	6	amod	_	_
 6	olmam	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	10	nmod	_	_
@@ -4014,7 +4014,7 @@
 9	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	8	compound	_	_
 10	her	her	DET	Det	_	3	conj	_	_
 11	şeyi	şey	NOUN	Noun	Case=Acc|Number=Sing|Person=3	10	compound	_	_
-12	yapar	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	10	compound	_	SpaceAfter=No
+12	yapar	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	10	compound	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-1715
@@ -4056,7 +4056,7 @@
 # sent_id = mst-1732
 # text = Seni yargılamaz.
 1	Seni	sen	PRON	Pers	Case=Acc|Number=Sing|Person=2|PronType=Prs	2	obj	_	_
-2	yargılamaz	yargıla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+2	yargılamaz	yargıla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-1733
@@ -4113,7 +4113,7 @@
 33	bir	bir	NUM	ANum	NumType=Card	34	det	_	_
 34	çocuğun	çocuk	NOUN	Noun	Case=Gen|Number=Sing|Person=3	35	nmod:poss	_	_
 35	kucağında	kucak	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	36	amod	_	_
-36	görür	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	38	acl	_	_
+36	görür	gör	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	38	acl	_	_
 37	gibi	gibi	ADP	PCNom	_	36	case	_	_
 38	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 39	.	.	PUNCT	Punc	_	38	punct	_	_
@@ -4139,7 +4139,7 @@
 17	yoluyla	yol	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	obl	_	_
 18	sistemleştirilmiş	sistemleş	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=CauPass	14	conj	_	_
 19	bilgilerimizden	bilgi	NOUN	Noun	Case=Abl|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=1	20	obl	_	_
-20	oluşur	oluş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+20	oluşur	oluş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 21	.	.	PUNCT	Punc	_	20	punct	_	_
 
 # sent_id = mst-1769
@@ -4204,7 +4204,7 @@
 3	satılsa	sat	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	_
 4	özel	özel	ADJ	Adj	_	5	amod	_	_
 5	yerde	yer	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
-6	satılır	sat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	3	conj	_	SpaceAfter=No
+6	satılır	sat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	3	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-1795
@@ -4250,8 +4250,8 @@
 
 # sent_id = mst-1815
 # text = Öper öpmez bir de ne görsün?
-1	Öper	öp	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	nmod	_	_
-2	öpmez	öp	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	1	compound	_	_
+1	Öper	öp	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	nmod	_	_
+2	öpmez	öp	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	1	compound	_	_
 3	bir	bir	ADV	Adverb	_	5	advmod	_	_
 4	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
 5	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	6	obl	_	_
@@ -4365,7 +4365,7 @@
 1	Bilimsel	bilimsel	ADJ	Adj	_	2	amod	_	_
 2	sorunlarımıza	sorun	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=1	4	obl	_	_
 3	çözüm	çözüm	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
-4	ararken	ara	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	8	nmod	_	_
+4	ararken	ara	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	8	nmod	_	_
 5	işin	iş	NOUN	Noun	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
 6	içine	iç	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	amod	_	_
 7	Tanrı'yı	Tanrı	PROPN	Prop	Case=Acc|Number=Sing|Person=3	8	obj	_	_
@@ -4585,7 +4585,7 @@
 
 # sent_id = mst-1970
 # text = Görünmez ipler gibi tarihin derinliklerine giden manevi değerlerini uyandırmaya ve geliştirmeye çalışıyor.
-1	Görünmez	görün	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	2	acl	_	_
+1	Görünmez	görün	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	2	acl	_	_
 2	ipler	ip	NOUN	Noun	Case=Nom|Number=Plur|Person=3	6	obl	_	_
 3	gibi	gibi	ADP	PCNom	_	2	case	_	_
 4	tarihin	tarih	NOUN	Noun	Case=Gen|Number=Sing|Person=3	5	nmod:poss	_	_
@@ -4631,7 +4631,7 @@
 20	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	21	acl	_	_
 21	kanıt	kanıt	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	nsubj	_	_
 22	pek	pek	ADV	Adverb	_	23	advmod	_	_
-23	kullanılmaz	kullan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	10	conj	_	SpaceAfter=No
+23	kullanılmaz	kullan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Pass	10	conj	_	SpaceAfter=No
 24	.	.	PUNCT	Punc	_	23	punct	_	_
 
 # sent_id = mst-1985
@@ -4743,7 +4743,7 @@
 # sent_id = mst-2014
 # text = Kahve'yi bilmem ama Ali pek hazır değil galiba.
 1	Kahve'yi	Kahve	PROPN	Prop	Case=Acc|Number=Sing|Person=3	2	obj	_	_
-2	bilmem	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	_
+2	bilmem	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	_
 3	ama	ama	CCONJ	Conj	_	6	cc	_	_
 4	Ali	Ali	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
 5	pek	pek	ADV	Adverb	_	6	advmod	_	_
@@ -4788,12 +4788,12 @@
 2	sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	6	nsubj	_	_
 3	ille	ille	ADV	Adverb	_	6	advmod	_	_
 4	de	de	CCONJ	Conj	_	5	cc	_	_
-5	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	3	conj	_	_
-6	dersen	de	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	1	conj	_	_
+5	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	3	conj	_	_
+6	dersen	de	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	1	conj	_	_
 7	kim	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	10	obj	_	_
 8	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	10	obl	_	_
 9	bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	10	obj	_	_
-10	dayatabilir	daya	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	6	conj	_	SpaceAfter=No
+10	dayatabilir	daya	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	6	conj	_	SpaceAfter=No
 11	?	?	PUNCT	Punc	_	10	punct	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	10	punct	_	_
 
@@ -4807,7 +4807,7 @@
 6	iş	iş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	conj	_	_
 7	diye	diye	ADP	PCNom	_	6	case	_	_
 8	buna	bu	PRON	Demons	Case=Dat|Number=Sing|Person=3|PronType=Dem	9	obl	_	_
-9	derim	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	3	conj	_	_
+9	derim	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	conj	_	_
 10	iste	is	NOUN	Noun	Case=Loc|Number=Sing|Person=3	9	nmod	_	SpaceAfter=No
 11	!	!	PUNCT	Punc	_	9	punct	_	SpaceAfter=No
 12	...	...	PUNCT	Punc	_	9	punct	_	_
@@ -4838,7 +4838,7 @@
 3	yerlerini	yer	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	6	obj	_	_
 4	değiştirip	değiş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	6	obj	_	_
 5	de	de	CCONJ	Conj	_	4	advmod:emph	_	_
-6	sorabiliriz	sor	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	sorabiliriz	sor	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-2051
@@ -4862,12 +4862,12 @@
 # text = Evden ayrılıp giderken, ne almama izin verirsin diye sormuştum babama.
 1	Evden	ev	NOUN	Noun	Case=Abl|Number=Sing|Person=3	2	obl	_	_
 2	ayrılıp	ayrıl	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	3	nmod	_	_
-3	giderken	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	10	nmod	_	SpaceAfter=No
+3	giderken	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	10	nmod	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	3	punct	_	_
 5	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	6	obj	_	_
 6	almama	al	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	nmod	_	_
 7	izin	izin	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obl	_	_
-8	verirsin	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	7	compound	_	_
+8	verirsin	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	7	compound	_	_
 9	diye	diye	ADP	PCNom	_	7	case	_	_
 10	sormuştum	sor	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pqp	0	root	_	_
 11	babama	baba	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	10	obl	_	SpaceAfter=No
@@ -4906,7 +4906,7 @@
 7	yıkayın	yıka	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	10	punct	_	_
 9	sonra	sonra	ADV	Adverb	_	10	advmod	_	_
-10	dinlenirsiniz	dinlen	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+10	dinlenirsiniz	dinlen	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 11	,	,	PUNCT	Punc	_	10	punct	_	_
 12	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
@@ -5034,7 +5034,7 @@
 2	ondan	o	PRON	Pers	Case=Abl|Number=Sing|Person=3|PronType=Prs	5	obl	_	_
 3	da	da	CCONJ	Conj	_	2	advmod:emph	_	_
 4	tartışma	tartış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	obj	_	_
-5	açarlar	aç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	açarlar	aç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-2137
@@ -5193,7 +5193,7 @@
 # sent_id = mst-2192
 # text = Kimse kurtaramaz artık beni.
 1	Kimse	kimse	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
-2	kurtaramaz	kurtar	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	_
+2	kurtaramaz	kurtar	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
 3	artık	artık	ADV	Adverb	_	2	advmod	_	_
 4	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	2	punct	_	_
@@ -5306,7 +5306,7 @@
 7	öldürmek	öl	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	9	nmod	_	_
 8	için	için	ADP	PCNom	_	7	case	_	_
 9	bağımlı	bağımlı	ADJ	Adj	_	0	root	_	_
-10	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	9	compound:lvc	_	SpaceAfter=No
+10	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	compound:lvc	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2236
@@ -5389,24 +5389,24 @@
 3	ifade	ifade	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obj	_	_
 4	etmesi	et	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	3	compound:lvc	_	_
 5	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	6	obl	_	_
-6	yasaklanırsa	yasakla	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	1	conj	_	SpaceAfter=No
+6	yasaklanırsa	yasakla	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	1	conj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	12	punct	_	_
 8	duygularının	duygu	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	10	nmod:poss	_	_
 9	yanlış	yanlış	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	10	obj	_	_
 10	olduğu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	12	obj	_	_
 11	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	12	obl	_	_
-12	söylenirse	söyle	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	6	conj	_	SpaceAfter=No
+12	söylenirse	söyle	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	6	conj	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	16	punct	_	_
 14	hissettiklerinden	hisset	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	16	acl	_	_
 15	dolayı	dolayı	ADP	PCAbl	_	14	case	_	_
-16	yargılanırsa	yargıla	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	6	conj	_	SpaceAfter=No
+16	yargılanırsa	yargıla	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	6	conj	_	SpaceAfter=No
 17	,	,	PUNCT	Punc	_	22	punct	_	_
 18	fiziksel	fiziksel	ADJ	Adj	_	21	amod	_	_
 19	ve	ve	CCONJ	Conj	_	20	cc	_	_
 20	duygusal	duygusal	ADJ	Adj	_	18	conj	_	_
 21	şiddete	şiddet	NOUN	Noun	Case=Dat|Number=Sing|Person=3	22	obl	_	_
 22	maruz	maruz	ADJ	Adj	_	6	conj	_	_
-23	kalırsa	kal	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	22	compound	_	SpaceAfter=No
+23	kalırsa	kal	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	22	compound	_	SpaceAfter=No
 24	,	,	PUNCT	Punc	_	31	punct	_	_
 25	ağlaması	ağla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	31	nsubj	_	SpaceAfter=No
 26	,	,	PUNCT	Punc	_	27	punct	_	_
@@ -5414,11 +5414,11 @@
 28	,	,	PUNCT	Punc	_	29	punct	_	_
 29	kızması	kız	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	25	conj	_	_
 30	suç	suç	NOUN	Noun	Case=Nom|Number=Sing|Person=3	31	obj	_	_
-31	olursa	ol	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+31	olursa	ol	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 32	,	,	PUNCT	Punc	_	34	punct	_	_
 33	duygularıyla	duygu	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	34	nmod	_	_
 34	alay	alay	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	conj	_	_
-35	edilirse	et	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	34	compound:lvc	_	SpaceAfter=No
+35	edilirse	et	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	34	compound:lvc	_	SpaceAfter=No
 36	.	.	PUNCT	Punc	_	34	punct	_	_
 
 # sent_id = mst-2296
@@ -5454,7 +5454,7 @@
 2	eve	ev	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
 3	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
 4	prenses	prenses	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	det	_	_
-5	yeter	yet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	obj	_	SpaceAfter=No
+5	yeter	yet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	obj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 7	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
@@ -5465,7 +5465,7 @@
 2	dolduran	dol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	8	acl	_	_
 3	suların	su	NOUN	Noun	Case=Gen|Number=Plur|Person=3	4	nmod:poss	_	_
 4	yüzeyi	yüzey	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
-5	aydınlanır	aydınlan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	8	nmod	_	_
+5	aydınlanır	aydınlan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	_
 6-7	gibiydi	_	_	_	_	_	_	_	SpaceAfter=No
 6	gibi	gibi	ADP	PCNom	_	0	root	_	_
 7	ydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	6	cop	_	_
@@ -5579,7 +5579,7 @@
 1	Dünya	dünya	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
 2	görüşleri	görüş	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	1	compound	_	_
 3	tıpatıp	tıpatıp	ADV	Adverb	_	4	advmod	_	_
-4	oturmaz	otur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	oturmaz	otur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2374
@@ -5599,7 +5599,7 @@
 13	bu	bu	DET	Det	_	14	det	_	_
 14	mağazadan	mağaza	NOUN	Noun	Case=Abl|Number=Sing|Person=3	16	obl	_	_
 15	uzak	uzak	ADJ	Adj	_	16	amod	_	_
-16	durur	dur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	11	conj	_	SpaceAfter=No
+16	durur	dur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	conj	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-2382
@@ -5711,8 +5711,8 @@
 9	,	,	PUNCT	Punc	_	12	punct	_	_
 10	insan	insan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
 11	yerinde	yer	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	obl	_	_
-12	dolanır	dolan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	3	conj	_	_
-13	durur	dur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	12	compound	_	SpaceAfter=No
+12	dolanır	dolan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	conj	_	_
+13	durur	dur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	12	compound	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	20	punct	_	_
 15	hiçbir	hiçbir	DET	Det	_	16	det	_	_
 16	ışık	ışık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nsubj	_	SpaceAfter=No
@@ -5752,7 +5752,7 @@
 1	Eroin	eroin	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	bağımlılığı	bağımlılık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
 3	tesadüfen	tesadüfen	ADV	Adverb	_	4	advmod	_	_
-4	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2455
@@ -5765,7 +5765,7 @@
 6	Rum	Rum	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	7	nmod:poss	_	_
 7	tarafı	taraf	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
 8	birlikte	birlikte	ADV	Adverb	_	9	advmod	_	_
-9	engeller	engelle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+9	engeller	engelle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2462
@@ -5829,7 +5829,7 @@
 13	ihracatçı	ihracatçı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	conj	_	_
 14	şirketlere	şirket	NOUN	Noun	Case=Dat|Number=Plur|Person=3	15	nmod	_	_
 15	yatırım	yatırım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-16	yapılabilir	yap	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	15	compound:lvc	_	SpaceAfter=No
+16	yapılabilir	yap	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	15	compound:lvc	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-2490
@@ -5946,7 +5946,7 @@
 
 # sent_id = mst-2541
 # text = Yürürken kendimi bir garip hissediyorum; ama topuklu ayakkabılarımı çok seviyorum.
-1	Yürürken	yürü	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	5	nmod	_	_
+1	Yürürken	yürü	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	5	nmod	_	_
 2	kendimi	kendi	PRON	Reflex	Case=Acc|Number=Sing|Number[psor]=Sing|Person=1|Person[psor]=1|Reflex=Yes	5	obj	_	_
 3	bir	bir	ADV	Adverb	_	4	advmod	_	_
 4	garip	garip	ADJ	Adj	_	5	amod	_	_
@@ -5970,10 +5970,10 @@
 5	"	"	PUNCT	Punc	_	8	punct	_	_
 6	Hüseyin	Hüseyin	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	obj	_	_
 7	Çağlayan'ı	Çağlayan	PROPN	Prop	Case=Acc|Number=Sing|Person=3	6	flat	_	_
-8	beğenir	beğen	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+8	beğenir	beğen	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 9	ya	ya	CCONJ	Conj	_	8	compound	_	_
 10	da	da	CCONJ	Conj	_	8	compound	_	_
-11	beğenmezsiniz	beğen	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Neg|Tense=Aor	8	conj	_	SpaceAfter=No
+11	beğenmezsiniz	beğen	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	8	conj	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	19	punct	_	_
 13	ama	ama	CCONJ	Conj	_	19	cc	_	_
 14	son	son	ADJ	Adj	_	15	amod	_	_
@@ -6071,7 +6071,7 @@
 # sent_id = mst-2580
 # text = Ne gezer, oramı ovalıyorum hala, hafiflediği halde acısı.
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	gezer	gez	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound	_	SpaceAfter=No
+2	gezer	gez	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	5	punct	_	_
 4	oramı	ora	PRON	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	5	obj	_	_
 5	ovalıyorum	ovala	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	_
@@ -6095,7 +6095,7 @@
 1	Satırlara	satır	NOUN	Noun	Case=Dat|Number=Plur|Person=3	3	nmod	_	_
 2	bir	bir	NUM	ANum	NumType=Card	3	nummod	_	_
 3	göz	göz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obj	_	_
-4	atar	at	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	3	compound	_	SpaceAfter=No
+4	atar	at	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	compound	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	6	punct	_	_
 6	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 7	adam	adam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	SpaceAfter=No
@@ -6323,7 +6323,7 @@
 1	Bir	bir	ADV	Adverb	_	2	advmod:emph	_	_
 2	de	de	CCONJ	Conj	_	4	nmod	_	_
 3	Tibet	Tibet	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
-4	gelmezse	gel	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	gelmezse	gel	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2685
@@ -6341,13 +6341,13 @@
 3	nesnel	nesnel	ADJ	Adj	_	4	amod	_	_
 4	evrenin	evren	NOUN	Noun	Case=Gen|Number=Sing|Person=3	5	nmod:poss	_	_
 5	gerçekliği	gerçeklik	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nsubj	_	_
-6	yadsınır	yadsı	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+6	yadsınır	yadsı	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 7	;	;	PUNCT	Punc	_	12	punct	_	_
 8	özdek	özdek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
 9	(	(	PUNCT	Punc	_	10	punct	_	SpaceAfter=No
 10	madde	madde	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	appos	_	SpaceAfter=No
 11	)	)	PUNCT	Punc	_	10	punct	_	_
-12	yadsınır	yadsı	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	6	conj	_	SpaceAfter=No
+12	yadsınır	yadsı	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	6	conj	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-2695
@@ -6774,7 +6774,7 @@
 1	Fıkır	fıkır	X	Dup	Echo=Rdp	3	nmod	_	_
 2	fıkır	fıkır	X	Dup	Echo=Rdp	1	compound:redup	_	_
 3	sesini	ses	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obl	_	_
-4	beklerken	bekle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	15	nmod	_	SpaceAfter=No
+4	beklerken	bekle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	15	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	4	punct	_	_
 6	kart	kart	ADJ	Adj	_	10	amod	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	8	punct	_	_
@@ -6842,14 +6842,14 @@
 2	yoğun	yoğun	ADJ	Adj	_	4	amod	_	_
 3	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
 4	tempoyla	tempo	NOUN	Noun	Case=Ins|Number=Sing|Person=3	5	obl	_	_
-5	çalışırız	çalış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	çalışırız	çalış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	11	punct	_	_
-7	umarım	um	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	11	nmod	_	_
+7	umarım	um	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	11	nmod	_	_
 8	bize	biz	PRON	Pers	Case=Dat|Number=Plur|Person=1|PronType=Prs	9	nmod	_	_
 9	ayak	ayak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nmod	_	_
 10	uydurmakta	uy	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Form|Tense=Pres|Voice=Cau	9	compound	_	_
 11	güçlük	güçlük	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	conj	_	_
-12	çekmezsiniz	çek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Neg|Tense=Aor	11	compound	_	SpaceAfter=No
+12	çekmezsiniz	çek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	11	compound	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-2910
@@ -6904,7 +6904,7 @@
 # sent_id = mst-2934
 # text = Beni sorarsanız.
 1	Beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	_	_
-2	sorarsanız	sor	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	sorarsanız	sor	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-2935
@@ -6912,7 +6912,7 @@
 1	Sokak	sokak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	köpeğinden	köpek	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obl	_	_
 3	farkın	fark	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	4	obj	_	_
-4	kalmaz	kal	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	kalmaz	kal	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2936
@@ -7081,7 +7081,7 @@
 # text = -Atlattı sayılır.
 1	-	-	PUNCT	Punc	_	0	root	_	SpaceAfter=No
 2	Atlattı	atla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	3	obj	_	_
-3	sayılır	say	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	1	conj	_	SpaceAfter=No
+3	sayılır	say	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	1	conj	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3001
@@ -7160,7 +7160,7 @@
 # text = Gelemeyecekse gününü değiştiririm.
 1	Gelemeyecekse	gel	VERB	Verb	Aspect=Perf|Mood=CndPot|Number=Sing|Person=3|Polarity=Neg|Tense=Fut	3	nmod	_	_
 2	gününü	gün	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
-3	değiştiririm	değiş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+3	değiştiririm	değiş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3033
@@ -7181,7 +7181,7 @@
 5	günlerinizi	gün	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=2	6	obj	_	_
 6	hatırlamanız	hatırla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nmod	_	_
 7	zor	zor	ADJ	Adj	_	8	obj	_	_
-8	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+8	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-3042
@@ -7285,7 +7285,7 @@
 # text = Böyle ifade edebiliriz:...
 1	Böyle	böyle	ADV	Adverb	_	2	advmod	_	_
 2	ifade	ifade	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-3	edebiliriz	et	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	2	compound:lvc	_	SpaceAfter=No
+3	edebiliriz	et	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	2	compound:lvc	_	SpaceAfter=No
 4	:	:	PUNCT	Punc	_	2	punct	_	SpaceAfter=No
 5	...	...	PUNCT	Punc	_	2	punct	_	_
 
@@ -7343,7 +7343,7 @@
 6	"	"	PUNCT	Punc	_	9	punct	_	_
 7	Bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	8	obj	_	_
 8	demiş	de	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	9	nmod	_	_
-9	olabilirim	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	4	conj	_	SpaceAfter=No
+9	olabilirim	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	4	conj	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	14	punct	_	_
 11	ama	ama	CCONJ	Conj	_	14	cc	_	_
 12	kastım	kasıt	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	14	nsubj	_	_
@@ -7363,7 +7363,7 @@
 5	yirmibeş	yirmibeş	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	4	flat	_	_
 6	'lik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	4	case	_	_
 7	kayıpla	kayıp	ADJ	NAdj	Case=Ins|Number=Sing|Person=3	8	amod	_	_
-8	kapatırken	kapa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv|Voice=Cau	17	nmod	_	_
+8	kapatırken	kapa	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	17	nmod	_	_
 9	dolar	dolar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod	_	_
 10-11	bazlı	_	_	_	_	_	_	_	_
 10	baz	baz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
@@ -7393,7 +7393,7 @@
 3	iki	iki	NUM	ANum	NumType=Card	4	nummod	_	_
 4	faili	fail	ADJ	NAdj	Case=Acc|Number=Sing|Person=3	6	nsubj	_	_
 5	meçhul	meçhul	ADJ	Adj	_	4	compound	_	_
-6	gelir	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	gelir	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	14	punct	_	_
 8	en	en	ADV	Adverb	_	10	advmod	_	_
 9	aşağı	aşağı	ADJ	Adj	_	8	compound	_	_
@@ -7401,12 +7401,12 @@
 11	de	de	CCONJ	Conj	_	10	advmod:emph	_	_
 12	aşk	aşk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nmod:poss	_	_
 13	cinayeti	cinayet	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	nsubj	_	_
-14	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+14	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 15	,	,	PUNCT	Punc	_	19	punct	_	_
 16	bir	bir	NUM	ANum	NumType=Card	18	nummod	_	_
 17	de	de	CCONJ	Conj	_	16	advmod:emph	_	_
 18	hakaretten	hakaret	NOUN	Noun	Case=Abl|Number=Sing|Person=3	19	obl	_	_
-19	çıkar	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+19	çıkar	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 20	,	,	PUNCT	Punc	_	28	punct	_	_
 21	yani	yani	CCONJ	Conj	_	28	nmod	_	_
 22	en	en	ADV	Adverb	_	23	advmod	_	_
@@ -7415,7 +7415,7 @@
 25	-	-	PUNCT	Punc	_	26	punct	_	SpaceAfter=No
 26	sekiz	sekiz	NUM	ANum	NumType=Card	24	conj	_	_
 27	cinayet	cinayet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	28	nsubj	_	_
-28	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+28	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 29	.	.	PUNCT	Punc	_	28	punct	_	_
 
 # sent_id = mst-3139
@@ -7496,12 +7496,12 @@
 # sent_id = mst-3167
 # text = Masalı bitirir bitirmez de bu mektupla postalarım.
 1	Masalı	masal	NOUN	Noun	Case=Acc|Number=Sing|Person=3	7	obj	_	_
-2	bitirir	bitir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	nmod	_	_
-3	bitirmez	bitir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	2	compound	_	_
+2	bitirir	bitir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	nmod	_	_
+3	bitirmez	bitir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	2	compound	_	_
 4	de	de	CCONJ	Conj	_	2	mark	_	_
 5	bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	6	det	_	_
 6	mektupla	mektup	NOUN	Noun	Case=Ins|Number=Sing|Person=3	7	obl	_	_
-7	postalarım	postala	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+7	postalarım	postala	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-3171
@@ -7632,7 +7632,7 @@
 5	takipsizlik	takipsizlik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 6	kararına	karar	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nmod	_	_
 7	itiraz	itiraz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod:poss	_	_
-8	edilebilir	et	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	7	compound:lvc	_	_
+8	edilebilir	et	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	7	compound:lvc	_	_
 9	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	7	aux:q	_	_
 10	sorusu	soru	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	nmod	_	_
 11	ile	ile	CCONJ	Conj	_	12	nmod	_	_
@@ -7873,7 +7873,7 @@
 3	ille	ille	ADV	Adverb	_	6	advmod	_	_
 4	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
 5	kötü	kötü	ADJ	Adj	_	6	amod	_	_
-6	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	9	nmod	_	_
+6	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	nmod	_	_
 7	diye	diye	ADP	PCNom	_	6	case	_	_
 8	kendini	kendi	PRON	Reflex	Case=Acc|Number=Sing|Number[psor]=Sing|Person=2|Person[psor]=2|Reflex=Yes	9	obj	_	_
 9	inandırmışsın	inan	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
@@ -8105,7 +8105,7 @@
 # sent_id = mst-3416
 # text = Yerimde duramam.
 1	Yerimde	yer	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	0	root	_	_
-2	duramam	dur	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	1	compound	_	SpaceAfter=No
+2	duramam	dur	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	1	compound	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-3420
@@ -8136,7 +8136,7 @@
 1	Değişik	değişik	ADJ	Adj	_	2	amod	_	_
 2	görüş	görüş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 3	kardeşliği	kardeşlik	NOUN	Noun	Case=Acc|Number=Sing|Person=3	4	obj	_	_
-4	batırmaz	batır	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	batırmaz	batır	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-3435
@@ -8179,21 +8179,21 @@
 3	çatısı	çatı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
 4	kapanan	kapa	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	5	acl	_	_
 5	evlere	ev	NOUN	Noun	Case=Dat|Number=Plur|Person=3	6	obl	_	_
-6	girer	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	girer	gir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	8	punct	_	_
-8	dağıtır	dağıt	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+8	dağıtır	dağıt	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	10	punct	_	_
-10	parçalar	parçala	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+10	parçalar	parçala	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 11	,	,	PUNCT	Punc	_	12	punct	_	_
-12	yıkar	yık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+12	yıkar	yık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	14	punct	_	_
-14	döker	dök	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+14	döker	dök	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 15	,	,	PUNCT	Punc	_	20	punct	_	_
 16	bir	bir	NUM	ANum	NumType=Card	20	obj	_	_
 17	yanı	yan	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	compound	_	_
 18	noksan	noksan	ADJ	Adj	_	16	compound	_	_
 19	olsun	ol	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	16	compound	_	_
-20	ister	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+20	ister	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 21	.	.	PUNCT	Punc	_	20	punct	_	_
 
 # sent_id = mst-3460
@@ -8288,7 +8288,7 @@
 # sent_id = mst-3496
 # text = Seni yargılamaz.
 1	Seni	sen	PRON	Pers	Case=Acc|Number=Sing|Person=2|PronType=Prs	2	obj	_	_
-2	yargılamaz	yargıla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+2	yargılamaz	yargıla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-3500
@@ -8303,7 +8303,7 @@
 # text = Hep başrollere çıkarlar.
 1	Hep	hep	ADV	Adverb	_	3	advmod	_	_
 2	başrollere	başrol	NOUN	Noun	Case=Dat|Number=Plur|Person=3	3	obl	_	_
-3	çıkarlar	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	çıkarlar	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3510
@@ -8435,7 +8435,7 @@
 
 # sent_id = mst-3573
 # text = Koşarken göbeği bıngıl bıngıl yere değiyordu.
-1	Koşarken	koş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	6	nmod	_	_
+1	Koşarken	koş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
 2	göbeği	göbek	NOUN	Noun	Case=Acc|Number=Sing|Person=3	6	nsubj	_	_
 3	bıngıl	bıngıl	ADJ	Adj	_	6	amod	_	_
 4	bıngıl	bıngıl	ADJ	Adj	_	3	compound:redup	_	_
@@ -8520,7 +8520,7 @@
 3	her	her	DET	Det	_	6	det	_	_
 4	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	compound	_	_
 5	bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	6	obj	_	_
-6	öğütler	öğütle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	öğütler	öğütle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3609
@@ -8639,7 +8639,7 @@
 13	pilotun	pilot	NOUN	Noun	Case=Gen|Number=Sing|Person=3	14	nmod	_	_
 14	üzerine	üzer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obl	_	_
 15	atılarak	at	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	16	nmod	_	_
-16	kapatılır	kapa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=CauPass	0	root	_	SpaceAfter=No
+16	kapatılır	kapa	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=CauPass	0	root	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-3654
@@ -8672,7 +8672,7 @@
 8	günleri	gün	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	11	obj	_	_
 9	çok	çok	ADV	Adverb	_	10	advmod	_	_
 10	iyi	iyi	ADJ	Adj	_	11	amod	_	_
-11	bilirim	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+11	bilirim	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-3667
@@ -8753,12 +8753,12 @@
 # Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Çocukları	çocuk	NOUN	Noun	Case=Acc|Number=Plur|Person=3	3	obj	_	_
 2	pek	pek	ADV	Adverb	_	3	advmod	_	_
-3	sevmem	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+3	sevmem	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	8	punct	_	_
 5	ama	ama	CCONJ	Conj	_	8	cc	_	_
 6	onlarla	on	NUM	NNum	Case=Ins|Number=Plur|NumType=Card|Person=3	7	nummod	_	_
 7	konuşmaktan	konuş	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nmod	_	_
-8	hoşlanırım	hoşlan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+8	hoşlanırım	hoşlan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 9	;	;	PUNCT	Punc	_	20	punct	_	_
 10	çünkü	çünkü	CCONJ	Conj	_	20	cc	_	_
 11	bence	ben	PRON	Pers	Case=Equ|Number=Sing|Person=1|PronType=Prs	20	cc	_	_
@@ -8779,26 +8779,26 @@
 25	hiçbir	hiçbir	DET	Det	_	26	det	_	_
 26	düşüncelerini	düşünce	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	28	obj	_	_
 27	kendilerine	kendi	PRON	Reflex	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|Reflex=Yes	28	obl	_	_
-28	saklamazlar	sakla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Aor	3	conj	_	_
+28	saklamazlar	sakla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	3	conj	_	_
 29	hemen	hemen	ADV	Adverb	_	30	advmod	_	_
-30	söylerler	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+30	söylerler	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 31	,	,	PUNCT	Punc	_	40	punct	_	_
 32	onun	o	PRON	Demons	Case=Gen|Number=Sing|Person=3|PronType=Dem	40	obl	_	_
 33	için	için	ADP	PCNom	_	32	case	_	_
 34	onlarla	on	NUM	NNum	Case=Ins|Number=Plur|NumType=Card|Person=3	35	nummod	_	_
-35	konuşurken	konuş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	40	nmod	_	_
+35	konuşurken	konuş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	40	nmod	_	_
 36	daima	daima	ADV	Adverb	_	40	advmod	_	_
 37	ilginç	ilginç	ADJ	Adj	_	39	amod	_	_
 38	bir	bir	NUM	ANum	NumType=Card	39	det	_	_
 39	şeyler	şey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	40	obj	_	_
-40	duyabilirsiniz	duy	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+40	duyabilirsiniz	duy	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 41	.	.	PUNCT	Punc	_	40	punct	_	_
 
 # sent_id = mst-3703
 # text = ' eşgüdüm olmazsa vay halimize.
 1	'	'	PUNCT	Punc	_	3	discourse	_	_
 2	eşgüdüm	eşgüdüm	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
-3	olmazsa	ol	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	_
+3	olmazsa	ol	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
 4	vay	vay	INTJ	Interj	_	1	conj	_	_
 5	halimize	hal	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	4	compound	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -8810,7 +8810,7 @@
 3	-	-	PUNCT	Punc	_	1	punct	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	1	punct	_	_
 5	evleri	ev	NOUN	Noun	Case=Acc|Number=Plur|Person=3	6	obj	_	_
-6	yaparken	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	11	nmod	_	SpaceAfter=No
+6	yaparken	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	11	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
 8	sizin	siz	PRON	Pers	Case=Gen|Number=Plur|Person=2|PronType=Prs	9	nmod:poss	_	_
 9	makinelerinizi	makine	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=2	11	obj	_	_
@@ -8883,7 +8883,7 @@
 # text = Öleceğini bilsem bırakır mıyım aga? Canın mı sıkıldı? dedim.
 1	Öleceğini	öl	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	2	obj	_	_
 2	bilsem	bil	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	nmod	_	_
-3	bırakır	bırak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	11	obj	_	_
+3	bırakır	bırak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	obj	_	_
 4	mıyım	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	3	aux:q	_	_
 5	aga	aga	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 6	?	?	PUNCT	Punc	_	11	punct	_	_
@@ -8899,7 +8899,7 @@
 1	Teori	teori	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	4	punct	_	_
 3	kavramlarla	kavram	NOUN	Noun	Case=Ins|Number=Plur|Person=3	4	obl	_	_
-4	yapılır	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+4	yapılır	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-3748
@@ -8965,7 +8965,7 @@
 3	birine	biri	PRON	Quant	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	9	obl	_	_
 4	benim	ben	PRON	Pers	Case=Gen|Number=Sing|Person=1|PronType=Prs	5	nmod:poss	_	_
 5	rehberim	rehber	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	6	obj	_	_
-6	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	9	obj	_	_
+6	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	obj	_	_
 7	musun	mu	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Pres	6	aux:q	_	SpaceAfter=No
 8	?	?	PUNCT	Punc	_	6	punct	_	_
 9	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -8994,9 +8994,9 @@
 4	daha	daha	ADV	Adverb	_	7	advmod	_	_
 5	kolay	kolay	ADJ	Adj	_	7	amod	_	_
 6	kolay	kolay	ADJ	Adj	_	5	compound:redup	_	_
-7	kurtulamaz	kurtul	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+7	kurtulamaz	kurtul	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	9	punct	_	_
-9	çıkamaz	çık	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	7	conj	_	_
+9	çıkamaz	çık	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	7	conj	_	_
 10	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	9	obl	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
@@ -9052,7 +9052,7 @@
 # text = Buharlar fışkırtan kaynar suyla bir duş aldım; su cildimi yakarak tazeliyordu beni, sonra bir çay, birkaç ayçöreği, sabah gazeteleri, cinayetler ve yeniden hayata döndüm.
 1	Buharlar	buhar	NOUN	Noun	Case=Nom|Number=Plur|Person=3	2	obj	_	_
 2	fışkırtan	fışkır	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	4	acl	_	_
-3	kaynar	kayna	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	4	acl	_	_
+3	kaynar	kayna	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	acl	_	_
 4	suyla	su	NOUN	Noun	Case=Ins|Number=Sing|Person=3	6	nmod	_	_
 5	bir	bir	NUM	ANum	NumType=Card	6	det	_	_
 6	duş	duş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
@@ -9140,7 +9140,7 @@
 # sent_id = mst-3846
 # text = Nasıl ulaştırırız ki bu mektubu ona.
 1	Nasıl	nasıl	ADV	Adverb	_	2	advmod	_	_
-2	ulaştırırız	ulaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	_
+2	ulaştırırız	ulaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	_
 3	ki	ki	CCONJ	Conj	_	2	advmod:emph	_	_
 4	bu	bu	DET	Det	_	5	det	_	_
 5	mektubu	mektup	NOUN	Noun	Case=Acc|Number=Sing|Person=3	2	obj	_	_
@@ -9184,7 +9184,7 @@
 1	-	-	PUNCT	Punc	_	0	root	_	SpaceAfter=No
 2	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 3	size	siz	PRON	Pers	Case=Dat|Number=Plur|Person=2|PronType=Prs	4	obl	_	_
-4	getiririm	getir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+4	getiririm	getir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	1	conj	_	_
 
 # sent_id = mst-3870
@@ -9253,8 +9253,8 @@
 13	gördükçe	gör	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	16	nmod	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	13	punct	_	_
 15	tarihi	tarih	NOUN	Noun	Case=Acc|Number=Sing|Person=3	16	obj	_	_
-16	tekrarlar	tekrarla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
-17	dururuz	dur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	16	compound	_	SpaceAfter=No
+16	tekrarlar	tekrarla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
+17	dururuz	dur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	16	compound	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-3894
@@ -9338,7 +9338,7 @@
 8	bir	bir	NUM	ANum	NumType=Card	10	det	_	_
 9	başka	başka	ADJ	Adj	_	10	det	_	_
 10	olayı	olay	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obj	_	_
-11	izler	izle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+11	izler	izle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-3934
@@ -9394,7 +9394,7 @@
 3	çaresizlik	çaresizlik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obl	_	_
 4	canavarının	canavar	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nmod:poss	_	_
 5	kollarına	kol	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	_
-6	atarlarsa	at	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	atarlarsa	at	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	?	?	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3958
@@ -9467,7 +9467,7 @@
 4-5	sizinkine	_	_	_	_	_	_	_	_
 4	sizin	siz	PRON	Pers	Case=Gen|Number=Plur|Person=2|PronType=Prs	6	obl	_	_
 5	kine	ki	ADP	Rel	Case=Dat|Number=Sing|Person=3	4	case	_	_
-6	veririm	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	veririm	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3992
@@ -9502,14 +9502,14 @@
 # text = Kadın Peki der demez evlenmişler.
 1	Kadın	kadın	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	Peki	peki	ADV	Adverb	_	3	advmod	_	_
-3	der	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	nmod	_	_
-4	demez	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	3	compound	_	_
+3	der	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	nmod	_	_
+4	demez	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	3	compound	_	_
 5	evlenmişler	evlen	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4008
 # text = İyileştirir.
-1	İyileştirir	iyileş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+1	İyileştirir	iyileş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-4009
@@ -9635,7 +9635,7 @@
 2	işin	iş	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
 3	sonu	son	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nsubj	_	_
 4	nereye	nere	PRON	Ques	Case=Dat|Number=Sing|Person=3	5	obl	_	_
-5	varır	var	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	obj	_	_
+5	varır	var	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	obj	_	_
 6	bilinmiyor	bil	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Polite=Infm|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
 8	ancak	ancak	CCONJ	Conj	_	6	cc	_	_
@@ -9882,7 +9882,7 @@
 4	çıkıp	çık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	_
 5	gitar	gitar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
 6	'	'	PUNCT	Punc	_	9	punct	_	_
-7	çalar	çal	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	9	acl	_	_
+7	çalar	çal	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	acl	_	_
 8	gibi	gibi	ADP	PCNom	_	7	case	_	_
 9	yapan	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	acl	_	_
 10	'	'	PUNCT	Punc	_	9	punct	_	_
@@ -9947,7 +9947,7 @@
 2	sürekli	sürekli	ADV	Adverb	_	5	advmod	_	_
 3	yeni	yeni	ADJ	Adj	_	4	amod	_	_
 4	algılar	algı	NOUN	Noun	Case=Nom|Number=Plur|Person=3	5	obj	_	_
-5	yaratır	yarat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	yaratır	yarat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4222
@@ -9959,7 +9959,7 @@
 5	doğru	doğru	ADJ	Adj	_	7	amod	_	_
 6	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
 7	biçem	biçem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8	kazanabilir	kazan	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+8	kazanabilir	kazan	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-4228
@@ -9988,7 +9988,7 @@
 7	esasını	esas	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obj	_	_
 8	da	da	CCONJ	Conj	_	7	advmod:emph	_	_
 9	gözardı	gözardı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	conj	_	_
-10	edemeyiz	et	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Neg|Tense=Aor	9	compound	_	SpaceAfter=No
+10	edemeyiz	et	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Neg|Tense=Pres	9	compound	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-4236
@@ -10039,7 +10039,7 @@
 3	:	:	PUNCT	Punc	_	5	punct	_	_
 4	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	5	det	_	_
 5	iş	iş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	conj	_	_
-6	yaparsınız	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	5	compound:lvc	_	_
+6	yaparsınız	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	5	compound:lvc	_	_
 7	siz	siz	PRON	Pers	Case=Nom|Number=Plur|Person=2|PronType=Prs	5	nsubj	_	SpaceAfter=No
 8	?	?	PUNCT	Punc	_	2	punct	_	_
 
@@ -10195,7 +10195,7 @@
 # text = Müşteri tanınmak ister.
 1	Müşteri	müşteri	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	tanınmak	tanı	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	3	obj	_	_
-3	ister	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	ister	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-4309
@@ -10208,7 +10208,7 @@
 6	yiyecekler	yiyecek	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	0	root	_	SpaceAfter=No
 7	;	;	PUNCT	Punc	_	12	punct	_	_
 8	gereksinme	gereksin	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	obj	_	_
-9	duyarsam	duy	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	12	nmod	_	_
+9	duyarsam	duy	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	12	nmod	_	_
 10	soğuk	soğuk	ADJ	Adj	_	12	amod	_	_
 11	beyaz	beyaz	ADJ	Adj	_	12	amod	_	_
 12	şarap	şarap	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	conj	_	_
@@ -10233,7 +10233,7 @@
 1	Kırk	kırk	NUM	ANum	NumType=Card	2	nummod	_	_
 2	çeşit	çeşit	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod	_	_
 3	yemeği	yemek	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
-4	yapılır	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+4	yapılır	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4320
@@ -10430,7 +10430,7 @@
 6	iklimde	iklim	NOUN	Noun	Case=Loc|Number=Sing|Person=3	9	obl	_	_
 7	bir	bir	NUM	ANum	NumType=Card	8	det	_	_
 8	yer	yer	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
-9	bulur	bul	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	_
+9	bulur	bul	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	_
 10	kendine	kendi	PRON	Reflex	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	9	obl	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
@@ -10599,7 +10599,7 @@
 2	korkan	kork	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	2	punct	_	_
 4	darı	darı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
-5	ekmez	ek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+5	ekmez	ek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4472
@@ -10764,7 +10764,7 @@
 13	bu	bu	DET	Det	_	14	det	_	_
 14	hatayı	hata	NOUN	Noun	Case=Acc|Number=Sing|Person=3	16	obj	_	_
 15	nasıl	nasıl	ADV	Adverb	_	16	advmod	_	_
-16	yapar	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	18	obj	_	_
+16	yapar	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	obj	_	_
 17	"	"	PUNCT	Punc	_	16	punct	_	_
 18	diyerek	de	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	20	obj	_	_
 19	gözyaşı	gözyaşı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	conj	_	_
@@ -11075,14 +11075,14 @@
 3	karşısında	karşı	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	amod	_	_
 4	yüzlerine	yüz	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	6	obl	_	_
 5	ilgisizce	ilgisizce	ADV	Adverb	_	6	advmod	_	_
-6	bakarsanız	bak	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	12	nmod	_	_
+6	bakarsanız	bak	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	12	nmod	_	_
 7-8	gözlerindeki	_	_	_	_	_	_	_	_
 7	gözlerinde	göz	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	9	nmod	_	_
 8	ki	ki	ADP	Rel	_	7	case	_	_
 9	umutsuzluk	umutsuzluk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
 10	ve	ve	CCONJ	Conj	_	11	cc	_	_
 11	çaresizlikle	çaresizlik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	9	conj	_	_
-12	karşılaşırsınız	karşılaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+12	karşılaşırsınız	karşılaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-4716
@@ -11302,7 +11302,7 @@
 5	Katana	katana	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	4	punct	_	_
 7	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	_	_
-8	taşırım	taşı	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	4	obj	_	SpaceAfter=No
+8	taşırım	taşı	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	4	obj	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-4815
@@ -11399,7 +11399,7 @@
 23	bahşişini	bahşiş	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	obj	_	SpaceAfter=No
 24	,	,	PUNCT	Punc	_	21	punct	_	_
 25	yine	yine	ADV	Adverb	_	26	advmod	_	_
-26	görüşürüz	görüş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	18	conj	_	SpaceAfter=No
+26	görüşürüz	görüş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	18	conj	_	SpaceAfter=No
 27	!	!	PUNCT	Punc	_	26	punct	_	_
 28	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	12	conj	_	SpaceAfter=No
 29	.	.	PUNCT	Punc	_	28	punct	_	_
@@ -11478,7 +11478,7 @@
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	kıvılcım	kıvılcım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	4	punct	_	_
-4	yeter	yet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+4	yeter	yet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 5	çözülmesine	çöz	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	4	nmod	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
@@ -11689,7 +11689,7 @@
 2	o	o	DET	Det	_	3	det	_	_
 3	olayı	olay	NOUN	Noun	Case=Acc|Number=Sing|Person=3	1	obj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	1	punct	_	_
-5	bilemezsiniz	bil	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+5	bilemezsiniz	bil	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4973
@@ -11712,7 +11712,7 @@
 14	ereksel	ereksel	ADJ	Adj	_	15	amod	_	_
 15	olana	ol	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	10	conj	_	_
 16	uygulanabileceğini	uygula	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	17	ccomp	_	_
-17	söyler	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+17	söyler	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-4984
@@ -11845,7 +11845,7 @@
 3	,	,	PUNCT	Punc	_	12	punct	_	_
 4	Ortaçağ	ortaçağ	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
 5	ideolojisine	ideoloji	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nmod	_	_
-6	onulmaz	onul	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	7	acl	_	_
+6	onulmaz	onul	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	7	acl	_	_
 7	darbeler	darbe	NOUN	Noun	Case=Nom|Number=Plur|Person=3	12	nmod	_	_
 8	indirerek	in	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	7	compound	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	12	punct	_	_
@@ -11915,7 +11915,7 @@
 # sent_id = mst-5077
 # text = Hendekten atlarlarken Miskoye'nin ayağı kaydı.
 1	Hendekten	hendek	NOUN	Noun	Case=Abl|Number=Sing|Person=3	2	obl	_	_
-2	atlarlarken	atla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	5	nmod	_	_
+2	atlarlarken	atla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	5	nmod	_	_
 3	Miskoye'nin	Miskoye	PROPN	Prop	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
 4	ayağı	ayak	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
 5	kaydı	kay	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -11953,8 +11953,8 @@
 # sent_id = mst-5095
 # text = Sen uyanır uyanmaz, en iyi dostun alaca boğayı yanaklarından öp.
 1	Sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	2	nsubj	_	_
-2	uyanır	uyan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	11	nmod	_	_
-3	uyanmaz	uyan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	2	compound	_	SpaceAfter=No
+2	uyanır	uyan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	nmod	_	_
+3	uyanmaz	uyan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	2	compound	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	2	punct	_	_
 5	en	en	ADV	Adverb	_	6	advmod	_	_
 6	iyi	iyi	ADJ	Adj	_	7	amod	_	_
@@ -12007,7 +12007,7 @@
 4	şeyi	şey	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obj	_	_
 5	çok	çok	ADJ	Adj	_	6	det	_	_
 6	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
-7	bilir	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+7	bilir	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 8	yani	yani	CCONJ	Conj	_	7	nmod	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	7	punct	_	_
 
@@ -12112,7 +12112,7 @@
 # text = Üstüne peynir koyarlar.
 1	Üstüne	üst	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	amod	_	_
 2	peynir	peynir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
-3	koyarlar	koy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	koyarlar	koy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-5177
@@ -12206,7 +12206,7 @@
 # text = Bu soruları çoğaltabiliriz.
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	soruları	soru	NOUN	Noun	Case=Acc|Number=Plur|Person=3	3	obj	_	_
-3	çoğaltabiliriz	çoğal	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+3	çoğaltabiliriz	çoğal	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-5228
@@ -12299,7 +12299,7 @@
 16	küçük	küçük	ADJ	Adj	_	18	amod	_	_
 17	bir	bir	NUM	ANum	NumType=Card	18	det	_	_
 18	kızla	kız	ADJ	NAdj	Case=Ins|Number=Sing|Person=3	19	amod	_	_
-19	sevişir	seviş	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	21	acl	_	_
+19	sevişir	seviş	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	21	acl	_	_
 20	gibi	gibi	ADP	PCNom	_	19	case	_	_
 21	sevişebilirdi	seviş	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 22	.	.	PUNCT	Punc	_	21	punct	_	_
@@ -12325,7 +12325,7 @@
 # sent_id = mst-5284
 # text = Kimselere güvenemem.
 1	Kimselere	kimse	NOUN	Noun	Case=Dat|Number=Plur|Person=3	2	obl	_	_
-2	güvenemem	güven	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+2	güvenemem	güven	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-5287
@@ -12368,7 +12368,7 @@
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	gece	gece	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obl	_	_
 3	damda	dam	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
-4	uyurken	uyu	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	8	nmod	_	_
+4	uyurken	uyu	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	8	nmod	_	_
 5	rüyasına	rüya	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	_
 6	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
 7	prens	prens	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
@@ -12445,7 +12445,7 @@
 1	Ama	ama	CCONJ	Conj	_	7	nmod	_	_
 2	benim	ben	PRON	Pers	Case=Gen|Number=Sing|Person=1|PronType=Prs	3	nmod:poss	_	_
 3	hissettiklerimi	hisset	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	4	obj	_	_
-4	hissedemezler	hisset	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=Aor	7	nmod	_	SpaceAfter=No
+4	hissedemezler	hisset	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	7	nmod	_	SpaceAfter=No
 5	!	!	PUNCT	Punc	_	4	punct	_	_
 6	diye	diye	ADP	PCNom	_	4	case	_	_
 7	bağırdım	bağır	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -12535,14 +12535,14 @@
 1	Kimi	kimi	DET	Det	_	5	det	_	_
 2	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
 3	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
-4	konuşurken	konuş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	5	nmod	_	_
+4	konuşurken	konuş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	5	nmod	_	_
 5	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	25	obl	_	_
 6	içimden	iç	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	5	amod	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	25	punct	_	_
 8	kimi	kimi	DET	Det	_	12	det	_	_
 9	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	compound	_	_
 10	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	_	_
-11	konuşurken	konuş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	12	nmod	_	_
+11	konuşurken	konuş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	12	nmod	_	_
 12	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	5	conj	_	_
 13	içinden	iç	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	amod	_	SpaceAfter=No
 14	;	;	PUNCT	Punc	_	25	punct	_	_
@@ -12567,7 +12567,7 @@
 4	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	compound	_	_
 5	ne	ne	ADV	Adverb	_	6	advmod	_	_
 6	kolay	kolay	ADJ	Adj	_	7	amod	_	_
-7	görünür	görün	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+7	görünür	görün	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	33	punct	_	_
 9	hatta	hatta	CCONJ	Conj	_	13	nmod	_	_
 10	Zübeyde	Zübeyde	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
@@ -12686,18 +12686,18 @@
 # sent_id = mst-5420
 # text = Mutluluğu ararsan bulursun, mutsuzluğun geleceğini beklersen kendi kendine mutsuz olursun, der.
 1	Mutluluğu	mutluluk	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	obj	_	_
-2	ararsan	ara	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	3	nmod	_	_
-3	bulursun	bul	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	13	obj	_	SpaceAfter=No
+2	ararsan	ara	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	3	nmod	_	_
+3	bulursun	bul	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	13	obj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	10	punct	_	_
 5	mutsuzluğun	mutsuzluk	NOUN	Noun	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
 6	geleceğini	gelecek	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	amod	_	_
-7	beklersen	bekle	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	10	nmod	_	_
+7	beklersen	bekle	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	10	nmod	_	_
 8	kendi	kendi	PRON	Reflex	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	10	obl	_	_
 9	kendine	kendi	PRON	Reflex	Case=Dat|Number=Sing|Number[psor]=Sing|Person=2|Person[psor]=2|Reflex=Yes	8	compound:redup	_	_
 10	mutsuz	mutsuz	ADJ	Adj	_	3	conj	_	_
-11	olursun	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	10	compound:lvc	_	SpaceAfter=No
+11	olursun	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	10	compound:lvc	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	10	punct	_	_
-13	der	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+13	der	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-5427
@@ -12807,11 +12807,11 @@
 
 # sent_id = mst-5467
 # text = Bırakmaz, hiçbir yere bırakmaz sizi.
-1	Bırakmaz	bırak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+1	Bırakmaz	bırak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	5	punct	_	_
 3	hiçbir	hiçbir	DET	Det	_	5	obl	_	_
 4	yere	yer	NOUN	Noun	Case=Dat|Number=Sing|Person=3	3	fixed	_	_
-5	bırakmaz	bırak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	1	conj	_	_
+5	bırakmaz	bırak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	1	conj	_	_
 6	sizi	siz	PRON	Pers	Case=Acc|Number=Plur|Person=2|PronType=Prs	5	obj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
@@ -12867,7 +12867,7 @@
 10	,	,	PUNCT	Punc	_	11	punct	_	_
 11	yumurtayı	yumurta	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	conj	_	_
 12	yardıma	yardım	NOUN	Noun	Case=Dat|Number=Sing|Person=3	13	obl	_	_
-13	çağırır	çağır	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+13	çağırır	çağır	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-5499
@@ -12906,7 +12906,7 @@
 
 # sent_id = mst-5510
 # text = İmrenmem korkma.
-1	İmrenmem	imren	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	2	nmod	_	_
+1	İmrenmem	imren	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	2	nmod	_	_
 2	korkma	kork	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -12951,7 +12951,7 @@
 # text = Üçü de yakışırlar soframıza.
 1	Üçü	üç	NUM	NNum	Case=Acc|Number=Sing|NumType=Card|Person=3	3	nsubj	_	_
 2	de	de	CCONJ	Conj	_	1	advmod:emph	_	_
-3	yakışırlar	yakış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+3	yakışırlar	yakış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 4	soframıza	sofra	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	3	obl	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -12962,7 +12962,7 @@
 3	de	de	CCONJ	Conj	_	2	advmod:emph	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	2	punct	_	_
 5	mutfağa	mutfak	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
-6	girmez	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	2	conj	_	SpaceAfter=No
+6	girmez	gir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	2	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-5533
@@ -13080,7 +13080,7 @@
 # sent_id = mst-5577
 # text = Ama bilmem beyaz peynirin ihtiyacı var mı?
 1	Ama	ama	CCONJ	Conj	_	0	root	_	_
-2	bilmem	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	1	conj	_	_
+2	bilmem	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	1	conj	_	_
 3	beyaz	beyaz	ADJ	Adj	_	5	nmod:poss	_	_
 4	peynirin	peynir	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	compound	_	_
 5	ihtiyacı	ihtiyaç	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	conj	_	_
@@ -13192,7 +13192,7 @@
 # sent_id = mst-5622
 # text = İsmi değişir.
 1	İsmi	isim	NOUN	Noun	Case=Acc|Number=Sing|Person=3	2	nsubj	_	_
-2	değişir	değiş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	değişir	değiş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-5626
@@ -13220,7 +13220,7 @@
 3	ön	ön	ADJ	Adj	_	4	amod	_	_
 4	mezeler	meze	NOUN	Noun	Case=Nom|Number=Plur|Person=3	5	nmod:poss	_	_
 5	arasına	ara	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
-6	girerler	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	5	compound	_	SpaceAfter=No
+6	girerler	gir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	5	compound	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-5635

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -712,6 +712,7 @@
 
 # sent_id = mst-0327
 # text = İMKB'nin orta ve uzun vadeli getiri potansiyelinden yararlanmak isteyen yatırımcılar için iki alternatif var: Risk alabilen yatırımcılar için A tipi endeks ve hisse fonlar veya İmkb'deki potansiyelden yararlanırken fazla risk almak istemiyorum diyenler için ise A tipi karma ve değişken fonlar.
+# Change 2.2/dev: merge -(y)An
 1	İMKB'nin	İmkb	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	8	nmod:poss	_	_
 2	orta	orta	ADJ	Adj	_	5	amod	_	_
 3	ve	ve	CCONJ	Conj	_	4	cc	_	_
@@ -739,7 +740,7 @@
 24	ve	ve	CCONJ	Conj	_	25	cc	_	_
 25	hisse	hisse	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	conj	_	_
 26	fonlar	fon	NOUN	Noun	Case=Nom|Number=Plur|Person=3	23	compound	_	_
-27	veya	veya	CCONJ	Conj	_	45	cc	_	_
+27	veya	veya	CCONJ	Conj	_	44	cc	_	_
 28-29	İmkb'deki	_	_	_	_	_	_	_	_
 28	İmkb'de	İmkb	PROPN	Prop	Case=Loc|Number=Sing|Person=3	30	nmod	_	_
 29	ki	ki	ADP	Rel	_	28	case	_	_
@@ -749,18 +750,16 @@
 33	risk	risk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	35	obj	_	_
 34	almak	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	33	compound	_	_
 35	istemiyorum	iste	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Polite=Infm|Tense=Pres	36	obj	_	_
-36-37	diyenler	_	_	_	_	_	_	_	_
-36	diyen	de	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	45	acl	_	_
-37	ler	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	36	case	_	_
-38	için	için	ADP	PCNom	_	36	case	_	_
-39	ise	ise	CCONJ	Conj	_	36	discourse	_	_
-40	A	a	INTJ	Interj	_	15	discourse	_	_
-41	tipi	tip	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	40	compound	_	_
-42	karma	karma	ADJ	Adj	_	45	amod	_	_
-43	ve	ve	CCONJ	Conj	_	44	cc	_	_
-44	değişken	değişken	ADJ	Adj	_	42	conj	_	_
-45	fonlar	fon	NOUN	Noun	Case=Nom|Number=Plur|Person=3	15	conj	_	SpaceAfter=No
-46	.	.	PUNCT	Punc	_	45	punct	_	_
+36	diyenler	de	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	44	acl	_	_
+37	için	için	ADP	PCNom	_	36	case	_	_
+38	ise	ise	CCONJ	Conj	_	36	discourse	_	_
+39	A	a	INTJ	Interj	_	15	discourse	_	_
+40	tipi	tip	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	39	compound	_	_
+41	karma	karma	ADJ	Adj	_	44	amod	_	_
+42	ve	ve	CCONJ	Conj	_	43	cc	_	_
+43	değişken	değişken	ADJ	Adj	_	41	conj	_	_
+44	fonlar	fon	NOUN	Noun	Case=Nom|Number=Plur|Person=3	15	conj	_	SpaceAfter=No
+45	.	.	PUNCT	Punc	_	44	punct	_	_
 
 # sent_id = mst-0352
 # text = Bir olayın meydana gelişinden başlayan, sonrasındaki gerilimi hissederken sana bir de öteki yolun olduğunu hissettirecek bir kapı, pencere, ne bileyim, açılım işte...
@@ -871,15 +870,14 @@
 
 # sent_id = mst-0392
 # text = Yanaşanı haklarım anladınız mı?
-1-2	Yanaşanı	_	_	_	_	_	_	_	_
-1	Yanaşan	yanaş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	obj	_	_
-2	ı	_	ADP	Zero	Case=Acc|Number=Sing|Person=3	1	case	_	_
-3-4	haklarım	_	_	_	_	_	_	_	_
-3	haklar	hak	NOUN	Noun	Case=Nom|Number=Plur|Person=3	0	root	_	_
-4	ım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	3	cop	_	_
-5	anladınız	anla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Past	3	conj	_	_
-6	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	3	aux:q	_	SpaceAfter=No
-7	?	?	PUNCT	Punc	_	3	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Yanaşanı	yanaş	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	2	ccomp	_	_
+2-3	haklarım	_	_	_	_	_	_	_	_
+2	haklar	hak	NOUN	Noun	Case=Nom|Number=Plur|Person=3	0	root	_	_
+3	ım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	3	cop	_	_
+4	anladınız	anla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Past	3	conj	_	_
+5	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	3	aux:q	_	SpaceAfter=No
+6	?	?	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-0394
 # text = Gecekondu derken, günümüzde mafyatik ilişkilerle, rant ekonomisinin bir parçası olan uygulamalardan değil, bindokuzyüzatmış bindokuzyüzyetmişsekiz arası, her ailenin kendi evini kendisinin yapması şeklinde gerçekleşen (dokuz) uygulamalardan söz ediyorum.
@@ -1272,6 +1270,7 @@
 
 # sent_id = mst-0557
 # text = Ama bütün gerçeklik-buna karşın-belli bir yere kadardı; başka bir yere gidildiğinde, gerçek olan şey, gerçek-olmayana dönüşüyordu.
+# Change 2.2/dev: merge -(y)An
 1	Ama	ama	CCONJ	Conj	_	11	cc	_	_
 2	bütün	bütün	ADJ	Adj	_	3	det	_	_
 3	gerçeklik	gerçeklik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nsubj	_	SpaceAfter=No
@@ -1285,23 +1284,21 @@
 11-12	kadardı	_	_	_	_	_	_	_	SpaceAfter=No
 11	kadar	kadar	ADP	PCGen	_	0	root	_	_
 12	dı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	11	cop	_	_
-13	;	;	PUNCT	Punc	_	27	punct	_	_
+13	;	;	PUNCT	Punc	_	26	punct	_	_
 14	başka	başka	ADJ	Adj	_	16	amod	_	_
 15	bir	bir	NUM	ANum	NumType=Card	16	det	_	_
 16	yere	yer	NOUN	Noun	Case=Dat|Number=Sing|Person=3	17	obl	_	_
-17	gidildiğinde	git	VERB	Verb	Aspect=Perf|Case=Loc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	27	acl	_	SpaceAfter=No
+17	gidildiğinde	git	VERB	Verb	Aspect=Perf|Case=Loc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	26	acl	_	SpaceAfter=No
 18	,	,	PUNCT	Punc	_	17	punct	_	_
 19	gerçek	gerçek	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	20	amod	_	_
 20	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	21	acl	_	_
-21	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	27	nsubj	_	SpaceAfter=No
-22	,	,	PUNCT	Punc	_	27	punct	_	_
+21	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	26	nsubj	_	SpaceAfter=No
+22	,	,	PUNCT	Punc	_	26	punct	_	_
 23	gerçek	gerçek	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	25	obj	_	SpaceAfter=No
 24	-	-	PUNCT	Punc	_	25	punct	_	SpaceAfter=No
-25-26	olmayana	_	_	_	_	_	_	_	_
-25	olmayan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	27	acl	_	_
-26	a	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	25	case	_	_
-27	dönüşüyordu	dönüş	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	11	conj	_	SpaceAfter=No
-28	.	.	PUNCT	Punc	_	27	punct	_	_
+25	olmayana	ol	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|VerbForm=Part	27	ccomp	_	_
+26	dönüşüyordu	dönüş	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	11	conj	_	SpaceAfter=No
+27	.	.	PUNCT	Punc	_	26	punct	_	_
 
 # sent_id = mst-0573
 # text = Evet dedi.
@@ -2632,13 +2629,12 @@
 
 # sent_id = mst-1140
 # text = Biraz gülüşerek olanları anlattık.
+# Change 2.2/dev: merge -(y)An
 1	Biraz	biraz	ADV	Adverb	_	2	advmod	_	_
-2	gülüşerek	gülüş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	5	nmod	_	_
-3-4	olanları	_	_	_	_	_	_	_	_
-3	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	obj	_	_
-4	ları	_	ADP	Zero	Case=Acc|Number=Plur|Person=3	3	case	_	_
-5	anlattık	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	5	punct	_	_
+2	gülüşerek	gülüş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	4	nmod	_	_
+3	olanları	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	4	ccomp	_	_
+4	anlattık	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-1142
 # text = Ne oluyorsun? diye sordu.
@@ -2985,6 +2981,7 @@
 
 # sent_id = mst-1292
 # text = Savundukları görüş platocu düalist görüştür: bu evreni, ancak salt usa vurma yeteneği gösterebilenler anlayabilir.
+# Change 2.2/dev: merge -(y)An
 1	Savundukları	savun	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	2	acl	_	_
 2	görüş	görüş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
 3	platocu	platocu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod	_	_
@@ -2992,20 +2989,18 @@
 5-6	görüştür	_	_	_	_	_	_	_	SpaceAfter=No
 5	görüş	görüş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 6	tür	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	5	cop	_	_
-7	:	:	PUNCT	Punc	_	18	punct	_	_
+7	:	:	PUNCT	Punc	_	17	punct	_	_
 8	bu	bu	DET	Det	_	9	det	_	_
 9	evreni	evren	NOUN	Noun	Case=Acc|Number=Sing|Person=3	18	obj	_	SpaceAfter=No
-10	,	,	PUNCT	Punc	_	18	punct	_	_
-11	ancak	ancak	ADV	Adverb	_	17	advmod	_	_
+10	,	,	PUNCT	Punc	_	17	punct	_	_
+11	ancak	ancak	ADV	Adverb	_	16	advmod	_	_
 12	salt	salt	ADV	Adverb	_	15	advmod	_	_
 13	usa	us	NOUN	Noun	Case=Dat|Number=Sing|Person=3	15	nmod:poss	_	_
 14	vurma	vur	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	13	compound	_	_
 15	yeteneği	yetenek	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obj	_	_
-16-17	gösterebilenler	_	_	_	_	_	_	_	_
-16	gösterebilen	göster	VERB	Verb	Aspect=Perf|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Part	18	nsubj	_	_
-17	ler	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	16	case	_	_
-18	anlayabilir	anla	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	SpaceAfter=No
-19	.	.	PUNCT	Punc	_	18	punct	_	_
+16	gösterebilenler	göster	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	17	csubj	_	_
+17	anlayabilir	anla	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	SpaceAfter=No
+18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-1303
 # text = Özer'lerin Mithatpaşa'daki bahçe içindeki evindeydik.
@@ -3267,32 +3262,31 @@
 
 # sent_id = mst-1423
 # text = Yapı Kredi Sanat Festivali yetkilileri de durumu bir ilanla duyurarak konsere bilet alanların ücretlerini Yapı Kredi Yayınları Galatasaray Kitabevi'nden hemen geri alabileceklerini açıkladı.
+# Change 2.2/dev: merge -(y)An
 1	Yapı	yapı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
 2	Kredi	kredi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
 3	Sanat	sanat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
 4	Festivali	festival	NOUN	Noun	Case=Acc|Number=Sing|Person=3	1	flat	_	_
-5	yetkilileri	yetkili	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	24	nsubj	_	_
+5	yetkilileri	yetkili	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	23	nsubj	_	_
 6	de	de	CCONJ	Conj	_	5	advmod:emph	_	_
 7	durumu	durum	NOUN	Noun	Case=Acc|Number=Sing|Person=3	10	obj	_	_
 8	bir	bir	NUM	ANum	NumType=Card	9	det	_	_
 9	ilanla	ilan	NOUN	Noun	Case=Ins|Number=Sing|Person=3	10	obl	_	_
 10	duyurarak	duyur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	24	nmod	_	_
-11	konsere	konser	NOUN	Noun	Case=Dat|Number=Sing|Person=3	14	obl	_	_
+11	konsere	konser	NOUN	Noun	Case=Dat|Number=Sing|Person=3	13	obl	_	_
 12	bilet	bilet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obj	_	_
-13-14	alanların	_	_	_	_	_	_	_	_
-13	alan	al	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	23	nmod:poss	_	_
-14	ların	_	ADP	Zero	Case=Gen|Number=Plur|Person=3	13	case	_	_
-15	ücretlerini	ücret	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	23	obj	_	_
-16	Yapı	yapı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	obl	_	_
-17	Kredi	kredi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	flat	_	_
-18	Yayınları	yayın	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	16	compound	_	_
-19	Galatasaray	Galatasaray	PROPN	Prop	Case=Nom|Number=Sing|Person=3	16	flat	_	_
-20	Kitabevi'nden	kitabev	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	flat	_	_
-21	hemen	hemen	ADV	Adverb	_	23	advmod	_	_
-22	geri	geri	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	23	amod	_	_
-23	alabileceklerini	al	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Pot|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	24	obj	_	_
-24	açıkladı	açıkla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-25	.	.	PUNCT	Punc	_	24	punct	_	_
+13	alanların	al	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	22	csubj	_	_
+14	ücretlerini	ücret	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	22	obj	_	_
+15	Yapı	yapı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	obl	_	_
+16	Kredi	kredi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	flat	_	_
+17	Yayınları	yayın	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	15	compound	_	_
+18	Galatasaray	Galatasaray	PROPN	Prop	Case=Nom|Number=Sing|Person=3	15	flat	_	_
+19	Kitabevi'nden	kitabev	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	flat	_	_
+20	hemen	hemen	ADV	Adverb	_	22	advmod	_	_
+21	geri	geri	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	22	amod	_	_
+22	alabileceklerini	al	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Pot|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	23	ccomp	_	_
+23	açıkladı	açıkla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+24	.	.	PUNCT	Punc	_	23	punct	_	_
 
 # sent_id = mst-1431
 # text = Ağırlık Japonlar ve Ruslar'da.
@@ -4900,18 +4894,17 @@
 
 # sent_id = mst-2078
 # text = Onunla aynı ortamı paylaşmış olanlar böyle anlatıyorlardı büyük amcamı.
+# Change 2.2/dev: merge -(y)An
 1	Onunla	o	PRON	Demons	Case=Ins|Number=Sing|Person=3|PronType=Dem	4	obl	_	_
 2	aynı	aynı	ADJ	Adj	_	3	amod	_	_
 3	ortamı	ortam	NOUN	Noun	Case=Acc|Number=Sing|Person=3	4	obj	_	_
 4	paylaşmış	paylaş	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	5	acl	_	_
-5-6	olanlar	_	_	_	_	_	_	_	_
-5	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	8	nsubj	_	_
-6	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	5	case	_	_
-7	böyle	böyle	ADV	Adverb	_	8	advmod	_	_
-8	anlatıyorlardı	anlat	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	_
-9	büyük	büyük	ADJ	Adj	_	10	amod	_	_
-10	amcamı	amca	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	8	obj	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	8	punct	_	_
+5	olanlar	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	7	csubj	_	_
+6	böyle	böyle	ADV	Adverb	_	7	advmod	_	_
+7	anlatıyorlardı	anlat	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	_
+8	büyük	büyük	ADJ	Adj	_	9	amod	_	_
+9	amcamı	amca	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	7	obj	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-2082
 # text = Ama Ali oldukça üzgündü ve bu kadar uzun bir hikayeyi baştan sona dinleyecek durumda değildi o gün.
@@ -5992,17 +5985,16 @@
 
 # sent_id = mst-2560
 # text = Onunla konuşanlar belki de ona da öyle diyorlar.
+# Change 2.2/dev: merge -(y)An
 1	Onunla	o	PRON	Pers	Case=Ins|Number=Sing|Person=3|PronType=Prs	2	obl	_	_
-2-3	konuşanlar	_	_	_	_	_	_	_	_
-2	konuşan	konuş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	nsubj	_	_
-3	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	2	case	_	_
-4	belki	belki	ADV	Adverb	_	0	root	_	_
-5	de	de	CCONJ	Conj	_	4	advmod:emph	_	_
-6	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	9	obl	_	_
-7	da	da	CCONJ	Conj	_	6	advmod:emph	_	_
-8	öyle	öyle	ADV	Adverb	_	9	advmod	_	_
-9	diyorlar	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	4	conj	_	SpaceAfter=No
-10	.	.	PUNCT	Punc	_	9	punct	_	_
+2	konuşanlar	konuş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	8	nsubj	_	_
+3	belki	belki	ADV	Adverb	_	0	root	_	_
+4	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
+5	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	8	obl	_	_
+6	da	da	CCONJ	Conj	_	5	advmod:emph	_	_
+7	öyle	öyle	ADV	Adverb	_	8	advmod	_	_
+8	diyorlar	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	3	conj	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-2566
 # text = Sözgelimi Hüseyin hiç de sandığım gibi yaşlı, zengin kadınları kullanan bir erkek değilmiş.
@@ -6374,23 +6366,22 @@
 
 # sent_id = mst-2710
 # text = Benim başından beri gördüğüm kadarıyla vurgulanan da zaten hep buydu.
+# Change 2.2/dev: merge kadar + ıyla
 1-2	Benim	_	_	_	_	_	_	_	_
 1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nmod:poss	_	_
 2	im	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	1	cop	_	_
 3	başından	baş	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 4	beri	beri	ADP	PCAbl	_	3	case	_	_
-5	gördüğüm	gör	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	7	nmod:poss	_	_
-6-7	kadarıyla	_	_	_	_	_	_	_	_
-6	kadar	kadar	ADP	PCNom	_	12	case	_	_
-7	ıyla	_	ADP	Zero	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	case	_	_
-8	vurgulanan	vurgula	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	12	nsubj	_	_
-9	da	da	CCONJ	Conj	_	8	advmod:emph	_	_
-10	zaten	zaten	ADV	Adverb	_	12	advmod	_	_
-11	hep	hep	ADV	Adverb	_	12	advmod	_	_
-12-13	buydu	_	_	_	_	_	_	_	SpaceAfter=No
-12	bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	0	root	_	_
-13	ydu	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	12	cop	_	_
-14	.	.	PUNCT	Punc	_	12	punct	_	_
+5	gördüğüm	gör	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	11	advmod	_	_
+6	kadarıyla	kadar	ADP	PCNom	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	advmod	_	_
+7	vurgulanan	vurgula	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	11	csubj	_	_
+8	da	da	CCONJ	Conj	_	7	advmod:emph	_	_
+9	zaten	zaten	ADV	Adverb	_	11	advmod	_	_
+10	hep	hep	ADV	Adverb	_	11	advmod	_	_
+11-12	buydu	_	_	_	_	_	_	_	SpaceAfter=No
+11	bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	0	root	_	_
+12	ydu	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	11	cop	_	_
+13	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-2717
 # text = Bir dilim kavun aldı.
@@ -8717,19 +8708,18 @@
 
 # sent_id = mst-3685
 # text = Büyük mimar Len Ti-, yararlı olanı güzel saymıştı.
+# Change 2.2/dev: merge -(y)An
 1	Büyük	büyük	ADJ	Adj	_	2	amod	_	_
 2	mimar	mimar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod	_	_
-3	Len	Len	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
+3	Len	Len	PROPN	Prop	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
 4	Ti	Ti	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	flat	_	SpaceAfter=No
-5	-	-	PUNCT	Punc	_	11	punct	_	SpaceAfter=No
-6	,	,	PUNCT	Punc	_	11	punct	_	_
-7	yararlı	yararlı	ADJ	Adj	_	9	amod	_	_
-8-9	olanı	_	_	_	_	_	_	_	_
-8	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	obj	_	_
-9	ı	_	ADP	Zero	Case=Acc|Number=Sing|Person=3	8	case	_	_
-10	güzel	güzel	ADJ	Adj	_	11	obj	_	_
-11	saymıştı	say	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
-12	.	.	PUNCT	Punc	_	11	punct	_	_
+5	-	-	PUNCT	Punc	_	10	punct	_	SpaceAfter=No
+6	,	,	PUNCT	Punc	_	10	punct	_	_
+7	yararlı	yararlı	ADJ	Adj	_	8	obj	_	_
+8	olanı	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	10	obj	_	_
+9	güzel	güzel	ADJ	Adj	_	10	obj	_	_
+10	saymıştı	say	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
+11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-3691
 # text = Çocukları pek sevmem, ama onlarla konuşmaktan hoşlanırım; çünkü bence insanların en ilginç fikirleri aslında söylemeyip kendilerine sakladıkları fikirleridir, çocuklar ise hiçbir düşüncelerini kendilerine saklamazlar hemen söylerler, onun için onlarla konuşurken daima ilginç bir şeyler duyabilirsiniz.
@@ -9131,6 +9121,7 @@
 
 # sent_id = mst-3850
 # text = Bir zaman sonra komşular da fakir olduğundan seyrekleşmiş getirilenler.
+# Change 2.2/dev: merge -(y)An
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
 3	sonra	sonra	ADP	PCAbl	_	2	case	_	_
@@ -9139,10 +9130,8 @@
 6	fakir	fakir	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	7	obj	_	_
 7	olduğundan	ol	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	8	acl	_	_
 8	seyrekleşmiş	seyrekleş	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
-9-10	getirilenler	_	_	_	_	_	_	_	SpaceAfter=No
-9	getirilen	getir	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	8	nsubj	_	_
-10	ler	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	9	case	_	_
-11	.	.	PUNCT	Punc	_	9	punct	_	_
+9	getirilenler	getir	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	8	csubj	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-3857
 # text = Kendimizi kullanılmayan topraklara çekmek zorunda kaldık diyor Yakut Devlet Üniversitesi antropologlarından Profesör Anatoliy Alekseyev.
@@ -9189,58 +9178,56 @@
 
 # sent_id = mst-3876
 # text = Bu süre içinde doğum yapanların karları erimiş, otları çıkmaya başlamış, suyu olan, kurtlara karşı korunaklı bir alanda koruma altına alınmaları gerekecek.
+# Change 2.2/dev: merge -(y)An
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	süre	süre	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 3	içinde	iç	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	amod	_	_
 4	doğum	doğum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	case	_	_
-5-6	yapanların	_	_	_	_	_	_	_	_
-5	yapan	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	nmod:poss	_	_
-6	ların	_	ADP	Zero	Case=Gen|Number=Plur|Person=3	4	compound:lvc	_	_
-7	karları	kar	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	8	nsubj	_	_
-8	erimiş	eri	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	22	acl	_	SpaceAfter=No
-9	,	,	PUNCT	Punc	_	12	punct	_	_
-10	otları	ot	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	12	nsubj	_	_
-11	çıkmaya	çık	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	12	nmod	_	_
-12	başlamış	başla	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	8	conj	_	SpaceAfter=No
-13	,	,	PUNCT	Punc	_	15	punct	_	_
-14	suyu	su	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	nsubj	_	_
-15	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	8	conj	_	SpaceAfter=No
-16	,	,	PUNCT	Punc	_	15	punct	_	_
-17	kurtlara	kurt	NOUN	Noun	Case=Dat|Number=Plur|Person=3	22	nmod	_	_
-18	karşı	karşı	ADP	PCDat	_	17	case	_	_
-19-20	korunaklı	_	_	_	_	_	_	_	_
-19	korunak	korunak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	nmod	_	_
-20	lı	li	ADP	With	_	19	case	_	_
-21	bir	bir	NUM	ANum	NumType=Card	22	det	_	_
-22	alanda	alan	NOUN	Noun	Case=Loc|Number=Sing|Person=3	23	obl	_	_
-23	koruma	koru	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	26	obj	_	_
-24	altına	alt	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	23	compound	_	_
-25	alınmaları	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	23	compound	_	_
-26	gerekecek	gerek	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	SpaceAfter=No
-27	.	.	PUNCT	Punc	_	26	punct	_	_
+5	yapanların	yap	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	22	csubj	_	_
+6	karları	kar	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	7	nsubj	_	_
+7	erimiş	eri	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	21	acl	_	SpaceAfter=No
+8	,	,	PUNCT	Punc	_	11	punct	_	_
+9	otları	ot	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	11	nsubj	_	_
+10	çıkmaya	çık	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	11	nmod	_	_
+11	başlamış	başla	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	7	conj	_	SpaceAfter=No
+12	,	,	PUNCT	Punc	_	14	punct	_	_
+13	suyu	su	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	nsubj	_	_
+14	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	conj	_	SpaceAfter=No
+15	,	,	PUNCT	Punc	_	14	punct	_	_
+16	kurtlara	kurt	NOUN	Noun	Case=Dat|Number=Plur|Person=3	21	nmod	_	_
+17	karşı	karşı	ADP	PCDat	_	16	case	_	_
+18-19	korunaklı	_	_	_	_	_	_	_	_
+18	korunak	korunak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	nmod	_	_
+19	lı	li	ADP	With	_	18	case	_	_
+20	bir	bir	NUM	ANum	NumType=Card	21	det	_	_
+21	alanda	alan	NOUN	Noun	Case=Loc|Number=Sing|Person=3	22	obl	_	_
+22	koruma	koru	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	25	obj	_	_
+23	altına	alt	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	22	compound	_	_
+24	alınmaları	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	22	compound	_	_
+25	gerekecek	gerek	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	SpaceAfter=No
+26	.	.	PUNCT	Punc	_	25	punct	_	_
 
 # sent_id = mst-3885
 # text = Tarihi, yaşanmışların hatıra defteri olmaktan çıkarıp geleceğimizin yol gösteren rehberi olarak gördükçe, tarihi tekrarlar dururuz.
-1	Tarihi	tarih	NOUN	Noun	Case=Acc|Number=Sing|Person=3	8	obj	_	SpaceAfter=No
-2	,	,	PUNCT	Punc	_	8	punct	_	_
-3-4	yaşanmışların	_	_	_	_	_	_	_	_
-3	yaşanmış	yaşa	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	5	nmod	_	_
-4	ların	_	ADP	Zero	Case=Gen|Number=Plur|Person=3	3	case	_	_
-5	hatıra	hatıra	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
-6	defteri	defter	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	compound	_	_
-7	olmaktan	ol	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nmod	_	_
-8	çıkarıp	çıkar	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	14	nmod	_	_
-9	geleceğimizin	gelecek	ADJ	NAdj	Case=Gen|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	12	amod	_	_
-10	yol	yol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nmod	_	_
-11	gösteren	göster	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	compound	_	_
-12	rehberi	rehber	NOUN	Noun	Case=Acc|Number=Sing|Person=3	14	obl	_	_
-13	olarak	olarak	ADP	PCNom	_	12	case	_	_
-14	gördükçe	gör	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	17	nmod	_	SpaceAfter=No
-15	,	,	PUNCT	Punc	_	14	punct	_	_
-16	tarihi	tarih	NOUN	Noun	Case=Acc|Number=Sing|Person=3	17	obj	_	_
-17	tekrarlar	tekrarla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
-18	dururuz	dur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	17	compound	_	SpaceAfter=No
-19	.	.	PUNCT	Punc	_	17	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Tarihi	tarih	NOUN	Noun	Case=Acc|Number=Sing|Person=3	7	obj	_	SpaceAfter=No
+2	,	,	PUNCT	Punc	_	7	punct	_	_
+3	yaşanmışların	yaşa	VERB	Verb	Aspect=Perf|Case=Gen|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	4	nmod	_	_
+4	hatıra	hatıra	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obj	_	_
+5	defteri	defter	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	compound	_	_
+6	olmaktan	ol	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	nmod	_	_
+7	çıkarıp	çıkar	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	13	nmod	_	_
+8	geleceğimizin	gelecek	ADJ	NAdj	Case=Gen|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	11	amod	_	_
+9	yol	yol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nmod	_	_
+10	gösteren	göster	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	compound	_	_
+11	rehberi	rehber	NOUN	Noun	Case=Acc|Number=Sing|Person=3	13	obl	_	_
+12	olarak	olarak	ADP	PCNom	_	11	case	_	_
+13	gördükçe	gör	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	16	nmod	_	SpaceAfter=No
+14	,	,	PUNCT	Punc	_	13	punct	_	_
+15	tarihi	tarih	NOUN	Noun	Case=Acc|Number=Sing|Person=3	16	obj	_	_
+16	tekrarlar	tekrarla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+17	dururuz	dur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	16	compound	_	SpaceAfter=No
+18	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-3894
 # text = Başkent Yakutsk'tan kalkan İlin Tur'a ait çift kanatlı kargo uçağı, iki saatlik soğuk bir yolculuktan sonra bıraktı beni, rehberimle buluşacağım Verkhoyansk Dağları'na.
@@ -9499,29 +9486,28 @@
 
 # sent_id = mst-4009
 # text = Bazı geceler, gelenlerin arasından, balıkçıların bir kenarda oturmalarına üzülen sıcakkanlı birinin, onları ellerinden çekerek ortaya çıkardığı olurdu.
+# Change 2.2/dev: merge -(y)An
 1	Bazı	bazı	DET	Det	_	2	det	_	_
-2	geceler	gece	NOUN	Noun	Case=Nom|Number=Plur|Person=3	21	obl	_	SpaceAfter=No
-3	,	,	PUNCT	Punc	_	21	punct	_	_
-4-5	gelenlerin	_	_	_	_	_	_	_	_
-4	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	nmod:poss	_	_
-5	lerin	_	ADP	Zero	Case=Gen|Number=Plur|Person=3	4	case	_	_
-6	arasından	ara	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	amod	_	SpaceAfter=No
-7	,	,	PUNCT	Punc	_	21	punct	_	_
-8	balıkçıların	balıkçı	NOUN	Noun	Case=Gen|Number=Plur|Person=3	11	nmod:poss	_	_
-9	bir	bir	NUM	ANum	NumType=Card	10	det	_	_
-10	kenarda	kenar	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	11	amod	_	_
-11	oturmalarına	otur	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	12	nmod	_	_
-12	üzülen	üz	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	14	acl	_	_
-13	sıcakkanlı	sıcakkanlı	ADJ	Adj	_	14	amod	_	_
-14	birinin	biri	PRON	Quant	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	19	nmod	_	SpaceAfter=No
-15	,	,	PUNCT	Punc	_	21	punct	_	_
-16	onları	o	PRON	Pers	Case=Acc|Number=Plur|Person=3|PronType=Prs	19	obj	_	_
-17	ellerinden	el	NOUN	Noun	Case=Abl|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	18	obl	_	_
-18	çekerek	çek	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	19	nmod	_	_
-19	ortaya	orta	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	21	nsubj	_	_
-20	çıkardığı	çıkar	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	19	compound	_	_
-21	olurdu	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
-22	.	.	PUNCT	Punc	_	21	punct	_	_
+2	geceler	gece	NOUN	Noun	Case=Nom|Number=Plur|Person=3	20	obl	_	SpaceAfter=No
+3	,	,	PUNCT	Punc	_	20	punct	_	_
+4	gelenlerin	gel	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	5	nmod:poss	_	_
+5	arasından	ara	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	amod	_	SpaceAfter=No
+6	,	,	PUNCT	Punc	_	20	punct	_	_
+7	balıkçıların	balıkçı	NOUN	Noun	Case=Gen|Number=Plur|Person=3	10	nmod:poss	_	_
+8	bir	bir	NUM	ANum	NumType=Card	9	det	_	_
+9	kenarda	kenar	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	10	amod	_	_
+10	oturmalarına	otur	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	11	nmod	_	_
+11	üzülen	üz	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	13	acl	_	_
+12	sıcakkanlı	sıcakkanlı	ADJ	Adj	_	13	amod	_	_
+13	birinin	biri	PRON	Quant	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	18	nmod	_	SpaceAfter=No
+14	,	,	PUNCT	Punc	_	20	punct	_	_
+15	onları	o	PRON	Pers	Case=Acc|Number=Plur|Person=3|PronType=Prs	18	obj	_	_
+16	ellerinden	el	NOUN	Noun	Case=Abl|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	17	obl	_	_
+17	çekerek	çek	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	18	nmod	_	_
+18	ortaya	orta	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	20	nsubj	_	_
+19	çıkardığı	çıkar	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	18	compound	_	_
+20	olurdu	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+21	.	.	PUNCT	Punc	_	20	punct	_	_
 
 # sent_id = mst-4023
 # text = Şimdi, öbür sebzelere geçiyoruz.
@@ -10101,30 +10087,29 @@
 
 # sent_id = mst-4273
 # text = Bu ilkeden yola çıkanlar, düşüncenin daha asil, düşüncedeki nesnelerin duyu organlarınca algılanan nesnelerden daha gerçek olduğunu savunmaktadırlar.
+# Change 2.2/dev: merge -(y)An
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	ilkeden	ilke	NOUN	Noun	Case=Abl|Number=Sing|Person=3	3	nmod	_	_
-3	yola	yol	NOUN	Noun	Case=Dat|Number=Sing|Person=3	21	nsubj	_	_
-4-5	çıkanlar	_	_	_	_	_	_	_	SpaceAfter=No
-4	çıkan	çık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	compound	_	_
-5	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	3	case	_	_
-6	,	,	PUNCT	Punc	_	21	punct	_	_
-7	düşüncenin	düşünce	NOUN	Noun	Case=Gen|Number=Sing|Person=3	20	nmod:poss	_	_
-8	daha	daha	ADV	Adverb	_	9	advmod	_	_
-9	asil	asil	ADJ	Adj	_	20	amod	_	SpaceAfter=No
-10	,	,	PUNCT	Punc	_	20	punct	_	_
-11-12	düşüncedeki	_	_	_	_	_	_	_	_
-11	düşüncede	düşünce	NOUN	Noun	Case=Loc|Number=Sing|Person=3	13	nmod	_	_
-12	ki	ki	ADP	Rel	_	11	case	_	_
-13	nesnelerin	nesne	NOUN	Noun	Case=Gen|Number=Plur|Person=3	20	nmod:poss	_	_
-14	duyu	duyu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	obl	_	_
-15	organlarınca	organ	NOUN	Noun	Case=Equ|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	14	compound	_	_
-16	algılanan	algıla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	17	acl	_	_
-17	nesnelerden	nesne	NOUN	Noun	Case=Abl|Number=Plur|Person=3	19	obl	_	_
-18	daha	daha	ADV	Adverb	_	19	advmod	_	_
-19	gerçek	gerçek	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	20	amod	_	_
-20	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	21	obj	_	_
-21	savunmaktadırlar	savun	VERB	Verb	Aspect=Prog|Mood=Gen|Number=Plur|Person=3|Polarity=Pos|Polite=Form|Tense=Pres	0	root	_	SpaceAfter=No
-22	.	.	PUNCT	Punc	_	21	punct	_	_
+3	yola	yol	NOUN	Noun	Case=Dat|Number=Sing|Person=3	20	nsubj	_	_
+4	çıkanlar	çık	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	3	compound	_	SpaceAfter=No
+5	,	,	PUNCT	Punc	_	20	punct	_	_
+6	düşüncenin	düşünce	NOUN	Noun	Case=Gen|Number=Sing|Person=3	19	nmod:poss	_	_
+7	daha	daha	ADV	Adverb	_	8	advmod	_	_
+8	asil	asil	ADJ	Adj	_	19	amod	_	SpaceAfter=No
+9	,	,	PUNCT	Punc	_	19	punct	_	_
+10-11	düşüncedeki	_	_	_	_	_	_	_	_
+10	düşüncede	düşünce	NOUN	Noun	Case=Loc|Number=Sing|Person=3	12	nmod	_	_
+11	ki	ki	ADP	Rel	_	10	case	_	_
+12	nesnelerin	nesne	NOUN	Noun	Case=Gen|Number=Plur|Person=3	19	nmod:poss	_	_
+13	duyu	duyu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	obl	_	_
+14	organlarınca	organ	NOUN	Noun	Case=Equ|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	13	compound	_	_
+15	algılanan	algıla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	16	acl	_	_
+16	nesnelerden	nesne	NOUN	Noun	Case=Abl|Number=Plur|Person=3	18	obl	_	_
+17	daha	daha	ADV	Adverb	_	18	advmod	_	_
+18	gerçek	gerçek	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	19	amod	_	_
+19	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	20	obj	_	_
+20	savunmaktadırlar	savun	VERB	Verb	Aspect=Prog|Mood=Gen|Number=Plur|Person=3|Polarity=Pos|Polite=Form|Tense=Pres	0	root	_	SpaceAfter=No
+21	.	.	PUNCT	Punc	_	20	punct	_	_
 
 # sent_id = mst-4284
 # text = Erkekler Parkı'nı biliyorum, dedim.
@@ -10970,41 +10955,40 @@
 # sent_id = mst-4667
 # text = Olan biteni kimden anlamasını bekleyebilirdim, ondan başka kime sığınabilirdim? Sofraya iyice abandım; susa dura, güle efkarlana, üzülüp sevine, kalkıp otura, bağıra çağıra bir bir anlattım.
 # Change 2.2/dev: merge -CA
+# Change 2.2/dev: merge -(y)An
 1	Olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	2	case	_	_
-2-3	biteni	_	_	_	_	_	_	_	_
-2	biten	bit	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	obj	_	_
-3	i	_	ADP	Zero	Case=Acc|Number=Sing|Person=3	1	compound	_	_
-4	kimden	kim	PRON	Ques	Case=Abl|Number=Sing|Person=3	6	obl	_	_
-5	anlamasını	anla	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	obj	_	_
-6	bekleyebilirdim	bekle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
-7	,	,	PUNCT	Punc	_	11	punct	_	_
-8	ondan	o	PRON	Pers	Case=Abl|Number=Sing|Person=3|PronType=Prs	10	nmod	_	_
-9	başka	başka	ADP	PCAbl	_	8	case	_	_
-10	kime	kim	PRON	Ques	Case=Dat|Number=Sing|Person=3	11	obl	_	_
-11	sığınabilirdim	sığın	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	6	conj	_	SpaceAfter=No
-12	?	?	PUNCT	Punc	_	11	punct	_	_
-13	Sofraya	sofra	NOUN	Noun	Case=Dat|Number=Sing|Person=3	15	obl	_	_
-14	iyice	iyice	ADV	Adverb	_	15	advmod	_	_
-15	abandım	aban	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	6	conj	_	SpaceAfter=No
-16	;	;	PUNCT	Punc	_	34	punct	_	_
-17	susa	sus	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	nmod	_	_
-18	dura	dur	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	33	nmod	_	SpaceAfter=No
-19	,	,	PUNCT	Punc	_	21	punct	_	_
-20	güle	gül	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	21	nmod	_	_
-21	efkarlana	efkarlan	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	conj	_	SpaceAfter=No
-22	,	,	PUNCT	Punc	_	23	punct	_	_
-23	üzülüp	üz	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	18	conj	_	_
-24	sevine	sevin	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	23	compound:redup	_	SpaceAfter=No
-25	,	,	PUNCT	Punc	_	26	punct	_	_
-26	kalkıp	kalk	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	18	conj	_	_
-27	otura	otur	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	26	compound:redup	_	SpaceAfter=No
-28	,	,	PUNCT	Punc	_	29	punct	_	_
-29	bağıra	bağır	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	conj	_	_
-30	çağıra	çağır	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	29	compound:redup	_	_
-31	bir	bir	ADV	Adverb	_	18	advmod	_	_
-32	bir	bir	ADV	Adverb	_	31	advmod	_	_
-33	anlattım	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	15	conj	_	SpaceAfter=No
-34	.	.	PUNCT	Punc	_	33	punct	_	_
+2	biteni	bit	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	4	ccomp	_	_
+3	kimden	kim	PRON	Ques	Case=Abl|Number=Sing|Person=3	5	obl	_	_
+4	anlamasını	anla	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	obj	_	_
+5	bekleyebilirdim	bekle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+6	,	,	PUNCT	Punc	_	9	punct	_	_
+7	ondan	o	PRON	Pers	Case=Abl|Number=Sing|Person=3|PronType=Prs	8	nmod	_	_
+8	başka	başka	ADP	PCAbl	_	6	case	_	_
+9	kime	kim	PRON	Ques	Case=Dat|Number=Sing|Person=3	9	obl	_	_
+10	sığınabilirdim	sığın	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	4	conj	_	SpaceAfter=No
+11	?	?	PUNCT	Punc	_	9	punct	_	_
+12	Sofraya	sofra	NOUN	Noun	Case=Dat|Number=Sing|Person=3	13	obl	_	_
+13	iyice	iyice	ADV	Adverb	_	13	advmod	_	_
+14	abandım	aban	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	4	conj	_	SpaceAfter=No
+15	;	;	PUNCT	Punc	_	32	punct	_	_
+16	susa	sus	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	16	nmod	_	_
+17	dura	dur	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	31	nmod	_	SpaceAfter=No
+18	,	,	PUNCT	Punc	_	19	punct	_	_
+19	güle	gül	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	19	nmod	_	_
+20	efkarlana	efkarlan	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	16	conj	_	SpaceAfter=No
+21	,	,	PUNCT	Punc	_	21	punct	_	_
+22	üzülüp	üz	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	16	conj	_	_
+23	sevine	sevin	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	21	compound:redup	_	SpaceAfter=No
+24	,	,	PUNCT	Punc	_	24	punct	_	_
+25	kalkıp	kalk	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	16	conj	_	_
+26	otura	otur	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	24	compound:redup	_	SpaceAfter=No
+27	,	,	PUNCT	Punc	_	27	punct	_	_
+28	bağıra	bağır	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	16	conj	_	_
+29	çağıra	çağır	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	27	compound:redup	_	_
+30	bir	bir	ADV	Adverb	_	16	advmod	_	_
+31	bir	bir	ADV	Adverb	_	29	advmod	_	_
+32	anlattım	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	13	conj	_	SpaceAfter=No
+33	.	.	PUNCT	Punc	_	31	punct	_	_
 
 # sent_id = mst-4688
 # text = Doğrudur.
@@ -11040,13 +11024,12 @@
 
 # sent_id = mst-4702
 # text = Ağzından çıkanı iki ettirmezdim.
+# Change 2.2/dev: merge -(y)An
 1	Ağzından	ağız	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	obl	_	_
-2-3	çıkanı	_	_	_	_	_	_	_	_
-2	çıkan	çık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	obj	_	_
-3	ı	_	ADP	Zero	Case=Acc|Number=Sing|Person=3	2	case	_	_
-4	iki	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	0	root	_	_
-5	ettirmezdim	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=AorPast|Voice=Cau	4	compound	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	4	punct	_	_
+2	çıkanı	çık	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	3	ccomp	_	_
+3	iki	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	0	root	_	_
+4	ettirmezdim	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=AorPast|Voice=Cau	3	compound	_	SpaceAfter=No
+5	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-4705
 # text = Onların yanıtları karşısında yüzlerine ilgisizce bakarsanız gözlerindeki umutsuzluk ve çaresizlikle karşılaşırsınız.
@@ -11325,13 +11308,12 @@
 
 # sent_id = mst-4824
 # text = Yalnızca yararlı olandan tiksiniyoruz...
+# Change 2.2/dev: merge -(y)An
 1	Yalnızca	yalnızca	ADV	Adverb	_	0	root	_	_
-2	yararlı	yararlı	ADJ	Adj	_	4	amod	_	_
-3-4	olandan	_	_	_	_	_	_	_	_
-3	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	acl	_	_
-4	dan	_	ADP	Zero	Case=Abl|Number=Sing|Person=3	3	case	_	_
-5	tiksiniyoruz	tiksin	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
-6	...	...	PUNCT	Punc	_	5	punct	_	_
+2	yararlı	yararlı	ADJ	Adj	_	3	obj	_	_
+3	olandan	ol	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	5	advcl	_	_
+4	tiksiniyoruz	tiksin	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
+5	...	...	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4827
 # text = Pilot Yunak'ın sinir krizleri geçiren annesi Rüveyde Yunak ile ablası Asuman Taran ise doktor '..
@@ -11674,27 +11656,26 @@
 
 # sent_id = mst-4973
 # text = Matematik, usa vurmadaki kusursuzluğun duyu organlarımızla algıladığımız cisimlere değil, yalnızca ereksel olana uygulanabileceğini söyler.
-1	Matematik	matematik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	Punc	_	18	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Matematik	matematik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nsubj	_	SpaceAfter=No
+2	,	,	PUNCT	Punc	_	17	punct	_	_
 3	usa	us	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	nmod	_	_
 4-5	vurmadaki	_	_	_	_	_	_	_	_
 4	vurmada	vur	VERB	Verb	Aspect=Perf|Case=Loc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	3	compound	_	_
 5	ki	ki	ADP	Rel	_	3	case	_	_
-6	kusursuzluğun	kusursuzluk	NOUN	Noun	Case=Gen|Number=Sing|Person=3	17	nmod:poss	_	_
+6	kusursuzluğun	kusursuzluk	NOUN	Noun	Case=Gen|Number=Sing|Person=3	16	nmod	_	_
 7	duyu	duyu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
 8	organlarımızla	organ	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=1	7	compound	_	_
 9	algıladığımız	algıla	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	10	acl	_	_
-10	cisimlere	cisim	NOUN	Noun	Case=Dat|Number=Plur|Person=3	17	obl	_	_
+10	cisimlere	cisim	NOUN	Noun	Case=Dat|Number=Plur|Person=3	16	obl	_	_
 11	değil	değil	CCONJ	Conj	_	16	cc	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	15	punct	_	_
 13	yalnızca	yalnızca	ADV	Adverb	_	16	advmod	_	_
 14	ereksel	ereksel	ADJ	Adj	_	15	amod	_	_
-15-16	olana	_	_	_	_	_	_	_	_
-15	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	conj	_	_
-16	a	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	15	case	_	_
-17	uygulanabileceğini	uygula	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	18	obj	_	_
-18	söyler	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
-19	.	.	PUNCT	Punc	_	18	punct	_	_
+15	olana	ol	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	10	conj	_	_
+16	uygulanabileceğini	uygula	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	17	ccomp	_	_
+17	söyler	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-4984
 # text = Hastalık peynirleri bunlar.
@@ -11860,31 +11841,30 @@
 
 # sent_id = mst-5058
 # text = Değişiklik tasarısı tüketici kredisi kullananlara taksitlerini vadesinde ödeyememeleri durumunda uygulanan gecikme faizi oranını, kredi faizinin yüzde elli fazlasını geçmeyecek biçimde sınırlandırıyor.
+# Change 2.2/dev: merge -(y)An
 1	Değişiklik	değişiklik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
-2	tasarısı	tasarı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	23	nsubj	_	_
+2	tasarısı	tasarı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	22	nsubj	_	_
 3	tüketici	tüketici	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
 4	kredisi	kredi	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	compound	_	_
-5-6	kullananlara	_	_	_	_	_	_	_	_
-5	kullanan	kullan	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	acl	_	_
-6	lara	_	ADP	Zero	Case=Dat|Number=Plur|Person=3	5	case	_	_
-7	taksitlerini	taksit	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	9	obj	_	_
-8	vadesinde	vade	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
-9	ödeyememeleri	öde	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Number[psor]=Plur|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	10	nmod:poss	_	_
-10	durumunda	durum	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obl	_	_
-11	uygulanan	uygula	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	13	acl	_	_
-12	gecikme	gecik	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	13	nmod:poss	_	_
-13	faizi	faiz	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	nmod:poss	_	_
-14	oranını	oran	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	23	obj	_	SpaceAfter=No
-15	,	,	PUNCT	Punc	_	23	punct	_	_
-16	kredi	kredi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nmod:poss	_	_
-17	faizinin	faiz	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	nmod:poss	_	_
-18	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	20	nummod	_	_
-19	elli	elli	NUM	ANum	NumType=Card	18	flat	_	_
-20	fazlasını	fazla	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	obj	_	_
-21	geçmeyecek	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Fut|VerbForm=Part	22	nmod	_	_
-22	biçimde	biçim	NOUN	Noun	Case=Loc|Number=Sing|Person=3	23	obl	_	_
-23	sınırlandırıyor	sınırlan	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
-24	.	.	PUNCT	Punc	_	23	punct	_	_
+5	kullananlara	kullan	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	10	acl	_	_
+6	taksitlerini	taksit	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	8	obj	_	_
+7	vadesinde	vade	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	_
+8	ödeyememeleri	öde	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Number[psor]=Plur|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	9	nmod:poss	_	_
+9	durumunda	durum	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obl	_	_
+10	uygulanan	uygula	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	12	acl	_	_
+11	gecikme	gecik	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	12	nmod:poss	_	_
+12	faizi	faiz	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	nmod:poss	_	_
+13	oranını	oran	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	22	obj	_	SpaceAfter=No
+14	,	,	PUNCT	Punc	_	22	punct	_	_
+15	kredi	kredi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nmod:poss	_	_
+16	faizinin	faiz	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	nmod:poss	_	_
+17	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	19	nummod	_	_
+18	elli	elli	NUM	ANum	NumType=Card	17	flat	_	_
+19	fazlasını	fazla	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	obj	_	_
+20	geçmeyecek	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Fut|VerbForm=Part	21	nmod	_	_
+21	biçimde	biçim	NOUN	Noun	Case=Loc|Number=Sing|Person=3	22	obl	_	_
+22	sınırlandırıyor	sınırlan	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
+23	.	.	PUNCT	Punc	_	22	punct	_	_
 
 # sent_id = mst-5074
 # text = bu yana avukatlık yapıyordu.
@@ -13002,11 +12982,12 @@
 
 # sent_id = mst-5558
 # text = Hazır, Irak krizi patlamış, petrol fiyatları da artmışken bu tür araçlara karşı olanlar, seslerini " avazları çıktığı kadar " duyurmaya başladılar.
+# Change 2.2/dev: merge -(y)An
 1	Hazır	Hazır	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	5	punct	_	_
 3	Irak	Irak	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 4	krizi	kriz	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nsubj	_	_
-5	patlamış	patla	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	25	acl	_	SpaceAfter=No
+5	patlamış	patla	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	24	acl	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	10	punct	_	_
 7	petrol	petrol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
 8	fiyatları	fiyat	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	10	nsubj	_	_
@@ -13014,21 +12995,19 @@
 10	artmışken	art	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Conv	5	conj	_	_
 11	bu	bu	DET	Det	_	12	det	_	_
 12	tür	tür	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nmod	_	_
-13	araçlara	araç	NOUN	Noun	Case=Dat|Number=Plur|Person=3	16	obl	_	_
+13	araçlara	araç	NOUN	Noun	Case=Dat|Number=Plur|Person=3	15	obl	_	_
 14	karşı	karşı	ADP	PCDat	_	13	case	_	_
-15-16	olanlar	_	_	_	_	_	_	_	SpaceAfter=No
-15	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	25	nsubj	_	_
-16	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	15	case	_	_
-17	,	,	PUNCT	Punc	_	15	punct	_	_
-18	seslerini	ses	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	25	obj	_	_
-19	"	"	PUNCT	Punc	_	21	punct	_	_
-20	avazları	avaz	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	21	nsubj	_	_
-21	çıktığı	çık	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	25	acl	_	_
-22	kadar	kadar	ADP	PCDat	_	21	case	_	_
-23	"	"	PUNCT	Punc	_	21	punct	_	_
-24	duyurmaya	duyur	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	25	nmod	_	_
-25	başladılar	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-26	.	.	PUNCT	Punc	_	25	punct	_	_
+15	olanlar	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	24	nsubj	_	SpaceAfter=No
+16	,	,	PUNCT	Punc	_	14	punct	_	_
+17	seslerini	ses	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	24	obj	_	_
+18	"	"	PUNCT	Punc	_	20	punct	_	_
+19	avazları	avaz	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	20	nsubj	_	_
+20	çıktığı	çık	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	24	acl	_	_
+21	kadar	kadar	ADP	PCDat	_	20	case	_	_
+22	"	"	PUNCT	Punc	_	20	punct	_	_
+23	duyurmaya	duyur	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	24	nmod	_	_
+24	başladılar	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+25	.	.	PUNCT	Punc	_	24	punct	_	_
 
 # sent_id = mst-5566
 # text = Bu çoluk çocuk mu bizi yönetecek? deniyordu.
@@ -13120,19 +13099,18 @@
 
 # sent_id = mst-5604
 # text = Aklıma geleni onlara hemen söylemeyecektim, kesin kararlıydım.
-1	Aklıma	akıl	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	6	obj	_	_
-2-3	geleni	_	_	_	_	_	_	_	_
-2	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	1	compound	_	_
-3	i	_	ADP	Zero	Case=Acc|Number=Sing|Person=3	1	case	_	_
-4	onlara	o	PRON	Pers	Case=Dat|Number=Plur|Person=3|PronType=Prs	6	obl	_	_
-5	hemen	hemen	ADV	Adverb	_	6	advmod	_	_
-6	söylemeyecektim	söyle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=FutPast	0	root	_	SpaceAfter=No
-7	,	,	PUNCT	Punc	_	9	punct	_	_
-8	kesin	kesin	ADJ	Adj	_	9	amod	_	_
-9-10	kararlıydım	_	_	_	_	_	_	_	SpaceAfter=No
-9	kararlı	kararlı	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	6	conj	_	_
-10	ydım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Past	9	cop	_	_
-11	.	.	PUNCT	Punc	_	9	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Aklıma	akıl	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	5	obj	_	_
+2	geleni	gel	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	1	compound	_	_
+3	onlara	o	PRON	Pers	Case=Dat|Number=Plur|Person=3|PronType=Prs	5	obl	_	_
+4	hemen	hemen	ADV	Adverb	_	5	advmod	_	_
+5	söylemeyecektim	söyle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=FutPast	0	root	_	SpaceAfter=No
+6	,	,	PUNCT	Punc	_	8	punct	_	_
+7	kesin	kesin	ADJ	Adj	_	8	amod	_	_
+8-9	kararlıydım	_	_	_	_	_	_	_	SpaceAfter=No
+8	kararlı	kararlı	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	5	conj	_	_
+9	ydım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Past	8	cop	_	_
+10	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-5609
 # text = Türkiye, anlamsız iç savaş korkutmalarına iltifat etmiyor.

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -4783,7 +4783,7 @@
 14	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-2023
-# text = Ama sen ille de olmaz dersen kim sana bunu dayatabilir?.
+# text = Ama sen ille de olmaz dersen kim sana bunu dayatabilir?
 1	Ama	ama	CCONJ	Conj	_	0	root	_	_
 2	sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	6	nsubj	_	_
 3	ille	ille	ADV	Adverb	_	6	advmod	_	_
@@ -4795,7 +4795,6 @@
 9	bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	10	obj	_	_
 10	dayatabilir	daya	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	6	conj	_	SpaceAfter=No
 11	?	?	PUNCT	Punc	_	10	punct	_	SpaceAfter=No
-12	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-2028
 # text = Memo keyifle bağırdı: Ben iş diye buna derim iste!...
@@ -9630,7 +9629,7 @@
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-4065
-# text = Bu işin sonu nereye varır bilinmiyor, ancak tutkunları, SUV'ları kullanmakta fena halde ısrarlı!.
+# text = Bu işin sonu nereye varır bilinmiyor, ancak tutkunları, SUV'ları kullanmakta fena halde ısrarlı!
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	işin	iş	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
 3	sonu	son	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nsubj	_	_
@@ -9647,7 +9646,6 @@
 14	halde	hal	NOUN	Noun	Case=Loc|Number=Sing|Person=3	15	obl	_	_
 15	ısrarlı	ısrarlı	ADJ	Adj	_	6	conj	_	SpaceAfter=No
 16	!	!	PUNCT	Punc	_	15	punct	_	SpaceAfter=No
-17	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-4075
 # text = Bilerek.
@@ -11306,7 +11304,7 @@
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-4815
-# text = Melek sana bir döner ısmarlayayım mı?.
+# text = Melek sana bir döner ısmarlayayım mı?
 1	Melek	Melek	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	_
 2	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	5	obl	_	_
 3	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
@@ -11314,7 +11312,6 @@
 5	ısmarlayayım	ısmarla	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	1	conj	_	_
 6	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	5	aux:q	_	SpaceAfter=No
 7	?	?	PUNCT	Punc	_	5	punct	_	SpaceAfter=No
-8	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4818
 # text = Bana şunu söyledi: Ben, dedi, askeri bir hakimim, fakat bu tahkikatın doğru yapıldığına ben de inanmadım.

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -620,19 +620,16 @@
 
 # sent_id = mst-0303
 # text = Lahana gibi göz doyurucu, mide doldurucu değildir.
+# Change 2.2/dev: merge -(y)IcI
 1	Lahana	lahana	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod	_	_
 2	gibi	gibi	ADP	PCNom	_	1	case	_	_
 3	göz	göz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod	_	_
-4-5	doyurucu	_	_	_	_	_	_	_	SpaceAfter=No
-4	doyur	doyur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	3	compound	_	_
-5	ucu	ci	ADP	Agt	_	3	case	_	_
-6	,	,	PUNCT	Punc	_	8	punct	_	_
-7	mide	mide	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8-9	doldurucu	_	_	_	_	_	_	_	_
-8	doldur	dol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|Voice=Cau	10	obj	_	_
-9	ucu	ci	ADP	Agt	_	8	case	_	_
-10	değildir	değil	VERB	Neg	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	10	punct	_	_
+4	doyurucu	doy	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	3	compound	_	SpaceAfter=No
+5	,	,	PUNCT	Punc	_	7	punct	_	_
+6	mide	mide	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
+7	doldurucu	dol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	8	obj	_	_
+8	değildir	değil	VERB	Neg	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-0307
 # text = Ne kadar özlersem özleyeyim, yaşadığım ve işte şimdi bile büyük bir zevkle heyecan veren yaşadığım şu an, geçmişin acısı, donanımsız olduğumuz o günlere, bu yüzden çocuksu olan, bu yüzden çıplak olan, bu yüzden o anda hiç bilmesek de mutlu olduğumuz o günlere özlemimden doğuyor.
@@ -2267,27 +2264,26 @@
 
 # sent_id = mst-0984
 # text = Yorucu bir ilkbahar dönemi öncesinde güç toplamak, eğlenmek, biraz da kasabada bırakılan ailelerle zaman geçirmek amaç.
-1-2	Yorucu	_	_	_	_	_	_	_	_
-1	Yor	yor	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	5	nmod	_	_
-2	ucu	ci	ADP	Agt	_	1	case	_	_
-3	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
-4	ilkbahar	ilkbahar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
-5	dönemi	dönem	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nmod:poss	_	_
-6	öncesinde	önce	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obl	_	_
-7	güç	güç	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
-8	toplamak	topla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	compound	_	SpaceAfter=No
-9	,	,	PUNCT	Punc	_	10	punct	_	_
-10	eğlenmek	eğle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	7	conj	_	SpaceAfter=No
-11	,	,	PUNCT	Punc	_	17	punct	_	_
-12	biraz	biraz	ADV	Adverb	_	17	advmod	_	_
-13	da	da	CCONJ	Conj	_	12	advmod:emph	_	_
-14	kasabada	kasaba	NOUN	Noun	Case=Loc|Number=Sing|Person=3	15	obl	_	_
-15	bırakılan	bırak	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	16	acl	_	_
-16	ailelerle	aile	NOUN	Noun	Case=Ins|Number=Plur|Person=3	17	nmod	_	_
-17	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	conj	_	_
-18	geçirmek	geçir	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	conj	_	_
-19	amaç	amaç	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nsubj	_	SpaceAfter=No
-20	.	.	PUNCT	Punc	_	7	punct	_	_
+# Change 2.2/dev: merge -(y)IcI
+1	Yorucu	yor	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	acl	_	_
+2	bir	bir	NUM	ANum	NumType=Card	3	det	_	_
+3	ilkbahar	ilkbahar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
+4	dönemi	dönem	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nmod:poss	_	_
+5	öncesinde	önce	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	_
+6	güç	güç	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
+7	toplamak	topla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	compound	_	SpaceAfter=No
+8	,	,	PUNCT	Punc	_	9	punct	_	_
+9	eğlenmek	eğle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	6	conj	_	SpaceAfter=No
+10	,	,	PUNCT	Punc	_	16	punct	_	_
+11	biraz	biraz	ADV	Adverb	_	16	advmod	_	_
+12	da	da	CCONJ	Conj	_	11	advmod:emph	_	_
+13	kasabada	kasaba	NOUN	Noun	Case=Loc|Number=Sing|Person=3	14	obl	_	_
+14	bırakılan	bırak	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	15	acl	_	_
+15	ailelerle	aile	NOUN	Noun	Case=Ins|Number=Plur|Person=3	16	nmod	_	_
+16	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	conj	_	_
+17	geçirmek	geçir	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	conj	_	_
+18	amaç	amaç	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nsubj	_	SpaceAfter=No
+19	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-0994
 # text = Çünkü, biz de İslam ile demokrasinin bir arada uyum içinde yaşayabileceğini savunuyoruz.
@@ -2509,6 +2505,7 @@
 
 # sent_id = mst-1077
 # text = Bu olgulardan hareketle bilimin bugün içinde bulunduğu konumu belirleyebilmek için, bilimin şu üç yönünün üstünde durmak gerekir: Bilim, kullandığı kavramlar nedeniyle ideolojinin, bulgularının üretimde yarattığı ilerleme nedeniyle üretici güçlerin bir parçası olup, toplumsal bir etkinlik olması dolayısıyla da sosyal bir kurumdur.
+# Change 2.2/dev: merge -(y)IcI
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	olgulardan	olgu	NOUN	Noun	Case=Abl|Number=Plur|Person=3	3	nmod	_	_
 3	hareketle	hareket	NOUN	Noun	Case=Ins|Number=Sing|Person=3	9	obl	_	_
@@ -2528,7 +2525,7 @@
 17	durmak	dur	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	16	compound	_	_
 18	gerekir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
 19	:	:	PUNCT	Punc	_	47	punct	_	_
-20	Bilim	bilim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	47	nsubj	_	SpaceAfter=No
+20	Bilim	bilim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	46	nsubj	_	SpaceAfter=No
 21	,	,	PUNCT	Punc	_	18	punct	_	_
 22	kullandığı	kullan	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	23	acl	_	_
 23	kavramlar	kavram	NOUN	Noun	Case=Nom|Number=Plur|Person=3	24	nmod:poss	_	_
@@ -2539,27 +2536,25 @@
 28	üretimde	üretim	NOUN	Noun	Case=Loc|Number=Sing|Person=3	29	obl	_	_
 29	yarattığı	yarat	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	30	acl	_	_
 30	ilerleme	ilerle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	31	nmod:poss	_	_
-31	nedeniyle	neden	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	37	obl	_	_
-32-33	üretici	_	_	_	_	_	_	_	_
-32	üret	üre	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|Voice=Cau	34	nmod	_	_
-33	ici	ci	ADP	Agt	_	32	case	_	_
-34	güçlerin	güç	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	36	nmod:poss	_	_
-35	bir	bir	NUM	ANum	NumType=Card	36	nummod	_	_
-36	parçası	parça	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	37	obj	_	_
-37	olup	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	43	nmod	_	SpaceAfter=No
-38	,	,	PUNCT	Punc	_	42	punct	_	_
-39	toplumsal	toplumsal	ADJ	Adj	_	41	amod	_	_
-40	bir	bir	NUM	ANum	NumType=Card	41	det	_	_
-41	etkinlik	etkinlik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	42	obj	_	_
-42	olması	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	37	conj	_	_
-43	dolayısıyla	dolayısıyla	ADV	Adverb	_	47	advmod	_	_
-44	da	da	CCONJ	Conj	_	43	advmod:emph	_	_
-45	sosyal	sosyal	ADJ	Adj	_	47	amod	_	_
-46	bir	bir	NUM	ANum	NumType=Card	47	nummod	_	_
-47-48	kurumdur	_	_	_	_	_	_	_	SpaceAfter=No
-47	kurum	kurum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	conj	_	_
-48	dur	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	47	cop	_	_
-49	.	.	PUNCT	Punc	_	47	punct	_	_
+31	nedeniyle	neden	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	36	obl	_	_
+32	üretici	üre	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	33	acl	_	_
+33	güçlerin	güç	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	35	nmod:poss	_	_
+34	bir	bir	NUM	ANum	NumType=Card	35	nummod	_	_
+35	parçası	parça	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	36	obj	_	_
+36	olup	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	42	nmod	_	SpaceAfter=No
+37	,	,	PUNCT	Punc	_	41	punct	_	_
+38	toplumsal	toplumsal	ADJ	Adj	_	40	amod	_	_
+39	bir	bir	NUM	ANum	NumType=Card	40	det	_	_
+40	etkinlik	etkinlik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	41	obj	_	_
+41	olması	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	36	conj	_	_
+42	dolayısıyla	dolayısıyla	ADV	Adverb	_	46	advmod	_	_
+43	da	da	CCONJ	Conj	_	42	advmod:emph	_	_
+44	sosyal	sosyal	ADJ	Adj	_	46	amod	_	_
+45	bir	bir	NUM	ANum	NumType=Card	46	nummod	_	_
+46-47	kurumdur	_	_	_	_	_	_	_	SpaceAfter=No
+46	kurum	kurum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	conj	_	_
+47	dur	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	46	cop	_	_
+48	.	.	PUNCT	Punc	_	46	punct	_	_
 
 # sent_id = mst-1105
 # text = Halk arasında Alyans Mahallesi diye bilinen evler.

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -680,7 +680,7 @@
 41	o	o	DET	Det	_	42	det	_	_
 42	anda	an	NOUN	Noun	Case=Loc|Number=Sing|Person=3	44	obl	_	_
 43	hiç	hiç	ADV	Adverb	_	44	advmod	_	_
-44	bilmesek	bil	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=1|Polarity=Neg|Tense=Pres	46	nmod	_	_
+44	bilmesek	bil	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=1|Polarity=Neg|Tense=Pres	46	nmod	_	_
 45	de	de	CCONJ	Conj	_	44	advmod:emph	_	_
 46	mutlu	mutlu	ADJ	Adj	_	32	conj	_	_
 47	olduğumuz	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	46	compound:lvc	_	_
@@ -1088,7 +1088,7 @@
 # text = Ne ilgisi varsa bilmem, Kaymakam Arif Beyin kızı davet etmiş ilk kez, ilk kez 1912'de geldikleri İstanbul'da çektirmişler bu fotoğrafı.
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	2	nmod	_	_
 2	ilgisi	ilgi	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	nsubj	_	_
-3	varsa	var	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	obj	_	_
+3	varsa	var	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	obj	_	_
 4	bilmem	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	10	punct	_	_
 6	Kaymakam	kaymakam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
@@ -2050,11 +2050,11 @@
 8	istemez	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	3	conj	_	_
 9	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	7	obj	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	7	punct	_	_
-11	görse	gör	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	13	nmod	_	_
+11	görse	gör	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	13	nmod	_	_
 12	de	de	CCONJ	Conj	_	11	advmod:emph	_	_
 13	konuşmaz	konuş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	3	conj	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	20	punct	_	_
-15	konuşsa	konuş	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	20	nmod	_	_
+15	konuşsa	konuş	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	20	nmod	_	_
 16	da	da	CCONJ	Conj	_	15	advmod:emph	_	_
 17	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	20	obl	_	_
 18	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	obl	_	_
@@ -4201,7 +4201,7 @@
 # text = Bakkalda bile satılsa özel yerde satılır.
 1	Bakkalda	bakkal	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
 2	bile	bile	ADV	Adverb	_	1	advmod:emph	_	_
-3	satılsa	sat	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	_
+3	satılsa	sat	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	_
 4	özel	özel	ADJ	Adj	_	5	amod	_	_
 5	yerde	yer	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
 6	satılır	sat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	3	conj	_	SpaceAfter=No
@@ -4982,7 +4982,7 @@
 2	bağımlı	bağımlı	ADJ	Adj	_	5	nsubj	_	_
 3	favori	favori	ADJ	Adj	_	4	nmod:poss	_	_
 4	maddesini	madde	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
-5	bıraksa	bırak	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
+5	bıraksa	bırak	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 6	da	da	CCONJ	Conj	_	5	advmod:emph	_	_
 7	bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	8	det	_	_
 8	tek	tek	ADJ	Adj	_	9	amod	_	_
@@ -5515,7 +5515,7 @@
 1	Çeyiz	çeyiz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obl	_	_
 2	olarak	olarak	ADP	PCNom	_	1	case	_	_
 3	bölüp	böl	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	4	nmod	_	_
-4	dağıtsan	dağıt	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	8	nmod	_	_
+4	dağıtsan	dağıt	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	8	nmod	_	_
 5	birkaç	birkaç	DET	Det	_	6	det	_	_
 6	kız	kız	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	7	obj	_	_
 7	evlendirmeye	evlen	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	8	nmod	_	_
@@ -5889,7 +5889,7 @@
 4	yapılan	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	5	acl	_	_
 5	ihale	ihale	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
 6	ile	ile	CCONJ	Conj	_	17	nmod	_	_
-7	gerekse	gerek	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	17	cc	_	_
+7	gerekse	gerek	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	17	cc	_	_
 8	dış	dış	ADJ	Adj	_	9	amod	_	_
 9	borçlanmalar	borçlan	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	10	nmod	_	_
 10	ile	ile	CCONJ	Conj	_	6	conj	_	_
@@ -7706,7 +7706,7 @@
 3	cinsel	cinsel	ADJ	Adj	_	4	amod	_	_
 4	ihtiyaçları	ihtiyaç	NOUN	Noun	Case=Acc|Number=Plur|Person=3	6	obl	_	_
 5	için	için	ADP	PCNom	_	4	case	_	_
-6	kullansa	kullan	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	nmod	_	_
+6	kullansa	kullan	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	nmod	_	_
 7	da	da	CCONJ	Conj	_	6	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	6	punct	_	_
 9	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
@@ -8561,7 +8561,7 @@
 # sent_id = mst-3618
 # text = Nasıl olsa bir şey satamıyorsun.
 1	Nasıl	nasıl	ADV	Adverb	_	5	advmod	_	_
-2	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	_
+2	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	_
 3	bir	bir	NUM	ANum	NumType=Card	5	obj	_	_
 4	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	compound	_	_
 5	satamıyorsun	sat	VERB	Verb	Aspect=Prog|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
@@ -8835,7 +8835,7 @@
 5	boşaltıp	boşal	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	6	nmod	_	_
 6	hafifleştirmenin	hafifleş	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	7	nmod:poss	_	_
 7	yöntemini	yöntem	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
-8	kapsak	kap	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	13	nmod	_	_
+8	kapsak	kap	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	13	nmod	_	_
 9	günah	günah	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
 10	çıkarmaya	çıkarma	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	compound	_	_
 11	filan	filan	ADJ	Adj	_	9	amod	_	_
@@ -8882,7 +8882,7 @@
 # sent_id = mst-3738
 # text = Öleceğini bilsem bırakır mıyım aga? Canın mı sıkıldı? dedim.
 1	Öleceğini	öl	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	2	obj	_	_
-2	bilsem	bil	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	nmod	_	_
+2	bilsem	bil	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	nmod	_	_
 3	bırakır	bırak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	obj	_	_
 4	mıyım	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	3	aux:q	_	_
 5	aga	aga	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
@@ -10004,7 +10004,7 @@
 9	yerinde	yerinde	ADJ	Adj	_	12	obj	_	_
 10	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	_	_
 11	de	de	CCONJ	Conj	_	10	advmod:emph	_	_
-12	olsam	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	15	nmod	_	_
+12	olsam	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	15	nmod	_	_
 13	aynı	aynı	ADJ	Adj	_	14	amod	_	_
 14	şeyi	şey	NOUN	Noun	Case=Acc|Number=Sing|Person=3	15	obj	_	_
 15	yapardım	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	4	conj	_	SpaceAfter=No
@@ -10557,7 +10557,7 @@
 4	geçmişe	geçmiş	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	6	amod	_	_
 5	ait	ait	ADP	PCDat	_	4	case	_	_
 6	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-7	varsa	var	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	compound	_	_
+7	varsa	var	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	compound	_	_
 8	bıraktık	bırak	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
 9	geride	geri	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	8	compound	_	SpaceAfter=No
 10	...	...	PUNCT	Punc	_	8	punct	_	_
@@ -12291,7 +12291,7 @@
 8	ortalıkta	ortalık	NOUN	Noun	Case=Loc|Number=Sing|Person=3	10	nmod	_	_
 9	dolaşıp	dolaş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	8	compound	_	_
 10	fahişelik	fahişelik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	obl	_	_
-11	yapsaydın	yap	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Pos|Tense=Past	10	compound:lvc	_	_
+11	yapsaydın	yap	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Past	10	compound:lvc	_	_
 12	o	o	DET	Det	_	13	det	_	_
 13	adam	adam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	nsubj	_	_
 14	seninle	sen	PRON	Pers	Case=Ins|Number=Sing|Person=2|PronType=Prs	21	obl	_	_
@@ -12585,7 +12585,7 @@
 21	,	,	PUNCT	Punc	_	24	punct	_	_
 22	bu	bu	DET	Det	_	23	det	_	_
 23	oğlana	oğlan	NOUN	Noun	Case=Dat|Number=Sing|Person=3	13	conj	_	_
-24	kalsa	kal	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	33	nmod	_	_
+24	kalsa	kal	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	33	nmod	_	_
 25	her	her	DET	Det	_	26	det	_	_
 26	zenginliğin	zenginlik	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	27	nmod:poss	_	_
 27	altında	alt	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	33	amod	_	_

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -511,11 +511,9 @@
 
 # sent_id = mst-0262
 # text = Öylece yiyin.
-1-2	Öylece	_	_	_	_	_	_	_	_
-1	Öyle	öyle	ADJ	Adj	_	3	amod	_	_
-2	ce	ce	ADP	Ly	_	1	case	_	_
-3	yiyin	ye	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
-4	.	.	PUNCT	Punc	_	3	punct	_	_
+1	Öylece	öylece	ADV	Adverb	_	2	advmod	_	_
+2	yiyin	ye	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
+3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0266
 # text = Sonra tuhaf şeyler oldu...
@@ -1029,17 +1027,16 @@
 
 # sent_id = mst-0454
 # text = Sağlam bir iskele yapmıştı teknelerin rahatça yanaşabilmesi için.
+# Change 2.2/dev: merge -CA
 1	Sağlam	sağlam	ADJ	Adj	_	3	amod	_	_
 2	bir	bir	NUM	ANum	NumType=Card	3	det	_	_
 3	iskele	iskele	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
 4	yapmıştı	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	_
-5	teknelerin	tekne	NOUN	Noun	Case=Gen|Number=Plur|Person=3	8	nsubj	_	_
-6-7	rahatça	_	_	_	_	_	_	_	_
-6	rahat	rahat	ADJ	Adj	_	8	amod	_	_
-7	ça	ce	ADP	Ly	_	6	case	_	_
-8	yanaşabilmesi	yanaş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	nmod	_	_
-9	için	için	ADP	PCNom	_	8	case	_	SpaceAfter=No
-10	.	.	PUNCT	Punc	_	8	punct	_	_
+5	teknelerin	tekne	NOUN	Noun	Case=Gen|Number=Plur|Person=3	7	nsubj	_	_
+6	rahatça	rahatça	ADV	Adverb	_	7	advmod	_	_
+7	yanaşabilmesi	yanaş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	nmod	_	_
+8	için	için	ADP	PCNom	_	7	case	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-0457
 # text = Türkiye'ye de indiler.
@@ -1912,26 +1909,25 @@
 
 # sent_id = mst-0851
 # text = Hele, gazetecinin öne sürdüğü gibi, ' bilinçsizce efsane haline getirilen ' uyduruk bir türbe değildir.
+# Change 2.2/dev: merge -CA
 1	Hele	hele	ADV	Adverb	_	0	root	_	SpaceAfter=No
-2	,	,	PUNCT	Punc	_	17	punct	_	_
+2	,	,	PUNCT	Punc	_	16	punct	_	_
 3	gazetecinin	gazeteci	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod	_	_
-4	öne	ön	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	12	amod	_	_
+4	öne	ön	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	11	amod	_	_
 5	sürdüğü	sür	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	4	compound	_	_
 6	gibi	gibi	ADP	PCNom	_	4	case	_	SpaceAfter=No
-7	,	,	PUNCT	Punc	_	17	punct	_	_
-8	'	'	PUNCT	Punc	_	12	punct	_	_
-9-10	bilinçsizce	_	_	_	_	_	_	_	_
-9	bilinçsiz	bilinçsiz	ADJ	Adj	_	12	amod	_	_
-10	ce	ce	ADP	AsIf	_	9	case	_	_
-11	efsane	efsane	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nmod:poss	_	_
-12	haline	hal	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	nsubj	_	_
-13	getirilen	getir	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	12	compound	_	_
-14	'	'	PUNCT	Punc	_	12	punct	_	_
-15	uyduruk	uyduruk	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	17	amod	_	_
-16	bir	bir	NUM	ANum	NumType=Card	17	det	_	_
-17	türbe	türbe	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
-18	değildir	değil	VERB	Neg	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	17	cop	_	SpaceAfter=No
-19	.	.	PUNCT	Punc	_	17	punct	_	_
+7	,	,	PUNCT	Punc	_	16	punct	_	_
+8	'	'	PUNCT	Punc	_	11	punct	_	_
+9	bilinçsizce	bilinçsizce	ADV	Adverb	_	12	advmod	_	_
+10	efsane	efsane	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nmod:poss	_	_
+11	haline	hal	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	nsubj	_	_
+12	getirilen	getir	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	11	compound	_	_
+13	'	'	PUNCT	Punc	_	11	punct	_	_
+14	uyduruk	uyduruk	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	16	amod	_	_
+15	bir	bir	NUM	ANum	NumType=Card	16	det	_	_
+16	türbe	türbe	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
+17	değildir	değil	VERB	Neg	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	16	cop	_	SpaceAfter=No
+18	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-0856
 # text = Kadehler onun şerefine kalktı.
@@ -4541,28 +4537,27 @@
 
 # sent_id = mst-1952
 # text = Kolayca egemenlik altına almış ve sömürgecilik politikasının bir parçası olan Hristiyanlaştırma yoluyla bu küçük halkların kimliğini yok etmeye çalışmışlardı.
-1-2	Kolayca	_	_	_	_	_	_	_	_
-1	Kolay	kolay	ADJ	Adj	_	3	amod	_	_
-2	ca	ce	ADP	Ly	_	1	case	_	_
-3	egemenlik	egemenlik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-4	altına	alt	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	compound	_	_
-5	almış	al	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	compound	_	_
-6	ve	ve	CCONJ	Conj	_	20	cc	_	_
-7	sömürgecilik	sömürgecilik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
-8	politikasının	politika	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nmod:poss	_	_
-9	bir	bir	NUM	ANum	NumType=Card	10	det	_	_
-10	parçası	parça	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obl	_	_
-11	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	12	acl	_	_
-12	Hristiyanlaştırma	Hristiyanlaş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	13	nmod:poss	_	_
-13	yoluyla	yol	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	obl	_	_
-14	bu	bu	DET	Det	_	16	det	_	_
-15	küçük	küçük	ADJ	Adj	_	16	amod	_	_
-16	halkların	halk	NOUN	Noun	Case=Gen|Number=Plur|Person=3	17	nmod:poss	_	_
-17	kimliğini	kimlik	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	obj	_	_
-18	yok	yok	ADJ	Adj	_	20	amod	_	_
-19	etmeye	et	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	18	compound:lvc	_	_
-20	çalışmışlardı	çalış	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pqp	3	conj	_	SpaceAfter=No
-21	.	.	PUNCT	Punc	_	20	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Kolayca	kolayca	ADV	Adverb	_	2	advmod	_	_
+2	egemenlik	egemenlik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
+3	altına	alt	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	compound	_	_
+4	almış	al	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	2	compound	_	_
+5	ve	ve	CCONJ	Conj	_	19	cc	_	_
+6	sömürgecilik	sömürgecilik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod:poss	_	_
+7	politikasının	politika	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	nmod:poss	_	_
+8	bir	bir	NUM	ANum	NumType=Card	9	det	_	_
+9	parçası	parça	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obl	_	_
+10	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	acl	_	_
+11	Hristiyanlaştırma	Hristiyanlaş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	12	nmod:poss	_	_
+12	yoluyla	yol	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	obl	_	_
+13	bu	bu	DET	Det	_	15	det	_	_
+14	küçük	küçük	ADJ	Adj	_	15	amod	_	_
+15	halkların	halk	NOUN	Noun	Case=Gen|Number=Plur|Person=3	16	nmod:poss	_	_
+16	kimliğini	kimlik	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	obj	_	_
+17	yok	yok	ADJ	Adj	_	19	amod	_	_
+18	etmeye	et	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	17	compound:lvc	_	_
+19	çalışmışlardı	çalış	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pqp	2	conj	_	SpaceAfter=No
+20	.	.	PUNCT	Punc	_	19	punct	_	_
 
 # sent_id = mst-1964
 # text = Buradaki iki temel unsur, materyalizm ve teoridir.
@@ -5308,16 +5303,14 @@
 
 # sent_id = mst-2236
 # text = Memo sürücünün hoşgörüsünden yüz bularak hafifçe şımarmıştı.
-1	Memo	Memo	PROPN	Prop	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
+1	Memo	Memo	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
 2	sürücünün	sürücü	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
 3	hoşgörüsünden	hoşgörü	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nmod	_	_
-4	yüz	yüz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
+4	yüz	yüz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
 5	bularak	bul	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	4	compound	_	_
-6-7	hafifçe	_	_	_	_	_	_	_	_
-6	hafif	hafif	ADJ	Adj	_	8	amod	_	_
-7	çe	ce	ADP	Ly	_	6	case	_	_
-8	şımarmıştı	şımar	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
-9	.	.	PUNCT	Punc	_	8	punct	_	_
+6	hafifçe	hafifçe	ADV	Adverb	_	7	advmod	_	_
+7	şımarmıştı	şımar	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
+8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-2245
 # text = Kimsiniz?
@@ -6858,14 +6851,13 @@
 
 # sent_id = mst-2913
 # text = Konuşmuyor, öylece birbirlerine bakıyorlardı.
+# Change 2.2/dev: merge -CA
 1	Konuşmuyor	konuş	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
-2	,	,	PUNCT	Punc	_	6	punct	_	_
-3-4	öylece	_	_	_	_	_	_	_	_
-3	öyle	öyle	ADJ	Adj	_	6	amod	_	_
-4	ce	ce	ADP	Ly	_	3	case	_	_
-5	birbirlerine	birbiri	PRON	Quant	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	6	obl	_	_
-6	bakıyorlardı	bak	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	1	conj	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	6	punct	_	_
+2	,	,	PUNCT	Punc	_	5	punct	_	_
+3	öylece	öylece	ADV	Adverb	_	5	advmod	_	_
+4	birbirlerine	birbiri	PRON	Quant	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	5	obl	_	_
+5	bakıyorlardı	bak	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	1	conj	_	SpaceAfter=No
+6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-2920
 # text = Acı içindeydi.
@@ -7983,6 +7975,7 @@
 
 # sent_id = mst-3364
 # text = Besbelli havadaki nemden üşümüştü, üstündeki trençkota sımsıkı sarınmış, öylece duruyordu.
+# Change 2.2/dev: merge -CA
 1	Besbelli	besbelli	ADV	Adverb	_	0	root	_	_
 2-3	havadaki	_	_	_	_	_	_	_	_
 2	havada	hava	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	nmod	_	_
@@ -7996,12 +7989,10 @@
 9	trençkota	trençkot	NOUN	Noun	Case=Dat|Number=Sing|Person=3	11	obl	_	_
 10	sımsıkı	sımsıkı	ADJ	Adj	_	11	amod	_	_
 11	sarınmış	sarın	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
-12	,	,	PUNCT	Punc	_	15	punct	_	_
-13-14	öylece	_	_	_	_	_	_	_	_
-13	öyle	öyle	ADJ	Adj	_	15	amod	_	_
-14	ce	ce	ADP	Ly	_	13	case	_	_
-15	duruyordu	dur	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	11	conj	_	SpaceAfter=No
-16	.	.	PUNCT	Punc	_	15	punct	_	_
+12	,	,	PUNCT	Punc	_	14	punct	_	_
+13	öylece	öylece	ADV	Adverb	_	14	advmod	_	_
+14	duruyordu	dur	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	11	conj	_	SpaceAfter=No
+15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-3377
 # text = Birbirinin içine geçmiş garip bir rüya gibi.
@@ -8212,35 +8203,34 @@
 
 # sent_id = mst-3466
 # text = Üniversitelerin özgürlüklere, mali özerkliklere ilişkin birikmiş onca sorunu varken beylik siyasi tartışmalar açmanın arkasında, üniversiteden bağımsız niyet olduğu konusunda hiç kuşku duymuyorum.
-1	Üniversitelerin	üniversite	NOUN	Noun	Case=Gen|Number=Plur|Person=3	10	nmod:poss	_	_
-2	özgürlüklere	özgürlük	NOUN	Noun	Case=Dat|Number=Plur|Person=3	10	nmod	_	SpaceAfter=No
+# Change 2.2/dev: merge -CA
+1	Üniversitelerin	üniversite	NOUN	Noun	Case=Gen|Number=Plur|Person=3	9	nmod:poss	_	_
+2	özgürlüklere	özgürlük	NOUN	Noun	Case=Dat|Number=Plur|Person=3	9	nmod	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	5	punct	_	_
 4	mali	mali	ADJ	Adj	_	5	amod	_	_
 5	özerkliklere	özerklik	NOUN	Noun	Case=Dat|Number=Plur|Person=3	2	conj	_	_
 6	ilişkin	ilişkin	ADP	PCDat	_	2	case	_	_
-7	birikmiş	birik	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	10	acl	_	_
-8-9	onca	_	_	_	_	_	_	_	_
-8	on	on	NUM	ANum	NumType=Card	10	nummod	_	_
-9	ca	ce	ADP	AsIf	_	8	case	_	_
-10	sorunu	sorun	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	nsubj	_	_
-11-12	varken	_	_	_	_	_	_	_	_
-11	var	var	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	25	amod	_	_
-12	ken	i	AUX	Zero	Aspect=Perf|Mood=Ind|Tense=Pres|VerbForm=Conv	11	cop	_	_
-13	beylik	beylik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	obl	_	_
-14	siyasi	siyasi	ADJ	Adj	_	15	amod	_	_
-15	tartışmalar	tartış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	16	obj	_	_
-16	açmanın	aç	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	17	nmod:poss	_	_
-17	arkasında	arka	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	22	amod	_	SpaceAfter=No
-18	,	,	PUNCT	Punc	_	22	punct	_	_
-19	üniversiteden	üniversite	NOUN	Noun	Case=Abl|Number=Sing|Person=3	20	obl	_	_
-20	bağımsız	bağımsız	ADJ	Adj	_	21	amod	_	_
-21	niyet	niyet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	nsubj	_	_
-22	olduğu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	23	nmod:poss	_	_
-23	konusunda	konu	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	25	nmod	_	_
-24	hiç	hiç	ADV	Adverb	_	25	advmod	_	_
-25	kuşku	kuşku	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-26	duymuyorum	duy	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Polite=Infm|Tense=Pres	25	compound	_	SpaceAfter=No
-27	.	.	PUNCT	Punc	_	25	punct	_	_
+7	birikmiş	birik	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	9	acl	_	_
+8	onca	onca	ADJ	Adj	_	10	amod	_	_
+9	sorunu	sorun	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nsubj	_	_
+10-11	varken	_	_	_	_	_	_	_	_
+10	var	var	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	24	amod	_	_
+11	ken	i	AUX	Zero	Aspect=Perf|Mood=Ind|Tense=Pres|VerbForm=Conv	10	cop	_	_
+12	beylik	beylik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	obl	_	_
+13	siyasi	siyasi	ADJ	Adj	_	14	amod	_	_
+14	tartışmalar	tartış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	15	obj	_	_
+15	açmanın	aç	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	16	nmod:poss	_	_
+16	arkasında	arka	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	amod	_	SpaceAfter=No
+17	,	,	PUNCT	Punc	_	21	punct	_	_
+18	üniversiteden	üniversite	NOUN	Noun	Case=Abl|Number=Sing|Person=3	19	obl	_	_
+19	bağımsız	bağımsız	ADJ	Adj	_	20	amod	_	_
+20	niyet	niyet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	nsubj	_	_
+21	olduğu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	22	nmod:poss	_	_
+22	konusunda	konu	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	24	nmod	_	_
+23	hiç	hiç	ADV	Adverb	_	24	advmod	_	_
+24	kuşku	kuşku	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
+25	duymuyorum	duy	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Polite=Infm|Tense=Pres	24	compound	_	SpaceAfter=No
+26	.	.	PUNCT	Punc	_	24	punct	_	_
 
 # sent_id = mst-3477
 # text = Okurlar doğru ismin Mustafa Fedai olduğunu anımsattılar.
@@ -10361,6 +10351,7 @@
 
 # sent_id = mst-4375
 # text = Öyle bir şey ki...
+# Change 2.2/dev: merge -CA
 1	Öyle	öyle	ADV	Adverb	_	2	advmod	_	_
 2	bir	bir	NUM	ANum	NumType=Card	0	root	_	_
 3	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound	_	_
@@ -10981,6 +10972,7 @@
 
 # sent_id = mst-4667
 # text = Olan biteni kimden anlamasını bekleyebilirdim, ondan başka kime sığınabilirdim? Sofraya iyice abandım; susa dura, güle efkarlana, üzülüp sevine, kalkıp otura, bağıra çağıra bir bir anlattım.
+# Change 2.2/dev: merge -CA
 1	Olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	2	case	_	_
 2-3	biteni	_	_	_	_	_	_	_	_
 2	biten	bit	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	obj	_	_
@@ -10994,30 +10986,28 @@
 10	kime	kim	PRON	Ques	Case=Dat|Number=Sing|Person=3	11	obl	_	_
 11	sığınabilirdim	sığın	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	6	conj	_	SpaceAfter=No
 12	?	?	PUNCT	Punc	_	11	punct	_	_
-13	Sofraya	sofra	NOUN	Noun	Case=Dat|Number=Sing|Person=3	16	obl	_	_
-14-15	iyice	_	_	_	_	_	_	_	_
-14	iyi	iyi	ADJ	Adj	_	16	amod	_	_
-15	ce	ce	ADP	Ly	_	14	case	_	_
-16	abandım	aban	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	6	conj	_	SpaceAfter=No
-17	;	;	PUNCT	Punc	_	34	punct	_	_
-18	susa	sus	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	19	nmod	_	_
-19	dura	dur	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	34	nmod	_	SpaceAfter=No
-20	,	,	PUNCT	Punc	_	22	punct	_	_
-21	güle	gül	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	22	nmod	_	_
-22	efkarlana	efkarlan	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	19	conj	_	SpaceAfter=No
-23	,	,	PUNCT	Punc	_	24	punct	_	_
-24	üzülüp	üz	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	19	conj	_	_
-25	sevine	sevin	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	24	compound:redup	_	SpaceAfter=No
-26	,	,	PUNCT	Punc	_	27	punct	_	_
-27	kalkıp	kalk	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	19	conj	_	_
-28	otura	otur	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	27	compound:redup	_	SpaceAfter=No
-29	,	,	PUNCT	Punc	_	30	punct	_	_
-30	bağıra	bağır	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	19	conj	_	_
-31	çağıra	çağır	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	30	compound:redup	_	_
-32	bir	bir	ADV	Adverb	_	19	advmod	_	_
-33	bir	bir	ADV	Adverb	_	32	advmod	_	_
-34	anlattım	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	16	conj	_	SpaceAfter=No
-35	.	.	PUNCT	Punc	_	34	punct	_	_
+13	Sofraya	sofra	NOUN	Noun	Case=Dat|Number=Sing|Person=3	15	obl	_	_
+14	iyice	iyice	ADV	Adverb	_	15	advmod	_	_
+15	abandım	aban	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	6	conj	_	SpaceAfter=No
+16	;	;	PUNCT	Punc	_	34	punct	_	_
+17	susa	sus	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	nmod	_	_
+18	dura	dur	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	33	nmod	_	SpaceAfter=No
+19	,	,	PUNCT	Punc	_	21	punct	_	_
+20	güle	gül	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	21	nmod	_	_
+21	efkarlana	efkarlan	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	conj	_	SpaceAfter=No
+22	,	,	PUNCT	Punc	_	23	punct	_	_
+23	üzülüp	üz	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	18	conj	_	_
+24	sevine	sevin	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	23	compound:redup	_	SpaceAfter=No
+25	,	,	PUNCT	Punc	_	26	punct	_	_
+26	kalkıp	kalk	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	18	conj	_	_
+27	otura	otur	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	26	compound:redup	_	SpaceAfter=No
+28	,	,	PUNCT	Punc	_	29	punct	_	_
+29	bağıra	bağır	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	conj	_	_
+30	çağıra	çağır	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	29	compound:redup	_	_
+31	bir	bir	ADV	Adverb	_	18	advmod	_	_
+32	bir	bir	ADV	Adverb	_	31	advmod	_	_
+33	anlattım	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	15	conj	_	SpaceAfter=No
+34	.	.	PUNCT	Punc	_	33	punct	_	_
 
 # sent_id = mst-4688
 # text = Doğrudur.
@@ -11063,22 +11053,21 @@
 
 # sent_id = mst-4705
 # text = Onların yanıtları karşısında yüzlerine ilgisizce bakarsanız gözlerindeki umutsuzluk ve çaresizlikle karşılaşırsınız.
+# Change 2.2/dev: merge -CA
 1	Onların	o	PRON	Pers	Case=Gen|Number=Plur|Person=3|PronType=Prs	2	nmod:poss	_	_
 2	yanıtları	yanıt	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	3	nmod:poss	_	_
-3	karşısında	karşı	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	amod	_	_
-4	yüzlerine	yüz	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	7	obl	_	_
-5-6	ilgisizce	_	_	_	_	_	_	_	_
-5	ilgisiz	ilgisiz	ADJ	Adj	_	7	amod	_	_
-6	ce	ce	ADP	AsIf	_	5	case	_	_
-7	bakarsanız	bak	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	13	nmod	_	_
-8-9	gözlerindeki	_	_	_	_	_	_	_	_
-8	gözlerinde	göz	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	10	nmod	_	_
-9	ki	ki	ADP	Rel	_	8	case	_	_
-10	umutsuzluk	umutsuzluk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
-11	ve	ve	CCONJ	Conj	_	12	cc	_	_
-12	çaresizlikle	çaresizlik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	10	conj	_	_
-13	karşılaşırsınız	karşılaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
-14	.	.	PUNCT	Punc	_	13	punct	_	_
+3	karşısında	karşı	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	amod	_	_
+4	yüzlerine	yüz	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	6	obl	_	_
+5	ilgisizce	ilgisizce	ADV	Adverb	_	6	advmod	_	_
+6	bakarsanız	bak	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	12	nmod	_	_
+7-8	gözlerindeki	_	_	_	_	_	_	_	_
+7	gözlerinde	göz	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	9	nmod	_	_
+8	ki	ki	ADP	Rel	_	7	case	_	_
+9	umutsuzluk	umutsuzluk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
+10	ve	ve	CCONJ	Conj	_	11	cc	_	_
+11	çaresizlikle	çaresizlik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	9	conj	_	_
+12	karşılaşırsınız	karşılaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-4716
 # text = Önemli değil.
@@ -11964,27 +11953,24 @@
 
 # sent_id = mst-5102
 # text = Terk edilişin hüznünden kurtulmak için bedenim delice bir enerji harcıyor ve ben çılgınca oradan oraya koşturuyordum.
+# Change 2.2/dev: merge -CA
 1	Terk	terk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 2	edilişin	et	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	1	compound	_	_
 3	hüznünden	hüzün	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obl	_	_
-4	kurtulmak	kurtul	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	11	nmod	_	_
+4	kurtulmak	kurtul	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	10	nmod	_	_
 5	için	için	ADP	PCNom	_	4	case	_	_
-6	bedenim	beden	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	11	nsubj	_	_
-7-8	delice	_	_	_	_	_	_	_	_
-7	deli	deli	ADJ	Adj	_	10	amod	_	_
-8	ce	ce	ADP	AsIf	_	7	case	_	_
-9	bir	bir	NUM	ANum	NumType=Card	10	det	_	_
-10	enerji	enerji	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obj	_	_
-11	harcıyor	harca	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	_
-12	ve	ve	CCONJ	Conj	_	18	cc	_	_
-13	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	18	nsubj	_	_
-14-15	çılgınca	_	_	_	_	_	_	_	_
-14	çılgın	çılgın	ADJ	Adj	_	18	amod	_	_
-15	ca	ce	ADP	AsIf	_	14	case	_	_
-16	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	18	obl	_	_
-17	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	16	compound	_	_
-18	koşturuyordum	koş	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Cau	11	conj	_	SpaceAfter=No
-19	.	.	PUNCT	Punc	_	18	punct	_	_
+6	bedenim	beden	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	10	nsubj	_	_
+7	delice	delice	ADV	Advmod	_	9	advmod	_	_
+8	bir	bir	NUM	ANum	NumType=Card	9	det	_	_
+9	enerji	enerji	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obj	_	_
+10	harcıyor	harca	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	_
+11	ve	ve	CCONJ	Conj	_	16	cc	_	_
+12	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	_	_
+13	çılgınca	çılgınca	ADV	Adverb	_	16	advmod	_	_
+14	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	16	obl	_	_
+15	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	14	compound	_	_
+16	koşturuyordum	koş	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Cau	10	conj	_	SpaceAfter=No
+17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-5112
 # text = Kira işlemi,...

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -108,7 +108,7 @@
 # sent_id = mst-0056
 # text = Ne anlatacaktın.
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	2	obj	_	_
-2	anlatacaktın	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+2	anlatacaktın	anlat	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0059
@@ -1271,7 +1271,7 @@
 1	Babamla	baba	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	4	obl	_	_
 2	Kahve'yi	Kahve	PROPN	Prop	Case=Acc|Number=Sing|Person=3	3	obj	_	_
 3	almaya	al	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	nmod	_	_
-4	gelecektik	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+4	gelecektik	gel	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-0557
@@ -3562,7 +3562,7 @@
 22	neredeyse	neredeyse	ADV	Adverb	_	24	advmod	_	_
 23	kasanın	kasa	NOUN	Noun	Case=Gen|Number=Sing|Person=3	24	nmod:poss	_	_
 24	içine	iç	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	25	amod	_	_
-25	sokacaktı	sok	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+25	sokacaktı	sok	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 26	.	.	PUNCT	Punc	_	25	punct	_	_
 
 # sent_id = mst-1525
@@ -4027,7 +4027,7 @@
 # sent_id = mst-1718
 # text = Galiba çalmayacaktım.
 1	Galiba	galiba	ADV	Adverb	_	2	advmod	_	_
-2	çalmayacaktım	çal	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=FutPast	0	root	_	SpaceAfter=No
+2	çalmayacaktım	çal	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Fut,Past	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-1721
@@ -4950,7 +4950,7 @@
 
 # sent_id = mst-2093
 # text = Feshedeceklermiş sözleşmesini.
-1	Feshedeceklermiş	feshet	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=FutPast	0	root	_	_
+1	Feshedeceklermiş	feshet	VERB	Verb	Aspect=Prosp|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Fut,Past	0	root	_	_
 2	sözleşmesini	sözleşme	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	obj	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
@@ -6509,7 +6509,7 @@
 14	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	16	obj	_	_
 15	içeri	içeri	NOUN	Noun	Case=Dat|Number=Sing|Person=3	16	obl	_	_
 16	çağırmasını	çağır	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	conj	_	_
-17	bekleyecektim	bekle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=FutPast	0	root	_	_
+17	bekleyecektim	bekle	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Fut,Past	0	root	_	_
 18	herhalde	herhalde	ADV	Adverb	_	17	conj	_	SpaceAfter=No
 19	.	.	PUNCT	Punc	_	18	punct	_	_
 
@@ -8402,7 +8402,7 @@
 # sent_id = mst-3558
 # text = Parkı anlatmayacaktım.
 1	Parkı	park	NOUN	Noun	Case=Acc|Number=Sing|Person=3	2	obj	_	_
-2	anlatmayacaktım	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=FutPast	0	root	_	SpaceAfter=No
+2	anlatmayacaktım	anlat	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Fut,Past	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-3560
@@ -10307,7 +10307,7 @@
 5	mecalsizlikten	mecalsizlik	NOUN	Noun	Case=Abl|Number=Sing|Person=3	7	nmod	_	_
 6	hayata	hayat	NOUN	Noun	Case=Dat|Number=Sing|Person=3	7	nmod	_	_
 7	veda	veda	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-8	edecektim	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=FutPast	7	compound:lvc	_	_
+8	edecektim	et	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Fut,Past	7	compound:lvc	_	_
 9	muhtemelen	muhtemelen	ADV	Adverb	_	7	advmod	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	7	punct	_	_
 
@@ -10698,7 +10698,7 @@
 12	kabin	kabin	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nmod:poss	_	_
 13	amiri	amir	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	nmod:poss	_	_
 14	görevi	görev	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obj	_	_
-15	yapacaktı	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	7	conj	_	SpaceAfter=No
+15	yapacaktı	yap	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	7	conj	_	SpaceAfter=No
 16	..	..	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-4520
@@ -13145,7 +13145,7 @@
 2	geleni	gel	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	1	compound	_	_
 3	onlara	o	PRON	Pers	Case=Dat|Number=Plur|Person=3|PronType=Prs	5	obl	_	_
 4	hemen	hemen	ADV	Adverb	_	5	advmod	_	_
-5	söylemeyecektim	söyle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=FutPast	0	root	_	SpaceAfter=No
+5	söylemeyecektim	söyle	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Fut,Past	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	8	punct	_	_
 7	kesin	kesin	ADJ	Adj	_	8	amod	_	_
 8-9	kararlıydım	_	_	_	_	_	_	_	SpaceAfter=No

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -12794,7 +12794,7 @@
 4	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
 5-7	haberliyim	_	_	_	_	_	_	_	SpaceAfter=No
 5	haberli	haberli	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
-6	li	li		ADP	With	_	5	case	_	_
+6	li	li	ADP	With	_	5	case	_	_
 7	yim	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	5	cop	_	_
 8	...	...	PUNCT	Punc	_	5	conj	_	_
 

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -39,7 +39,7 @@
 # sent_id = mst-0024
 # text = Oradaki tartışma hayli zengin.
 1-2	Oradaki	_	_	_	_	_	_	_	_
-1	Orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
+1	Orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
 2	ki	ki	ADP	Rel	_	1	case	_	_
 3	tartışma	tartış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	nsubj	_	_
 4	hayli	hayli	ADV	Adverb	_	5	advmod	_	_
@@ -1836,7 +1836,7 @@
 38	benim	ben	PRON	Pers	Case=Gen|Number=Sing|Person=1|PronType=Prs	39	nmod:poss	_	_
 39	belleğime	bellek	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	40	obl	_	_
 40	girip	gir	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	44	nmod	_	_
-41	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	44	obl	_	_
+41	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	44	obl	_	_
 42	inanılmaz	inan	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	43	acl	_	_
 43	sevişmeler	seviş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	44	obj	_	_
 44	çıkartıyorlardı	çıkar	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Cau	17	conj	_	SpaceAfter=No
@@ -2805,7 +2805,7 @@
 # text = Dil, orada doğar, büyür, serpilir...
 1	Dil	dil	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	4	punct	_	_
-3	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
+3	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 4	doğar	doğ	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	6	punct	_	_
 6	büyür	büyü	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	4	conj	_	SpaceAfter=No
@@ -3073,7 +3073,7 @@
 2	ömründe	ömür	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	_
 3	bir	bir	NUM	ANum	NumType=Card	6	nummod	_	_
 4	kez	kez	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	compound	_	_
-5	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
+5	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
 6	uğrar	uğra	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
@@ -3486,7 +3486,7 @@
 2	sa	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	1	cop	_	_
 3	biliyor	bil	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	_
 4	musunuz	mu	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	1	aux:q	_	_
-5	orayı	ora	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	conj	_	SpaceAfter=No
+5	orayı	ora	PRON	Noun	Case=Acc|Number=Sing|Person=3	3	conj	_	SpaceAfter=No
 6	?	?	PUNCT	Punc	_	5	punct	_	_
 7	diye	diye	ADP	PCNom	_	9	case	_	_
 8	hayretle	hayret	NOUN	Noun	Case=Ins|Number=Sing|Person=3	9	obl	_	_
@@ -3500,7 +3500,7 @@
 3	anlatmak	anlat	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	nmod	_	_
 4	için	için	ADP	PCNom	_	3	case	_	_
 5	gelmiştin	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pqp	0	root	_	_
-6	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
+6	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1511
@@ -3890,7 +3890,7 @@
 # text = Parktan çıkıp buraya doğru koşarken hepsi aklımdaydı.
 1	Parktan	park	NOUN	Noun	Case=Abl|Number=Sing|Person=3	2	obl	_	_
 2	çıkıp	çık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	5	obj	_	_
-3	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
+3	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
 4	doğru	doğru	ADP	PCDat	_	3	case	_	_
 5	koşarken	koş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	7	nmod	_	_
 6	hepsi	hepsi	PRON	Quant	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	7	obj	_	_
@@ -4552,7 +4552,7 @@
 # sent_id = mst-1964
 # text = Buradaki iki temel unsur, materyalizm ve teoridir.
 1-2	Buradaki	_	_	_	_	_	_	_	_
-1	Burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	nmod	_	_
+1	Burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	5	nmod	_	_
 2	ki	ki	ADP	Rel	_	1	case	_	_
 3	iki	iki	NUM	ANum	NumType=Card	5	nummod	_	_
 4	temel	temel	ADJ	Adj	_	5	amod	_	_
@@ -4801,7 +4801,7 @@
 4	ırmak	ırmak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
 5	yollarını	yol	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	6	obj	_	_
 6	seyreden	seyret	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	acl	_	_
-7	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	8	obl	_	_
+7	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	8	obl	_	_
 8	özgü	özgü	ADJ	Adj	_	10	amod	_	_
 9	yaban	yaban	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod	_	_
 10	koyunları	koyun	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
@@ -4953,7 +4953,7 @@
 1	Her	her	DET	Det	_	2	det	_	_
 2	gece	gece	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obl	_	_
 3	gelirdi	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	_
-4	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
+4	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
 5	Mebrure	Mebrure	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nsubj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -5787,7 +5787,7 @@
 # text = Hastane bayırının oralara doğru yürüdüm.
 1	Hastane	hastane	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	bayırının	bayır	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	nmod	_	_
-3	oralara	ora	NOUN	Noun	Case=Dat|Number=Plur|Person=3	5	obl	_	_
+3	oralara	ora	PRON	Noun	Case=Dat|Number=Plur|Person=3	5	obl	_	_
 4	doğru	doğru	ADP	PCDat	_	5	case	_	_
 5	yürüdüm	yürü	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
@@ -6054,7 +6054,7 @@
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
 2	gezer	gez	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	5	punct	_	_
-4	oramı	ora	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	5	obj	_	_
+4	oramı	ora	PRON	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	5	obj	_	_
 5	ovalıyorum	ovala	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	_
 6	hala	hala	ADV	Adverb	_	5	advmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	5	punct	_	_
@@ -6160,7 +6160,7 @@
 3	koşa	koşa	ADJ	Adj	_	5	amod	_	_
 4	koşa	koşa	ADJ	Adj	_	3	compound:redup	_	_
 5	geldim	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	1	conj	_	_
-6	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
+6	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-2623
@@ -6465,12 +6465,12 @@
 2	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	3	nmod	_	_
 3	işi	iş	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
 4	var	var	ADJ	Adj	_	0	root	_	_
-5	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	SpaceAfter=No
+5	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	SpaceAfter=No
 6	?	?	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2749
 # text = Orada durup, altıncı kattaki sevgilinin varlığımı fark etmesini, pencereyi açıp beni içeri çağırmasını bekleyecektim herhalde.
-1	Orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	2	obl	_	_
+1	Orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	2	obl	_	_
 2	durup	dur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	9	nmod	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	2	punct	_	_
 4	altıncı	altıncı	ADJ	Adj	_	5	amod	_	_
@@ -6784,7 +6784,7 @@
 # text = Ayhan'ın yazdıkları burda bitiyor...
 1	Ayhan'ın	Ayhan	PROPN	Prop	Case=Gen|Number=Sing|Person=3	2	nmod:poss	_	_
 2	yazdıkları	yaz	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	4	nsubj	_	_
-3	burda	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
+3	burda	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 4	bitiyor	bit	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 5	...	...	PUNCT	Punc	_	4	punct	_	_
 
@@ -7162,7 +7162,7 @@
 
 # sent_id = mst-3042
 # text = Oraya saptık.
-1	Oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
+1	Oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
 2	saptık	sap	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -7822,7 +7822,7 @@
 
 # sent_id = mst-3302
 # text = Orası Subay Evleri ya.
-1	Orası	ora	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	nsubj	_	_
+1	Orası	ora	PRON	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	nsubj	_	_
 2	Subay	Subay	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	_
 3	Evleri	ev	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	2	flat	_	_
 4	ya	ya	INTJ	Interj	_	2	discourse	_	SpaceAfter=No
@@ -8969,7 +8969,7 @@
 7	kurtulamaz	kurtul	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	9	punct	_	_
 9	çıkamaz	çık	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	7	conj	_	_
-10	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	9	obl	_	SpaceAfter=No
+10	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	9	obl	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-3789
@@ -9652,7 +9652,7 @@
 # sent_id = mst-4091
 # text = Oradakilerin hepsi senin gibi.
 1-2	Oradakilerin	_	_	_	_	_	_	_	_
-1	Orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	nmod:poss	_	_
+1	Orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	3	nmod:poss	_	_
 2	kilerin	ki	ADP	Rel	Case=Gen|Number=Plur|Person=3	1	case	_	_
 3	hepsi	hepsi	PRON	Quant	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	4	nsubj	_	_
 4	senin	sen	PRON	Pers	Case=Gen|Number=Sing|Person=2|PronType=Prs	0	root	_	_
@@ -9709,7 +9709,7 @@
 7	korktuğunuz	kork	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	9	acl	_	_
 8	için	için	ADP	PCNom	_	7	case	_	_
 9-10	buradasınız	_	_	_	_	_	_	_	SpaceAfter=No
-9	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	0	root	_	_
+9	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	0	root	_	_
 10	sınız	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	9	cop	_	_
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
@@ -10233,7 +10233,7 @@
 4	,	,	PUNCT	Punc	_	6	punct	_	_
 5	perişan	perişan	ADJ	Adj	_	6	amod	_	_
 6	oldum	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	3	conj	_	_
-7	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	SpaceAfter=No
+7	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-4335
@@ -11943,8 +11943,8 @@
 11	ve	ve	CCONJ	Conj	_	16	cc	_	_
 12	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	_	_
 13	çılgınca	çılgınca	ADV	Adverb	_	16	advmod	_	_
-14	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	16	obl	_	_
-15	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	14	compound	_	_
+14	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	16	obl	_	_
+15	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	14	compound	_	_
 16	koşturuyordum	koş	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Cau	10	conj	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
@@ -12272,7 +12272,7 @@
 3	gittim	git	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
 4	her	her	DET	Det	_	7	nsubj	_	_
 5	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	compound	_	_
-6	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	7	obl	_	_
+6	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	7	obl	_	_
 7	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -172,7 +172,7 @@
 17	üzere	üzere	ADP	PCNom	_	16	case	_	_
 18	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	19	obj	_	_
 19	haber	haber	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-20	verirdi	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	19	compound	_	SpaceAfter=No
+20	verirdi	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	19	compound	_	SpaceAfter=No
 21	.	.	PUNCT	Punc	_	19	punct	_	_
 
 # sent_id = mst-0092
@@ -2683,7 +2683,7 @@
 1	Son	son	ADJ	Adj	_	2	amod	_	_
 2	günlerinde	gün	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	4	obl	_	_
 3	kravat	kravat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
-4	takardı	tak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+4	takardı	tak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-1159
@@ -2881,7 +2881,7 @@
 3	askeriye	askeriye	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
 4	mühimmat	mühimmat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
 5	satışı	satış	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
-6	yapardı	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	5	compound:lvc	_	SpaceAfter=No
+6	yapardı	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	5	compound:lvc	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1247
@@ -4494,7 +4494,7 @@
 4	sabah	sabah	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
 5	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	7	obj	_	_
 6	mutlaka	mutlaka	ADV	Adverb	_	7	advmod	_	_
-7	arardı	ara	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	1	conj	_	SpaceAfter=No
+7	arardı	ara	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-1927
@@ -4971,7 +4971,7 @@
 # text = Her gece gelirdi buraya Mebrure.
 1	Her	her	DET	Det	_	2	det	_	_
 2	gece	gece	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obl	_	_
-3	gelirdi	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	_
+3	gelirdi	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 4	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
 5	Mebrure	Mebrure	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nsubj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -5004,7 +5004,7 @@
 
 # sent_id = mst-2120
 # text = Gerekmezdi ya, mersi.
-1	Gerekmezdi	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	_
+1	Gerekmezdi	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	_
 2	ya	ya	CCONJ	Conj	_	4	cc	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	1	punct	_	_
 4	mersi	mersi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	SpaceAfter=No
@@ -7014,7 +7014,7 @@
 # text = Çünkü titremesi dururdu.
 1	Çünkü	çünkü	CCONJ	Conj	_	3	cc	_	_
 2	titremesi	titre	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	3	obj	_	_
-3	dururdu	dur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+3	dururdu	dur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-2979
@@ -7109,7 +7109,7 @@
 6	trajediler	trajedi	NOUN	Noun	Case=Nom|Number=Plur|Person=3	9	obj	_	_
 7	case	case	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
 8	haline	hal	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
-9	gelebilirdi	gel	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	2	conj	_	SpaceAfter=No
+9	gelebilirdi	gel	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Past	2	conj	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-3011
@@ -8840,7 +8840,7 @@
 10	çıkarmaya	çıkarma	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	compound	_	_
 11	filan	filan	ADJ	Adj	_	9	amod	_	_
 12	gerek	gerek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obj	_	_
-13	kalmazdı	kal	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
+13	kalmazdı	kal	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-3724
@@ -9534,7 +9534,7 @@
 17	çekerek	çek	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	18	nmod	_	_
 18	ortaya	orta	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	20	nsubj	_	_
 19	çıkardığı	çıkar	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	18	compound	_	_
-20	olurdu	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+20	olurdu	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 21	.	.	PUNCT	Punc	_	20	punct	_	_
 
 # sent_id = mst-4023
@@ -9826,7 +9826,7 @@
 1	Kumsala	kumsal	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	4	amod	_	_
 2	darbukasını	darbuka	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
 3	pek	pek	ADV	Adverb	_	4	advmod	_	_
-4	getirmezdi	getir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	_
+4	getirmezdi	getir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	_
 5	ama	ama	CCONJ	Conj	_	20	cc	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	20	punct	_	_
 7-8	nedense	_	_	_	_	_	_	_	_
@@ -10007,7 +10007,7 @@
 12	olsam	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	15	nmod	_	_
 13	aynı	aynı	ADJ	Adj	_	14	amod	_	_
 14	şeyi	şey	NOUN	Noun	Case=Acc|Number=Sing|Person=3	15	obj	_	_
-15	yapardım	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	4	conj	_	SpaceAfter=No
+15	yapardım	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	4	conj	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-4242
@@ -10889,7 +10889,7 @@
 2	kime	kim	PRON	Ques	Case=Dat|Number=Sing|Person=3	3	obl	_	_
 3	çalınmışsa	çal	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	5	nsubj	_	_
 4	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	3	conj	_	_
-5	koşardı	koş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+5	koşardı	koş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4613
@@ -10996,12 +10996,12 @@
 2	biteni	bit	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	4	ccomp	_	_
 3	kimden	kim	PRON	Ques	Case=Abl|Number=Sing|Person=3	5	obl	_	_
 4	anlamasını	anla	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	obj	_	_
-5	bekleyebilirdim	bekle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+5	bekleyebilirdim	bekle	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	9	punct	_	_
 7	ondan	o	PRON	Pers	Case=Abl|Number=Sing|Person=3|PronType=Prs	9	nmod	_	_
 8	başka	başka	ADP	PCAbl	_	7	case	_	_
 9	kime	kim	PRON	Ques	Case=Dat|Number=Sing|Person=3	10	obl	_	_
-10	sığınabilirdim	sığın	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	5	conj	_	SpaceAfter=No
+10	sığınabilirdim	sığın	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Past	5	conj	_	SpaceAfter=No
 11	?	?	PUNCT	Punc	_	10	punct	_	_
 12	Sofraya	sofra	NOUN	Noun	Case=Dat|Number=Sing|Person=3	14	obl	_	_
 13	iyice	iyice	ADV	Adverb	_	14	advmod	_	_
@@ -11064,7 +11064,7 @@
 1	Ağzından	ağız	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	obl	_	_
 2	çıkanı	çık	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	3	ccomp	_	_
 3	iki	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	0	root	_	_
-4	ettirmezdim	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=AorPast|Voice=Cau	3	compound	_	SpaceAfter=No
+4	ettirmezdim	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Past|Voice=Cau	3	compound	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-4705
@@ -11139,7 +11139,7 @@
 # text = Üç kızımız olurdu.
 1	Üç	üç	NUM	ANum	NumType=Card	2	nummod	_	_
 2	kızımız	kız	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	3	obj	_	_
-3	olurdu	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+3	olurdu	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-4743
@@ -11153,7 +11153,7 @@
 1	Her	her	DET	Det	_	4	obl	_	_
 2	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	fixed	_	_
 3	taze	taze	ADJ	Adj	_	4	amod	_	_
-4	alınırmış	al	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast|Voice=Pass	0	root	_	SpaceAfter=No
+4	alınırmış	al	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4749
@@ -12301,7 +12301,7 @@
 18	kızla	kız	ADJ	NAdj	Case=Ins|Number=Sing|Person=3	19	amod	_	_
 19	sevişir	seviş	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	21	acl	_	_
 20	gibi	gibi	ADP	PCNom	_	19	case	_	_
-21	sevişebilirdi	seviş	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+21	sevişebilirdi	seviş	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 22	.	.	PUNCT	Punc	_	21	punct	_	_
 
 # sent_id = mst-5277
@@ -12396,7 +12396,7 @@
 5-6	yerler	_	_	_	_	_	_	_	_
 5	yer	yer	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	ccomp	_	_
 6	ler	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Tense=Pres	5	cop	_	_
-7	derlermiş	de	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+7	derlermiş	de	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-5321
@@ -13101,7 +13101,7 @@
 9	,	,	PUNCT	Punc	_	10	punct	_	_
 10	kasmpatı	kasmpatı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	conj	_	SpaceAfter=No
 11	!	!	PUNCT	Punc	_	12	punct	_	_
-12	Zıplardım	zıpla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	4	conj	_	_
+12	Zıplardım	zıpla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	4	conj	_	_
 13	kucağına	kucak	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	12	amod	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	12	punct	_	_
 

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -2728,7 +2728,7 @@
 13	sadece	sadece	ADV	Adverb	_	21	advmod	_	_
 14	bu	bu	DET	Det	_	15	det	_	_
 15	kalemden	kalem	NOUN	Noun	Case=Abl|Number=Sing|Person=3	21	obl	_	_
-16	üçyüzon	üçyüzon	NUM	ANum	NumType=Card	19	nummod	_	_
+16	üçyüzon	üçyüzon	NUM	ANum	NumType=Card	20	nummod	_	_
 17	trilyon	trilyon	NUM	ANum	NumType=Card	16	flat	_	_
 18-19	liralık	_	_	_	_	_	_	_	_
 18	lira	lira	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	flat	_	_
@@ -3172,7 +3172,7 @@
 6	artırılırsa	artır	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	16	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
 8	bu	bu	DET	Det	_	16	nsubj	_	_
-9	otuzaltı	otuzaltı	NUM	ANum	NumType=Card	14	nummod	_	_
+9	otuzaltı	otuzaltı	NUM	ANum	NumType=Card	15	nummod	_	_
 10	milyon	milyon	NUM	ANum	NumType=Card	9	flat	_	_
 11	dörtyüzseksensekiz	dörtyüzseksensekiz	NUM	ANum	NumType=Card	9	flat	_	_
 12	bin	bin	NUM	ANum	NumType=Card	9	flat	_	_
@@ -8678,7 +8678,7 @@
 11	tarafından	taraf	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	obl	_	_
 12	dağıtılmak	dağıt	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	19	nmod	_	_
 13	üzere	üzere	ADP	PCNom	_	12	case	_	_
-14	onsekiz	onsekiz	NUM	ANum	NumType=Card	16	nummod	_	_
+14	onsekiz	onsekiz	NUM	ANum	NumType=Card	17	nummod	_	_
 15-16	trilyonluk	_	_	_	_	_	_	_	_
 15	trilyon	trilyon	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	14	flat	_	_
 16	luk	lik	ADP	Ness	_	15	case	_	_
@@ -11572,7 +11572,7 @@
 2	kadarıyla	kadar	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obl	_	_
 3	gene	gene	ADV	Adverb	_	16	advmod	_	_
 4	ikimizin	iki	NUM	NNum	Case=Gen|Number=Sing|Number[psor]=Plur|NumType=Card|Person=3|Person[psor]=1	7	nmod:poss	_	_
-5	de	de	CCONJ	Conj	_	5	advmod:emph	_	_
+5	de	de	CCONJ	Conj	_	4	advmod:emph	_	_
 6	meslektaşı	meslektaş	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
 7	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	acl	_	_
 8	Yüksel	Yüksel	PROPN	Prop	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
@@ -11583,7 +11583,7 @@
 13	balkonundan	balkon	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obl	_	_
 14	bizi	biz	PRON	Pers	Case=Acc|Number=Plur|Person=1|PronType=Prs	16	obj	_	_
 15	seyrediyordu	seyret	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
-16	.	.	PUNCT	Punc	_	16	punct	_	_
+16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-4928
 # text = Aklımızdan çıktığı yok ki.

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -2237,12 +2237,13 @@
 
 # sent_id = mst-0973
 # text = Bir ay boyunca yani mayısın üçüncü haftasına kadar doğumlar devam edecek.
+# Change 2.2/dev: fix ordinal number
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	ay	ay	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
 3	boyunca	boyunca	ADP	PCNom	_	2	case	_	_
 4	yani	yani	CCONJ	Conj	_	2	cc	_	_
 5	mayısın	mayıs	NOUN	Noun	Case=Gen|Number=Sing|Person=3	7	nmod:poss	_	_
-6	üçüncü	üçüncü	ADJ	Adj	_	7	amod	_	_
+6	üçüncü	üç	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	7	amod	_	_
 7	haftasına	hafta	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nmod	_	_
 8	kadar	kadar	ADP	PCDat	_	7	case	_	_
 9	doğumlar	doğum	NOUN	Noun	Case=Nom|Number=Plur|Person=3	10	nsubj	_	_
@@ -2389,11 +2390,12 @@
 
 # sent_id = mst-1035
 # text = Atila Sav da Edebiyat'ta birinci olabildi.
+# Change 2.2/dev: fix ordinal number
 1	Atila	Atila	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
 2	Sav	Sav	PROPN	Prop	Case=Nom|Number=Sing|Person=3	1	flat	_	_
 3	da	da	CCONJ	Conj	_	1	advmod:emph	_	_
 4	Edebiyat'ta	Edebiyat	PROPN	Prop	Case=Loc|Number=Sing|Person=3	6	obl	_	_
-5	birinci	birinci	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	6	obj	_	_
+5	birinci	bir	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	6	obj	_	_
 6	olabildi	ol	VERB	Verb	Aspect=Perf|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
@@ -4218,8 +4220,9 @@
 
 # sent_id = mst-1808
 # text = Üstelik ikinci gün arayıp kadavranın cinsiyetinin benim için fark edip etmeyeceğini sordular.
+# Change 2.2/dev: fix ordinal number
 1	Üstelik	üstelik	ADV	Adverb	_	3	advmod	_	_
-2	ikinci	ikinci	ADJ	Adj	_	1	compound	_	_
+2	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	1	compound	_	_
 3	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
 4	arayıp	ara	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	12	obj	_	_
 5	kadavranın	kadavra	NOUN	Noun	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
@@ -4749,12 +4752,13 @@
 
 # sent_id = mst-2020
 # text = Bugün, bu kente geleli beşinci gün, hiçbir yerde bulabilmiş değilim onu.
+# Change 2.2/dev: fix ordinal number
 1	Bugün	bugün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	1	punct	_	_
 3	bu	bu	DET	Det	_	4	det	_	_
 4	kente	kent	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
 5	geleli	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	_
-6	beşinci	beşinci	ADJ	Adj	_	5	conj	_	_
+6	beşinci	beş	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	5	conj	_	_
 7	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obl	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	11	punct	_	_
 9	hiçbir	hiçbir	DET	Det	_	10	advmod:emph	_	_
@@ -6143,13 +6147,14 @@
 
 # sent_id = mst-2617
 # text = Ayhan Çilingiroğlu, Atila Sav'ın ortakokul birinci sınıftan arkadaşı.
+# Change 2.2/dev: fix ordinal number
 1	Ayhan	Ayhan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
 2	Çilingiroğlu	Çilingiroğlu	PROPN	Prop	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	flat	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	9	punct	_	_
 4	Atila	Atila	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	compound	_	_
 5	Sav'ın	Sav	PROPN	Prop	Case=Gen|Number=Sing|Person=3	4	flat	_	_
 6	ortakokul	ortakokul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod	_	_
-7	birinci	birinci	ADJ	Adj	_	8	amod	_	_
+7	birinci	bir	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	8	amod	_	_
 8	sınıftan	sınıf	NOUN	Noun	Case=Abl|Number=Sing|Person=3	9	nmod	_	_
 9	arkadaşı	arkadaş	NOUN	Noun	Case=Acc|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
@@ -6265,6 +6270,7 @@
 
 # sent_id = mst-2667
 # text = Bugün bakıyorum da, Osmanlı-Osmanlı Sonrası, Birinci Cumhuriyet-İkinci Cumhuriyetçi-Milliyetçi-Mukaddesatçı gibi kavramlar hala tartışılıyor.
+# Change 2.2/dev: fix ordinal number
 1	Bugün	bugün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	obl	_	_
 2	bakıyorum	bak	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	_
 3	da	da	CCONJ	Conj	_	2	advmod:emph	_	SpaceAfter=No
@@ -6274,10 +6280,10 @@
 7	Osmanlı	Osmanlı	PROPN	Prop	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
 8	Sonrası	sonra	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	conj	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	10	punct	_	_
-10	Birinci	birinci	ADJ	Adj	_	5	conj	_	_
+10	Birinci	bir	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	5	conj	_	_
 11	Cumhuriyet	cumhuriyet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	flat	_	SpaceAfter=No
 12	-	-	PUNCT	Punc	_	13	punct	_	SpaceAfter=No
-13	İkinci	ikinci	ADJ	Adj	_	5	conj	_	_
+13	İkinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	5	conj	_	_
 14	Cumhuriyetçi	cumhuriyetçi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	flat	_	SpaceAfter=No
 15	-	-	PUNCT	Punc	_	16	punct	_	SpaceAfter=No
 16	Milliyetçi	milliyetçi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	conj	_	SpaceAfter=No
@@ -9731,7 +9737,8 @@
 
 # sent_id = mst-4133
 # text = Dokuzuncu sınıfta ayrılınır.
-1	Dokuzuncu	dokuzuncu	ADJ	Adj	_	2	amod	_	_
+# Change 2.2/dev: fix ordinal number
+1	Dokuzuncu	dokuz	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	2	amod	_	_
 2	sınıfta	sınıf	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	nmod	_	_
 3	ayrılınır	ayrılınır	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -10405,6 +10412,7 @@
 
 # sent_id = mst-4407
 # text = onbirbindokuzyüzdoksansekiz tarihli, Cumhuriyet gazetesini gerçek samimiyete davet ediyoruz başlıklı bildirisinden: Evrendeki yüksek enerji düzeyine sahip tüm düzenli yapıların zaman içinde düzensizliğe doğru gittiklerini belirleyen Termodinamiğin İkinci kanunu, evrendeki ve canlılardaki kompleks düzenli yapıların kendiliğinden oluşamayacağı gerçeği yaratılışı desteklemektedir.
+# Change 2.2/dev: fix ordinal number
 1	onbirbindokuzyüzdoksansekiz	onbirbindokuzyüzdoksansekiz	NUM	ANum	NumType=Card	2	nummod	_	_
 2-3	tarihli	_	_	_	_	_	_	_	SpaceAfter=No
 2	tarih	tarih	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nmod	_	_
@@ -10438,7 +10446,7 @@
 28	gittiklerini	git	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	29	obj	_	_
 29	belirleyen	belirle	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	32	acl	_	_
 30	Termodinamiğin	termodinamik	NOUN	Noun	Case=Gen|Number=Sing|Person=3	32	nmod:poss	_	_
-31	İkinci	ikinci	ADJ	Adj	_	32	amod	_	_
+31	İkinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	32	amod	_	_
 32	kanunu	kanun	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	46	nsubj	_	SpaceAfter=No
 33	,	,	PUNCT	Punc	_	46	punct	_	_
 34-35	evrendeki	_	_	_	_	_	_	_	_

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -247,8 +247,9 @@
 
 # sent_id = mst-0118
 # text = Oğlunun neden eroinman olduğunu anlayamaması çok doğaldı.
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Oğlunun	oğul	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nmod:poss	_	_
-2	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	4	obl	_	_
+2	neden	neden	ADV	Ques	Case=Abl|Number=Sing|Person=3	4	advmod	_	_
 3	eroinman	eroinman	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	4	obj	_	_
 4	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	5	obj	_	_
 5	anlayamaması	anla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	7	nsubj	_	_
@@ -273,10 +274,11 @@
 
 # sent_id = mst-0134
 # text = (İzninizle, neden olmasın...
+# Change 2.2/dev: revise POS tag of 'neden'
 1	(	(	PUNCT	Punc	_	2	punct	_	SpaceAfter=No
 2	İzninizle	izin	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	5	punct	_	_
-4	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	5	obl	_	_
+4	neden	neden	ADV	Ques	Case=Abl|Number=Sing|Person=3	5	advmod	_	_
 5	olmasın	ol	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	2	conj	_	SpaceAfter=No
 6	...	...	PUNCT	Punc	_	5	punct	_	_
 
@@ -9803,6 +9805,7 @@
 
 # sent_id = mst-4156
 # text = Kumsala darbukasını pek getirmezdi ama, nedense bugün canı kıyıda, denize karşı, patlata patlata darbuka çalmak istemişti.
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Kumsala	kumsal	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	4	amod	_	_
 2	darbukasını	darbuka	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
 3	pek	pek	ADV	Adverb	_	4	advmod	_	_
@@ -9810,7 +9813,7 @@
 5	ama	ama	CCONJ	Conj	_	20	cc	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	20	punct	_	_
 7-8	nedense	_	_	_	_	_	_	_	_
-7	neden	neden	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	obl	_	_
+7	neden	neden	ADV	Noun	_	20	advcl	_	_
 8	se	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	7	cop	_	_
 9	bugün	bugün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	obl	_	_
 10	canı	can	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	nsubj	_	_
@@ -10196,12 +10199,13 @@
 
 # sent_id = mst-4313
 # text = Benim bacaklarımı nasıl tutacağıma büyükler neden karışsın ki?
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Benim	ben	PRON	Pers	Case=Gen|Number=Sing|Person=1|PronType=Prs	2	nmod:poss	_	_
 2	bacaklarımı	bacak	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=1	4	obj	_	_
 3	nasıl	nasıl	ADV	Adverb	_	4	advmod	_	_
 4	tutacağıma	tut	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Fut|VerbForm=Part	7	acl	_	_
 5	büyükler	büyük	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	7	nsubj	_	_
-6	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	7	obl	_	_
+6	neden	ne	ADV	Ques	Case=Abl|Number=Sing|Person=3	7	advmod	_	_
 7	karışsın	karış	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 8	ki	ki	CCONJ	Conj	_	7	advmod:emph	_	SpaceAfter=No
 9	?	?	PUNCT	Punc	_	7	punct	_	_

--- a/tr_imst-ud-dev.conllu
+++ b/tr_imst-ud-dev.conllu
@@ -874,10 +874,10 @@
 1	Yanaşanı	yanaş	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	2	ccomp	_	_
 2-3	haklarım	_	_	_	_	_	_	_	_
 2	haklar	hak	NOUN	Noun	Case=Nom|Number=Plur|Person=3	0	root	_	_
-3	ım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	3	cop	_	_
-4	anladınız	anla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Past	3	conj	_	_
-5	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	3	aux:q	_	SpaceAfter=No
-6	?	?	PUNCT	Punc	_	3	punct	_	_
+3	ım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	2	cop	_	_
+4	anladınız	anla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Past	2	conj	_	_
+5	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	2	aux:q	_	SpaceAfter=No
+6	?	?	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0394
 # text = Gecekondu derken, günümüzde mafyatik ilişkilerle, rant ekonomisinin bir parçası olan uygulamalardan değil, bindokuzyüzatmış bindokuzyüzyetmişsekiz arası, her ailenin kendi evini kendisinin yapması şeklinde gerçekleşen (dokuz) uygulamalardan söz ediyorum.
@@ -10962,33 +10962,33 @@
 4	anlamasını	anla	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	obj	_	_
 5	bekleyebilirdim	bekle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	9	punct	_	_
-7	ondan	o	PRON	Pers	Case=Abl|Number=Sing|Person=3|PronType=Prs	8	nmod	_	_
-8	başka	başka	ADP	PCAbl	_	6	case	_	_
-9	kime	kim	PRON	Ques	Case=Dat|Number=Sing|Person=3	9	obl	_	_
-10	sığınabilirdim	sığın	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	4	conj	_	SpaceAfter=No
-11	?	?	PUNCT	Punc	_	9	punct	_	_
-12	Sofraya	sofra	NOUN	Noun	Case=Dat|Number=Sing|Person=3	13	obl	_	_
-13	iyice	iyice	ADV	Adverb	_	13	advmod	_	_
-14	abandım	aban	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	4	conj	_	SpaceAfter=No
+7	ondan	o	PRON	Pers	Case=Abl|Number=Sing|Person=3|PronType=Prs	9	nmod	_	_
+8	başka	başka	ADP	PCAbl	_	7	case	_	_
+9	kime	kim	PRON	Ques	Case=Dat|Number=Sing|Person=3	10	obl	_	_
+10	sığınabilirdim	sığın	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	5	conj	_	SpaceAfter=No
+11	?	?	PUNCT	Punc	_	10	punct	_	_
+12	Sofraya	sofra	NOUN	Noun	Case=Dat|Number=Sing|Person=3	14	obl	_	_
+13	iyice	iyice	ADV	Adverb	_	14	advmod	_	_
+14	abandım	aban	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	5	conj	_	SpaceAfter=No
 15	;	;	PUNCT	Punc	_	32	punct	_	_
-16	susa	sus	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	16	nmod	_	_
+16	susa	sus	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	17	nmod	_	_
 17	dura	dur	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	31	nmod	_	SpaceAfter=No
 18	,	,	PUNCT	Punc	_	19	punct	_	_
-19	güle	gül	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	19	nmod	_	_
-20	efkarlana	efkarlan	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	16	conj	_	SpaceAfter=No
-21	,	,	PUNCT	Punc	_	21	punct	_	_
-22	üzülüp	üz	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	16	conj	_	_
+19	güle	gül	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	20	nmod	_	_
+20	efkarlana	efkarlan	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	17	conj	_	SpaceAfter=No
+21	,	,	PUNCT	Punc	_	20	punct	_	_
+22	üzülüp	üz	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	17	conj	_	_
 23	sevine	sevin	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	21	compound:redup	_	SpaceAfter=No
-24	,	,	PUNCT	Punc	_	24	punct	_	_
-25	kalkıp	kalk	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	16	conj	_	_
-26	otura	otur	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	24	compound:redup	_	SpaceAfter=No
-27	,	,	PUNCT	Punc	_	27	punct	_	_
-28	bağıra	bağır	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	16	conj	_	_
-29	çağıra	çağır	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	27	compound:redup	_	_
-30	bir	bir	ADV	Adverb	_	16	advmod	_	_
-31	bir	bir	ADV	Adverb	_	29	advmod	_	_
-32	anlattım	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	13	conj	_	SpaceAfter=No
-33	.	.	PUNCT	Punc	_	31	punct	_	_
+24	,	,	PUNCT	Punc	_	23	punct	_	_
+25	kalkıp	kalk	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	17	conj	_	_
+26	otura	otur	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	25	compound:redup	_	SpaceAfter=No
+27	,	,	PUNCT	Punc	_	26	punct	_	_
+28	bağıra	bağır	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	17	conj	_	_
+29	çağıra	çağır	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	28	compound:redup	_	_
+30	bir	bir	ADV	Adverb	_	32	advmod	_	_
+31	bir	bir	ADV	Adverb	_	30	advmod	_	_
+32	anlattım	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	14	conj	_	SpaceAfter=No
+33	.	.	PUNCT	Punc	_	32	punct	_	_
 
 # sent_id = mst-4688
 # text = Doğrudur.

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -7213,12 +7213,13 @@
 
 # sent_id = mst-3096
 # text = Ben üzerine gideceğim, dosyayı buyurun dedim.
+# Change 2.2/dev: fix buyurun NOUN -> VERB
 1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
 2	üzerine	üzer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 3	gideceğim	git	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Fut	2	compound	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	7	punct	_	_
-5	dosyayı	dosya	NOUN	Noun	Case=Acc|Number=Sing|Person=3	7	obj	_	_
-6	buyurun	buyuru	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	7	obj	_	_
+5	dosyayı	dosya	NOUN	Noun	Case=Acc|Number=Sing|Person=3	6	obj	_	_
+6	buyurun	buyuru	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	7	obj	_	_
 7	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -2790,7 +2790,7 @@
 19	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-1188
-# text = Kadınların ve erkeklerin alışveriş şekillerinde ne gibi farklılık var?.
+# text = Kadınların ve erkeklerin alışveriş şekillerinde ne gibi farklılık var?
 1	Kadınların	kadın	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	4	amod	_	_
 2	ve	ve	CCONJ	Conj	_	3	cc	_	_
 3	erkeklerin	erkek	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	1	conj	_	_
@@ -2801,7 +2801,6 @@
 8	farklılık	farklılık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
 9	var	var	ADJ	Adj	_	0	root	_	SpaceAfter=No
 10	?	?	PUNCT	Punc	_	9	punct	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-1195
 # text = Milletle alay eden reklamlardan iyidir...
@@ -3297,7 +3296,7 @@
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-1417
-# text = Nesrin: Yani bir sorununu başkasıyla konuşmak değil, buna günah çıkarma adı vermek mi rahatlatacak?.
+# text = Nesrin: Yani bir sorununu başkasıyla konuşmak değil, buna günah çıkarma adı vermek mi rahatlatacak?
 1	Nesrin	Nesrin	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 2	:	:	PUNCT	Punc	_	8	punct	_	_
 3	Yani	yani	CCONJ	Conj	_	8	cc	_	_
@@ -3315,7 +3314,6 @@
 15	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	14	aux:q	_	_
 16	rahatlatacak	rahatla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut|Voice=Cau	8	conj	_	SpaceAfter=No
 17	?	?	PUNCT	Punc	_	16	punct	_	SpaceAfter=No
-18	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-1420
 # text = Niçin? Niçin bir giren bir daha çıkamaz oradan? diye sordum.
@@ -6496,7 +6494,7 @@
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-2753
-# text = Yarın o araba benim!. dedi, biri Memo'ya bakarak.
+# text = Yarın o araba benim!... dedi, biri Memo'ya bakarak.
 1	Yarın	yarın	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod	_	_
 2	o	o	DET	Det	_	3	det	_	_
 3	araba	araba	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
@@ -6504,7 +6502,7 @@
 4	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	ccomp	_	_
 5	im	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	4	cop	_	_
 6	!	!	PUNCT	Punc	_	8	punct	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	8	punct	_	_
+7	...	...	PUNCT	Punc	_	8	punct	_	_
 8	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10	biri	bir	NUM	NNum	Case=Acc|Number=Sing|NumType=Card|Person=3	8	nsubj	_	_
@@ -11479,7 +11477,7 @@
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-4901
-# text = Ben mi senin üstüne köpeği saldırttım?.
+# text = Ben mi senin üstüne köpeği saldırttım?
 1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	_
 2	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	1	aux:q	_	_
 3	senin	sen	PRON	Pers	Case=Gen|Number=Sing|Person=2|PronType=Prs	4	nmod	_	_
@@ -11487,7 +11485,6 @@
 5	köpeği	köpek	NOUN	Noun	Case=Acc|Number=Sing|Person=3	6	obj	_	_
 6	saldırttım	sal	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
 7	?	?	PUNCT	Punc	_	6	punct	_	SpaceAfter=No
-8	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-4905
 # text = Domates, ikisine de uyar.
@@ -12765,7 +12762,7 @@
 8	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-5455
-# text = Kadınlar satın alırken daha mı detaylı inceleme yaparlar?.
+# text = Kadınlar satın alırken daha mı detaylı inceleme yaparlar?
 1	Kadınlar	kadın	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	8	nsubj	_	_
 2	satın	satın	ADV	Adverb	_	8	advmod	_	_
 3	alırken	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	2	compound	_	_
@@ -12777,7 +12774,6 @@
 8	inceleme	incele	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	0	root	_	_
 9	yaparlar	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	8	compound:lvc	_	SpaceAfter=No
 10	?	?	PUNCT	Punc	_	8	punct	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-5463
 # text = TKP Genel Sekreteri Kemal Okuyan, partisinin televizyon stüdyolarına, iç mekanlara hapsedilemeyeceğini belirterek, " Bize miting hakkı vermeseler de yine alanlara çıkarız.
@@ -12924,7 +12920,7 @@
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-5532
-# text = Memo bozuldu, Ağzını topla, ben hırsız mıyım?.
+# text = Memo bozuldu, Ağzını topla, ben hırsız mıyım?
 1	Memo	Memo	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
 2	bozuldu	boz	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	4	punct	_	_
@@ -12935,7 +12931,6 @@
 8	hırsız	hırsız	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	2	conj	_	_
 9	mıyım	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	8	aux:q	_	SpaceAfter=No
 10	?	?	PUNCT	Punc	_	8	punct	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-5539
 # text = Sen karıştırma, dedi Ramiz.

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -594,10 +594,11 @@
 
 # sent_id = mst-0286
 # text = İyi, ama neden? diye sordu sonunda.
+# Change 2.2/dev: revise POS tag of 'neden'
 1	İyi	iyi	ADJ	Adj	_	7	amod	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	4	punct	_	_
 3	ama	ama	CCONJ	Conj	_	4	cc	_	_
-4	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	1	conj	_	SpaceAfter=No
+4	neden	neden	ADV	Ques	Case=Abl|Number=Sing|Person=3	1	conj	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	4	punct	_	_
 6	diye	diye	ADP	PCNom	_	1	case	_	_
 7	sordu	sor	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
@@ -1525,6 +1526,7 @@
 
 # sent_id = mst-0656
 # text = Yöreye ve toplumlara göre (eskiden) evler neden farklılaşıyordu?
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Yöreye	yöre	NOUN	Noun	Case=Dat|Number=Sing|Person=3	10	obl	_	_
 2	ve	ve	CCONJ	Conj	_	3	cc	_	_
 3	toplumlara	toplum	NOUN	Noun	Case=Dat|Number=Plur|Person=3	1	conj	_	_
@@ -1533,7 +1535,7 @@
 6	eskiden	eski	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	10	amod	_	SpaceAfter=No
 7	)	)	PUNCT	Punc	_	6	punct	_	_
 8	evler	ev	NOUN	Noun	Case=Nom|Number=Plur|Person=3	10	nsubj	_	_
-9	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	10	obl	_	_
+9	neden	neden	ADV	Ques	Case=Abl|Number=Sing|Person=3	10	advmod	_	_
 10	farklılaşıyordu	farklılaş	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
 11	?	?	PUNCT	Punc	_	10	punct	_	_
 
@@ -4652,6 +4654,7 @@
 # sent_id = mst-1984
 # text = Öpüşmedikleri ya da birbirlerini mıncıklamadıkları zamanlar denize girmeye niyetlenen, ama her seferinde, nedendir bilinmez, vazgeçip geri dönen, bizlere bakıp asıl amacımızın yüzmek değil, denize işemek olduğunu anlayacaklarından çekiniyoruz.
 # Fixed 2.2/dev: original sentence ID: 00032161413/4
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Öpüşmedikleri	öpüş	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	6	acl	_	_
 2	ya	ya	CCONJ	Conj	_	1	compound	_	_
 3	da	da	CCONJ	Conj	_	1	compound	_	_
@@ -4667,7 +4670,7 @@
 13	seferinde	sefer	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	obl	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	15	punct	_	_
 15-16	nedendir	_	_	_	_	_	_	_	_
-15	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	13	conj	_	_
+15	neden	neden	ADV	Ques	_	13	conj	_	_
 16	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	15	cop	_	_
 17	bilinmez	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	13	conj	_	SpaceAfter=No
 18	,	,	PUNCT	Punc	_	17	punct	_	_
@@ -9335,10 +9338,11 @@
 
 # sent_id = mst-3979
 # text = Merkez sağ partiler neden bir araya gelemedi?
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Merkez	merkez	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod	_	_
 2	sağ	sağ	ADJ	Adj	_	3	amod	_	_
 3	partiler	parti	NOUN	Noun	Case=Nom|Number=Plur|Person=3	5	nsubj	_	_
-4	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	5	obl	_	_
+4	neden	neden	ADV	Ques	_	5	advmod	_	_
 5	bir	bir	NUM	ANum	NumType=Card	0	root	_	_
 6	araya	ara	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	5	compound	_	_
 7	gelemedi	gel	VERB	Verb	Aspect=Perf|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Past	5	compound	_	SpaceAfter=No
@@ -11827,8 +11831,9 @@
 
 # sent_id = mst-5056
 # text = Polyanna neden aklına gelmiyor?
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Polyanna	Polyanna	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
-2	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	3	nmod	_	_
+2	neden	neden	ADV	Ques	_	3	advmod	_	_
 3	aklına	akıl	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 4	gelmiyor	gel	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Polite=Infm|Tense=Pres	3	compound	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	3	punct	_	_

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -1316,7 +1316,7 @@
 
 # sent_id = mst-0556
 # text = Burada değineceğim şey Türkiye'nin konut sorununun çözümü, vb.
-1	Burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	nmod	_	_
+1	Burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	3	nmod	_	_
 2	değineceğim	değin	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Fut|VerbForm=Part	3	acl	_	_
 3	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 4	Türkiye'nin	Türkiye	PROPN	Prop	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
@@ -2293,7 +2293,7 @@
 6	sıcak	sıcak	ADJ	Adj	_	7	amod	_	_
 7	çay	çay	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
 8	misali	misal	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obl	_	_
-9	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	15	obl	_	_
+9	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	15	obl	_	_
 10	da	da	CCONJ	Conj	_	9	advmod:emph	_	_
 11	soğuğu	soğuk	ADJ	NAdj	Case=Acc|Number=Sing|Person=3	12	obj	_	_
 12	bastırıp	bas	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	13	nmod	_	_
@@ -2387,7 +2387,7 @@
 10	etkileyen	etkile	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	conj	_	_
 11	yanı	yan	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	nsubj	_	_
 12	da	da	CCONJ	Conj	_	11	advmod:emph	_	_
-13	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	16	obl	_	SpaceAfter=No
+13	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	16	obl	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	15	punct	_	_
 15	kusursuzluğunda	kusursuzluk	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	conj	_	_
 16	yatmaktadır	yat	VERB	Verb	Aspect=Prog|Mood=Gen|Number=Sing|Person=3|Polarity=Pos|Polite=Form|Tense=Pres	0	root	_	SpaceAfter=No
@@ -2397,7 +2397,7 @@
 # text = Masal da burada bitmiş.
 1	Masal	masal	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 2	da	da	CCONJ	Conj	_	1	advmod:emph	_	_
-3	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
+3	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 4	bitmiş	bit	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -2812,7 +2812,7 @@
 # sent_id = mst-1198
 # text = İşte burda biri kabahatli.
 1	İşte	işte	ADV	Adverb	_	2	advmod	_	_
-2	burda	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
+2	burda	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 3	biri	biri	PRON	Quant	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	4	nsubj	_	_
 4	kabahatli	kabahatli	ADJ	Adj	_	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
@@ -3322,7 +3322,7 @@
 6	bir	bir	ADV	Adverb	_	8	advmod	_	_
 7	daha	daha	ADV	Adverb	_	6	advmod	_	_
 8	çıkamaz	çık	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	12	obj	_	_
-9	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	8	obl	_	SpaceAfter=No
+9	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	8	obl	_	SpaceAfter=No
 10	?	?	PUNCT	Punc	_	8	punct	_	_
 11	diye	diye	ADP	PCNom	_	8	case	_	_
 12	sordum	sor	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -3988,7 +3988,7 @@
 9	gittiği	git	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	10	nsubj	_	_
 10	söyleniyor	söyle	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Pass	0	root	_	_
 11	ve	ve	CCONJ	Conj	_	22	cc	_	_
-12	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	14	nmod	_	_
+12	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	14	nmod	_	_
 13	Kazanın	kaza	NOUN	Noun	Case=Gen|Number=Sing|Person=3	15	nmod:poss	_	_
 14	oluş	oluş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	nmod:poss	_	_
 15	sebebini	sebep	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obj	_	_
@@ -4161,7 +4161,7 @@
 
 # sent_id = mst-1774
 # text = Orada, aynı yerde durur ve onu bekler.
-1	Orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
+1	Orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	5	punct	_	_
 3	aynı	aynı	ADJ	Adj	_	4	amod	_	_
 4	yerde	yer	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
@@ -4394,7 +4394,7 @@
 # text = Çay ocağının orada merdiven var.
 1	Çay	çay	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	ocağının	ocak	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	nmod	_	_
-3	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
+3	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
 4	merdiven	merdiven	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
 5	var	var	ADJ	Adj	_	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
@@ -4520,7 +4520,7 @@
 3	Ömür	ömür	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
 4	Uzatma	uza	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	3	flat	_	_
 5	Kıraathanesi	kıraathane	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	flat	_	_
-6	burası	bura	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	conj	_	SpaceAfter=No
+6	burası	bura	PRON	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-1938
@@ -4606,7 +4606,7 @@
 8	ocak	ocak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
 9	tüttüğüne	tüt	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	13	acl	_	_
 10	göre	göre	ADP	PCDat	_	9	case	_	_
-11	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	13	obl	_	_
+11	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	13	obl	_	_
 12	biri	biri	PRON	Quant	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	13	nsubj	_	_
 13	yaşıyor	yaşa	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	6	conj	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	13	punct	_	_
@@ -5071,7 +5071,7 @@
 2	yazacağım	yaz	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Fut|VerbForm=Part	6	acl	_	_
 3	için	için	ADP	PCNom	_	2	case	_	_
 4	mektubu	mektup	NOUN	Noun	Case=Acc|Number=Sing|Person=3	6	obj	_	_
-5	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
+5	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
 6	kesiyorum	kes	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
@@ -5090,7 +5090,7 @@
 9	kez	kez	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	compound	_	_
 10	mola	mola	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 11	verilecekti	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast|Voice=Pass	10	compound	_	_
-12	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	10	nmod	_	SpaceAfter=No
+12	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	10	nmod	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-2148
@@ -10240,7 +10240,7 @@
 # text = O da burada bekler.
 1	O	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	da	da	CCONJ	Conj	_	1	advmod:emph	_	_
-3	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
+3	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 4	bekler	bekle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -12142,7 +12142,7 @@
 
 # sent_id = mst-5211
 # text = Oraya saptık.
-1	Oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
+1	Oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
 2	saptık	sap	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -12245,7 +12245,7 @@
 
 # sent_id = mst-5264
 # text = Burada... yoktum... diye kekeledi.
-1	Burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	SpaceAfter=No
+1	Burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	SpaceAfter=No
 2	...	...	PUNCT	Punc	_	7	punct	_	_
 3-4	yoktum	_	_	_	_	_	_	_	SpaceAfter=No
 3	yok	yok	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	7	amod	_	_
@@ -12444,7 +12444,7 @@
 3	Sveta	Sveta	PROPN	Prop	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
 4	ve	ve	CCONJ	Conj	_	6	cc	_	_
 5	görümcesi	görümce	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nmod	_	_
-6	Şura	şura	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	conj	_	_
+6	Şura	Şura	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	conj	_	_
 7	ellerinde	el	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	9	nmod	_	_
 8	birer	bir	NUM	ANum	NumType=Dist	9	amod	_	_
 9	fincanla	fincan	NOUN	Noun	Case=Ins|Number=Sing|Person=3	10	obl	_	_
@@ -12981,7 +12981,7 @@
 1	Dünyanın	dünya	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
 2	tüm	tüm	DET	Det	_	3	det	_	_
 3	insanları	insan	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	4	nsubj	_	_
-4	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	0	root	_	SpaceAfter=No
+4	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-5565

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -77,7 +77,7 @@
 3	bu	bu	DET	Det	_	4	det	_	_
 4	akşam	akşam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obl	_	_
 5	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	6	obj	_	_
-6	aramasaydı	ara	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
+6	aramasaydı	ara	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 7	...	...	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-0045
@@ -1273,7 +1273,7 @@
 4	,	,	PUNCT	Punc	_	7	punct	_	_
 5	bir	bir	NUM	ANum	NumType=Card	6	det	_	_
 6	maç	maç	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
-7	bulsam	bul	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
+7	bulsam	bul	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	15	punct	_	_
 9	Serhat'ı	Serhat	PROPN	Prop	Case=Acc|Number=Sing|Person=3	15	obj	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	12	punct	_	_
@@ -2516,7 +2516,7 @@
 8	lazım	lazım	ADJ	Adj	_	16	amod	_	_
 9	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	_	_
 10	tarif	tarif	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
-11	etsem	et	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	10	compound:lvc	_	_
+11	etsem	et	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	10	compound:lvc	_	_
 12	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	8	conj	_	_
 13	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	12	aux:q	_	SpaceAfter=No
 14	?	?	PUNCT	Punc	_	12	punct	_	_
@@ -3678,7 +3678,7 @@
 # text = Ne de olsa eski kuşaktan.
 1	Ne	ne	CCONJ	Conj	_	0	root	_	_
 2	de	de	CCONJ	Conj	_	1	advmod:emph	_	_
-3	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	nmod	_	_
+3	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	nmod	_	_
 4	eski	eski	ADJ	Adj	_	5	amod	_	_
 5	kuşaktan	kuşak	NOUN	Noun	Case=Abl|Number=Sing|Person=3	1	conj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
@@ -3879,7 +3879,7 @@
 # sent_id = mst-1647
 # text = Nasıl anlatsam sana onu, bilemiyorum ki!
 1	Nasıl	nasıl	ADV	Adverb	_	2	advmod	_	_
-2	anlatsam	anlat	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	6	obj	_	_
+2	anlatsam	anlat	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	6	obj	_	_
 3	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	2	obj	_	_
 4	onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	2	obj	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	2	punct	_	_
@@ -6029,7 +6029,7 @@
 6	,	,	PUNCT	Punc	_	5	punct	_	_
 7	Suna	Suna	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
 8	Can	Can	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	flat	_	_
-9	duysa	duy	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	nmod	_	_
+9	duysa	duy	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	nmod	_	_
 10	nasıl	nasıl	ADV	Adverb	_	11	advmod:emph	_	_
 11	darılır	darıl	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	conj	_	_
 12	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	11	obl	_	SpaceAfter=No
@@ -6076,7 +6076,7 @@
 14	balıkçıların	balıkçı	NOUN	Noun	Case=Gen|Number=Plur|Person=3	20	nmod:poss	_	_
 15	da	da	CCONJ	Conj	_	14	advmod:emph	_	SpaceAfter=No
 16	,	,	PUNCT	Punc	_	20	punct	_	_
-17	bıraksa	bırak	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	20	nmod	_	_
+17	bıraksa	bırak	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	20	nmod	_	_
 18	sabaha	sabah	NOUN	Noun	Case=Dat|Number=Sing|Person=3	20	obl	_	_
 19	kadar	kadar	ADP	PCDat	_	18	case	_	_
 20	oynayacaklarını	oyna	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	12	conj	_	SpaceAfter=No
@@ -6307,7 +6307,7 @@
 2	yetkilerinin	yetki	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	6	obj	_	_
 3	kısmen	kısmen	ADV	Adverb	_	5	advmod	_	_
 4	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
-5	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	nmod	_	_
+5	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	nmod	_	_
 6	sınırlandırılması	sınırlan	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=CauPass	18	punct	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	conj	_	_
 8	hükümdar	hükümdar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod	_	_
@@ -6538,7 +6538,7 @@
 4	ki	ki	ADP	Rel	_	3	case	_	_
 5	anlaşmazlık	anlaşmazlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
 6	gerekçe	gerekçe	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
-7	gösterilse	göster	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	11	nmod	_	SpaceAfter=No
+7	gösterilse	göster	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	11	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	o	o	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	11	nsubj	_	_
 10	da	da	CCONJ	Conj	_	9	advmod:emph	_	_
@@ -8984,7 +8984,7 @@
 8	görünüyordu	görün	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	10	nmod	_	_
 9	ki	ki	CCONJ	Conj	_	8	mark	_	_
 10	elimi	el	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	11	obj	_	_
-11	uzatsam	uza	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres|Voice=Cau	12	nmod	_	_
+11	uzatsam	uza	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres|Voice=Cau	12	nmod	_	_
 12	değecek	değ	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	0	root	_	_
 13-14	gibiydim	_	_	_	_	_	_	_	SpaceAfter=No
 13	gibi	gibi	ADP	PCNom	_	12	case	_	_
@@ -10151,7 +10151,7 @@
 18	:	:	PUNCT	Punc	_	17	punct	_	_
 19	"	"	PUNCT	Punc	_	17	punct	_	_
 20	ABD	Abd	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	27	nsubj	_	_
-21	istese	iste	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	27	nmod	_	_
+21	istese	iste	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	27	nmod	_	_
 22	Rum	Rum	ADJ	Adj	_	25	amod	_	_
 23	Kesimi'nin	kesim	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	22	flat	_	_
 24	AB'ye	Ab	NOUN	Abr	Abbr=Yes|Case=Dat|Number=Sing|Person=3	25	nmod	_	_
@@ -10248,7 +10248,7 @@
 4	buluyorsun	bul	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	_
 5	ki	ki	CCONJ	Conj	_	4	advmod:emph	_	SpaceAfter=No
 6	?	?	PUNCT	Punc	_	4	punct	_	_
-7	Arasan	ara	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	11	nmod	_	_
+7	Arasan	ara	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	11	nmod	_	_
 8	Rusya'da	Rusya	PROPN	Prop	Case=Loc|Number=Sing|Person=3	11	obl	_	_
 9	Başbakan'ı	Başbakan	PROPN	Prop	Case=Acc|Number=Sing|Person=3	11	obj	_	_
 10	bile	bile	ADV	Adverb	_	11	advmod	_	_
@@ -11252,7 +11252,7 @@
 # text = O böyle ölmeseydi hayatın başka türlü mü olurdu, şimdiki gibi mi.
 1	O	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	böyle	böyle	ADV	Adverb	_	3	advmod	_	_
-3	ölmeseydi	öl	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Neg|Tense=Past	8	nmod	_	_
+3	ölmeseydi	öl	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Neg|Tense=Past	8	nmod	_	_
 4	hayatın	hayat	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	8	nsubj	_	_
 5	başka	başka	ADJ	Adj	_	6	amod	_	_
 6	türlü	türlü	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	8	amod	_	_
@@ -12800,7 +12800,7 @@
 17	Bize	biz	PRON	Pers	Case=Dat|Number=Plur|Person=1|PronType=Prs	24	obl	_	_
 18	miting	miting	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	nmod:poss	_	_
 19	hakkı	hak	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	obj	_	_
-20	vermeseler	ver	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	14	conj	_	_
+20	vermeseler	ver	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	14	conj	_	_
 21	de	de	CCONJ	Conj	_	20	advmod:emph	_	_
 22	yine	yine	ADV	Adverb	_	23	advmod	_	_
 23	alanlara	alan	NOUN	Noun	Case=Dat|Number=Plur|Person=3	24	obl	_	_
@@ -13095,7 +13095,7 @@
 # text = Kanun çıksa dahi biz bunun yarısı kadarını uygulamaya devam edeceğiz " dedi.
 # Change 2.2/dev: merge -(y)An
 1	Kanun	kanun	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nmod	_	_
-2	çıksa	çık	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	_
+2	çıksa	çık	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	_
 3	dahi	dahi	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	1	advmod:emph	_	_
 4	biz	biz	PRON	Pers	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	_	_
 5	bunun	bu	PRON	Demons	Case=Gen|Number=Sing|Person=3|PronType=Dem	6	nmod:poss	_	_

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -132,7 +132,7 @@
 # sent_id = mst-0064
 # text = Ama denmez.
 1	Ama	ama	CCONJ	Conj	_	0	root	_	_
-2	denmez	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	1	conj	_	SpaceAfter=No
+2	denmez	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Pass	1	conj	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0066
@@ -366,7 +366,7 @@
 1	Hepsi	hepsi	PRON	Quant	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	4	nsubj	_	_
 2	rakı	rakı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 3	sofrasına	sofra	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obl	_	_
-4	gider	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	gider	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-0180
@@ -379,13 +379,13 @@
 6	borç	borç	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
 7	alma	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	compound	_	_
 8	anlamına	anlam	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	obl	_	_
-9	gelir	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	14	nmod:poss	_	_
+9	gelir	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	14	nmod:poss	_	_
 10	ve	ve	CCONJ	Conj	_	9	conj	_	_
 11	bunun	bu	PRON	Demons	Case=Gen|Number=Sing|Person=3|PronType=Dem	12	nmod:poss	_	_
 12	karşılığında	karşılık	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	obl	_	_
 13	faiz	faiz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	conj	_	_
 14	ödenmesi	öde	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	15	nsubj	_	_
-15	gerekir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+15	gerekir	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-0187
@@ -489,7 +489,7 @@
 5	,	,	PUNCT	Punc	_	7	punct	_	_
 6	çatık	çatık	ADJ	Adj	_	7	amod	_	_
 7	kaşla	kaş	NOUN	Noun	Case=Ins|Number=Sing|Person=3	4	conj	_	_
-8	konuşmaz	konuş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+8	konuşmaz	konuş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	11	punct	_	_
 10	büyük	büyük	ADJ	Adj	_	11	amod	_	_
 11	kelam	kelam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	conj	_	_
@@ -621,7 +621,7 @@
 12	yasaların	yasa	NOUN	Noun	Case=Gen|Number=Plur|Person=3	13	nmod:poss	_	_
 13	varlığının	varlık	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	nmod:poss	_	_
 14	kabulünü	kabul	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obj	_	_
-15	gerektirir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+15	gerektirir	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-0295
@@ -721,7 +721,7 @@
 
 # sent_id = mst-0318
 # text = Uyanır gibi oldum ve o zamanki genç kızın artık dünyamızda olmadığını, erken bir ölümle öldüğünü düşündüm.
-1	Uyanır	uyan	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	3	acl	_	_
+1	Uyanır	uyan	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	acl	_	_
 2	gibi	gibi	ADP	PCNom	_	1	case	_	_
 3	oldum	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
 4	ve	ve	CCONJ	Conj	_	18	cc	_	_
@@ -870,7 +870,7 @@
 5	yumurta	yumurta	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 6	cezvesi	cezve	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obl	_	_
 7	ve	ve	CCONJ	Conj	_	9	cc	_	_
-8	kaynar	kayna	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	9	acl	_	_
+8	kaynar	kayna	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	acl	_	_
 9	suyla	su	NOUN	Noun	Case=Ins|Number=Sing|Person=3	6	conj	_	_
 10	yırtamazdım	yırt	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Past	1	conj	_	_
 11	herhalde	herhalde	ADV	Adverb	_	10	advmod	_	SpaceAfter=No
@@ -912,17 +912,17 @@
 # text = Ya boca ederler kahveyi, bir karış telve oluşur, ya cimrilikleri tutar, buyrun bulaşık suyuna.
 1	Ya	ya	CCONJ	Conj	_	2	cc	_	_
 2	boca	boca	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-3	ederler	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	2	compound	_	_
+3	ederler	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	2	compound	_	_
 4	kahveyi	kahve	NOUN	Noun	Case=Acc|Number=Sing|Person=3	2	obj	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	2	punct	_	_
 6	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
 7	karış	karış	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	compound	_	_
 8	telve	telve	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
-9	oluşur	oluş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	conj	_	SpaceAfter=No
+9	oluşur	oluş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	conj	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	9	punct	_	_
 11	ya	ya	CCONJ	Conj	_	13	cc	_	_
 12	cimrilikleri	cimrilik	NOUN	Noun	Case=Acc|Number=Plur|Person=3	13	obl	_	_
-13	tutar	tut	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	conj	_	SpaceAfter=No
+13	tutar	tut	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	conj	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	13	punct	_	_
 15	buyrun	buyur	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	2	conj	_	_
 16	bulaşık	bulaşık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nmod	_	_
@@ -935,7 +935,7 @@
 2	de	de	CCONJ	Conj	_	1	mark	_	_
 3	bütün	bütün	ADJ	Adj	_	4	amod	_	_
 4	paranı	para	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	5	obj	_	_
-5	alır	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	alır	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-0399
@@ -964,7 +964,7 @@
 5	iyi	iyi	ADJ	Adj	_	10	advmod:emph	_	_
 6	ki	ki	CCONJ	Conj	_	5	advmod:emph	_	_
 7	çarpılmadım	çarp	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Past|Voice=Pass	1	conj	_	_
-8	uyurken	uyu	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	7	nmod	_	SpaceAfter=No
+8	uyurken	uyu	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 11	kendi	kendi	PRON	Reflex	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	10	obl	_	_
@@ -974,7 +974,7 @@
 
 # sent_id = mst-0411
 # text = Severim tartışmayı, gevezeliği, tatlı tatlı takılmayı, uyuşuyorsa kafalar.
-1	Severim	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Severim	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 2	tartışmayı	tartış	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	1	obj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	4	punct	_	_
 4	gevezeliği	gevezelik	NOUN	Noun	Case=Acc|Number=Sing|Person=3	2	conj	_	SpaceAfter=No
@@ -1047,7 +1047,7 @@
 2	,	,	PUNCT	Punc	_	5	punct	_	_
 3	yine	yine	ADV	Adverb	_	1	conj	_	_
 4	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
-5	gitmez	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	1	conj	_	_
+5	gitmez	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	1	conj	_	_
 6	bu	bu	DET	Det	_	7	det	_	_
 7	meret	meret	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
 8	böyle	böyle	ADV	Adverb	_	5	advmod	_	SpaceAfter=No
@@ -1091,7 +1091,7 @@
 13	gözlemlerle	gözlem	NOUN	Noun	Case=Ins|Number=Plur|Person=3	15	obl	_	_
 14	tutarlı	tutarlı	ADJ	Adj	_	15	amod	_	_
 15	olmasında	ol	VERB	Verb	Aspect=Perf|Case=Loc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	conj	_	_
-16	yatar	yat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+16	yatar	yat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-0462
@@ -1198,7 +1198,7 @@
 # sent_id = mst-0503
 # text = Tepki gösterir demişim veya gereksiz yere kendini savunacak, derdimi anlatamayacağım demişim, vesaire.
 1	Tepki	tepki	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
-2	gösterir	göster	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	1	compound	_	_
+2	gösterir	göster	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	1	compound	_	_
 3	demişim	de	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
 4	veya	veya	CCONJ	Conj	_	12	cc	_	_
 5	gereksiz	gereksiz	ADJ	Adj	_	6	amod	_	_
@@ -1443,7 +1443,7 @@
 1	Yenisine	yeni	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	amod	_	_
 2	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 3	bile	bile	ADV	Adverb	_	2	advmod:emph	_	_
-4	dayanamam	dayan	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	dayanamam	dayan	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-0622
@@ -1666,7 +1666,7 @@
 
 # sent_id = mst-0723
 # text = Olmaz, köylü ağzı.
-1	Olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+1	Olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	1	punct	_	_
 3	köylü	köylü	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	4	amod	_	_
 4	ağzı	ağız	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	conj	_	SpaceAfter=No
@@ -1774,7 +1774,7 @@
 1	Beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	4	obj	_	_
 2	nasıl	nasıl	ADV	Adverb	_	3	advmod	_	_
 3	etkilediğini	etkile	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	4	obj	_	_
-4	bilemezsin	bil	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	bilemezsin	bil	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-0777
@@ -1806,7 +1806,7 @@
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	parçacıklar	parçacık	NOUN	Noun	Case=Nom|Number=Plur|Person=3	4	nsubj	_	_
 3	erkelerini	erke	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	4	obj	_	_
-4	koruyabilirler	koru	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	koruyabilirler	koru	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-0790
@@ -2007,7 +2007,7 @@
 # sent_id = mst-0868
 # text = Aslına bakarsanız, leblebi yemiş değildir.
 1	Aslına	asıl	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
-2	bakarsanız	bak	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	1	compound	_	SpaceAfter=No
+2	bakarsanız	bak	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	1	compound	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	6	punct	_	_
 4	leblebi	leblebi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
 5	yemiş	yemiş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obj	_	_
@@ -2022,7 +2022,7 @@
 3	diyinceye	de	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	advcl	_	_
 4	kadar	kadar	ADP	PCDat	_	3	case	_	_
 5	pazar	pazar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
-6	savrulur	savrul	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	ccomp	_	_
+6	savrulur	savrul	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	ccomp	_	_
 7	diyor	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	_
 8	Anadolu	Anadolu	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nmod:poss	_	_
 9	deyimi	deyim	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nsubj	_	SpaceAfter=No
@@ -2177,7 +2177,7 @@
 # text = İlk oturuşta anlarım bunu.
 1	İlk	ilk	ADV	Adverb	_	2	advmod	_	_
 2	oturuşta	oturuş	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
-3	anlarım	anla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+3	anlarım	anla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 4	bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -2200,10 +2200,10 @@
 4	herhangi	herhangi	ADJ	Adj	_	6	det	_	_
 5	bir	bir	NUM	ANum	NumType=Card	6	det	_	_
 6	bilgi	bilgi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
-7	isterse	iste	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	10	nmod	_	SpaceAfter=No
+7	isterse	iste	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	10	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	bunları	bu	PRON	Demons	Case=Acc|Number=Plur|Person=3|PronType=Dem	10	obj	_	_
-10	söyleyebilirim	söyle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+10	söyleyebilirim	söyle	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 11	onlara	o	PRON	Pers	Case=Dat|Number=Plur|Person=3|PronType=Prs	10	obl	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	10	punct	_	_
 
@@ -2230,7 +2230,7 @@
 
 # sent_id = mst-0954
 # text = Sanırım o da heyecanlanmıştı.
-1	Sanırım	san	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Sanırım	san	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 2	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 3	da	da	CCONJ	Conj	_	2	advmod:emph	_	_
 4	heyecanlanmıştı	heyecanlan	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	1	conj	_	SpaceAfter=No
@@ -2420,7 +2420,7 @@
 3	sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	5	nsubj	_	_
 4	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	5	obj	_	_
 5	yardım	yardım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-6	eder	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	compound:lvc	_	_
+6	eder	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	compound:lvc	_	_
 7	misin	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Pres	5	aux:q	_	SpaceAfter=No
 8	?	?	PUNCT	Punc	_	5	punct	_	_
 
@@ -2429,7 +2429,7 @@
 1	-	-	PUNCT	Punc	_	0	root	_	SpaceAfter=No
 2	Yazdıklarını	yaz	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	4	obj	_	_
 3	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	4	obl	_	_
-4	gösterir	göster	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	_
+4	gösterir	göster	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	_
 5	misin	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Pres	4	aux:q	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -2500,7 +2500,7 @@
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	viski	viski	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
 3	daha	daha	ADV	Adverb	_	2	advmod:emph	_	_
-4	içer	iç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+4	içer	iç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 5	misin	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Pres	4	aux:q	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -2517,7 +2517,7 @@
 9	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	_	_
 10	tarif	tarif	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
 11	etsem	et	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	10	compound:lvc	_	_
-12	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	8	conj	_	_
+12	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	8	conj	_	_
 13	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	12	aux:q	_	SpaceAfter=No
 14	?	?	PUNCT	Punc	_	12	punct	_	_
 15	diye	diye	ADP	PCNom	_	8	case	_	_
@@ -2659,7 +2659,7 @@
 1	Sabrı	sabır	NOUN	Noun	Case=Acc|Number=Sing|Person=3	2	obj	_	_
 2	öğrenmek	öğren	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	nsubj	_	_
 3	uygulamayla	uygulama	NOUN	Noun	Case=Ins|Number=Sing|Person=3	4	obl	_	_
-4	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-1130
@@ -2714,7 +2714,7 @@
 10	resim	resim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
 11	yapmalarıyla	yap	VERB	Verb	Aspect=Perf|Case=Ins|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	10	compound:lvc	_	_
 12	başlamıştır	başla	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Gen|Number=Sing|Person=3|Polarity=Pos|Tense=Past	13	nsubj	_	_
-13	denebilir	de	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+13	denebilir	de	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-1152
@@ -2764,7 +2764,7 @@
 # text = Bir kahve söylerim.
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	kahve	kahve	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
-3	söylerim	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	söylerim	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1180
@@ -2828,7 +2828,7 @@
 2-3	onsuz	_	_	_	_	_	_	_	_
 2	on	o	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	4	obj	_	_
 3	suz	siz	ADP	Without	_	2	case	_	_
-4	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	1	conj	_	SpaceAfter=No
+4	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	1	conj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-1207
@@ -2879,7 +2879,7 @@
 # text = Yıllar akıp giderken, çocukları büyüdü.
 1	Yıllar	yıl	NOUN	Noun	Case=Nom|Number=Plur|Person=3	2	nsubj	_	_
 2	akıp	ak	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
-3	giderken	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	2	compound	_	SpaceAfter=No
+3	giderken	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	2	compound	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	2	punct	_	_
 5	çocukları	çocuk	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	6	nsubj	_	_
 6	büyüdü	büyü	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -2977,7 +2977,7 @@
 11	doksanaltı'dan	doksanaltı	NUM	NNum	Case=Abl|Number=Sing|NumType=Card|Person=3	10	flat	_	_
 12	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	14	nummod	_	_
 13	atmışbeş'e	atmışbeş	NUM	NNum	Case=Dat|Number=Sing|NumType=Card|Person=3	12	flat	_	_
-14	inerken	in	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	23	nmod	_	SpaceAfter=No
+14	inerken	in	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	23	nmod	_	SpaceAfter=No
 15	,	,	PUNCT	Punc	_	14	punct	_	_
 16	Çukurova	Çukurova	PROPN	Prop	Case=Nom|Number=Sing|Person=3	18	nmod:poss	_	_
 17	Holding'in	Holding	PROPN	Prop	Case=Gen|Number=Sing|Person=3	16	flat	_	_
@@ -3081,7 +3081,7 @@
 # text = Uzak öpücük yeter.
 1	Uzak	uzak	ADJ	Adj	_	2	amod	_	_
 2	öpücük	öpücük	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
-3	yeter	yet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	yeter	yet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1316
@@ -3092,9 +3092,9 @@
 4	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 5	:	:	PUNCT	Punc	_	11	punct	_	_
 6	Sırayla	sıra	NOUN	Noun	Case=Ins|Number=Sing|Person=3	7	obl	_	_
-7	gezdiririz	gez	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor|Voice=Cau	11	obj	_	_
-8	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	conj	_	_
-9	biter	bit	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	8	compound	_	SpaceAfter=No
+7	gezdiririz	gez	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres|Voice=Cau	11	obj	_	_
+8	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	conj	_	_
+9	biter	bit	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	compound	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	8	punct	_	_
 11	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	4	conj	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
@@ -3142,7 +3142,7 @@
 15	başarılı	başarılı	ADJ	Adj	_	17	amod	_	_
 16	bir	bir	NUM	ANum	NumType=Card	17	nummod	_	_
 17	mağaza	mağaza	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	obj	_	_
-18	yaratırsınız	yarat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+18	yaratırsınız	yarat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 19	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-1344
@@ -3221,7 +3221,7 @@
 2	onun	o	PRON	Pers	Case=Gen|Number=Sing|Person=3|PronType=Prs	3	nmod:poss	_	_
 3	hali	hal	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nsubj	_	_
 4	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	5	obj	_	_
-5	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	?	?	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1381
@@ -3285,11 +3285,11 @@
 1	Bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	2	nmod	_	_
 2	telefon	telefon	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod	_	_
 3-4	ederkenki	_	_	_	_	_	_	_	_
-3	ederken	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	2	compound:lvc	_	_
+3	ederken	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	2	compound:lvc	_	_
 4	ki	ki	ADP	Rel	_	2	case	_	_
 5	aceleciliği	acelecilik	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	nsubj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	11	punct	_	_
-7	sanırım	san	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	11	nmod	_	SpaceAfter=No
+7	sanırım	san	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	11	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	birşeylerden	birşey	NOUN	Noun	Case=Abl|Number=Plur|Person=3	10	obl	_	_
 10	korktuğunu	kork	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	11	obj	_	_
@@ -3326,7 +3326,7 @@
 5	giren	gir	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	8	nsubj	_	_
 6	bir	bir	ADV	Adverb	_	8	advmod	_	_
 7	daha	daha	ADV	Adverb	_	6	advmod	_	_
-8	çıkamaz	çık	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	12	obj	_	_
+8	çıkamaz	çık	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	12	obj	_	_
 9	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	8	obl	_	SpaceAfter=No
 10	?	?	PUNCT	Punc	_	8	punct	_	_
 11	diye	diye	ADP	PCNom	_	8	case	_	_
@@ -3348,19 +3348,19 @@
 
 # sent_id = mst-1429
 # text = Yemeyiz, dedi Ramiz, önce ben girerim sınıfa, öğretmenim, derim, öğlende tarlaya babama yemek götürdüm, ondan geç kaldım.
-1	Yemeyiz	ye	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Neg|Tense=Aor	3	obj	_	SpaceAfter=No
+1	Yemeyiz	ye	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Neg|Tense=Pres	3	obj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	1	punct	_	_
 3	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 4	Ramiz	Ramiz	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nsubj	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	3	punct	_	_
 6	önce	önce	ADV	Adverb	_	8	advmod	_	_
 7	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	_	_
-8	girerim	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	3	conj	_	_
+8	girerim	gir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	conj	_	_
 9	sınıfa	sınıf	NOUN	Noun	Case=Dat|Number=Sing|Person=3	8	obl	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	8	punct	_	_
 11	öğretmenim	öğretmen	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	13	obj	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	13	punct	_	_
-13	derim	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+13	derim	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	19	punct	_	_
 15	öğlende	öğlen	NOUN	Noun	Case=Loc|Number=Sing|Person=3	19	obl	_	_
 16	tarlaya	tarla	NOUN	Noun	Case=Dat|Number=Sing|Person=3	19	obl	_	_
@@ -3383,7 +3383,7 @@
 4	gündemde	gündem	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	nmod:poss	_	_
 5	ki	ki	ADP	Rel	_	4	case	_	_
 6	yerini	yer	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obj	_	_
-7	korurken	koru	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	13	nmod	_	_
+7	korurken	koru	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	13	nmod	_	_
 8	Türkiye	Türkiye	PROPN	Prop	Case=Nom|Number=Sing|Person=3	12	nmod:poss	_	_
 9	ile	ile	CCONJ	Conj	_	10	cc	_	_
 10	ABD'nin	Abd	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	8	conj	_	_
@@ -3449,7 +3449,7 @@
 6	hem	hem	CCONJ	Conj	_	7	cc	_	_
 7	acıya	acı	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	9	amod	_	_
 8	nasıl	nasıl	ADV	Adverb	_	9	advmod	_	_
-9	katlanırlar	katlan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+9	katlanırlar	katlan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-1464
@@ -3562,7 +3562,7 @@
 # text = Kervan evlere yaklaşırken kasabaya doğru yola çıkan iki kar motosikletinin uzaklaşan gürültüsü geyikleri ürkütüyor.
 1	Kervan	kervan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	evlere	ev	NOUN	Noun	Case=Dat|Number=Plur|Person=3	3	obl	_	_
-3	yaklaşırken	yaklaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	14	nmod	_	_
+3	yaklaşırken	yaklaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	14	nmod	_	_
 4	kasabaya	kasaba	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	nmod	_	_
 5	doğru	doğru	ADP	PCDat	_	4	case	_	_
 6	yola	yol	NOUN	Noun	Case=Dat|Number=Sing|Person=3	10	nmod	_	_
@@ -3659,11 +3659,11 @@
 # text = Geleceği kimse bilemez, bu da olabilir; ama bunu düşünmekten, gece uykularınız kaçıyor.
 1	Geleceği	gelecek	ADJ	NAdj	Case=Acc|Number=Sing|Person=3	3	obj	_	_
 2	kimse	kimse	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
-3	bilemez	bil	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+3	bilemez	bil	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	7	punct	_	_
 5	bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	7	nsubj	_	_
 6	da	da	CCONJ	Conj	_	5	advmod:emph	_	_
-7	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+7	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 8	;	;	PUNCT	Punc	_	14	punct	_	_
 9	ama	ama	CCONJ	Conj	_	14	cc	_	_
 10	bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	11	obj	_	_
@@ -3916,10 +3916,10 @@
 5	her	her	DET	Det	_	8	obj	_	_
 6	şeyi	şey	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	fixed	_	_
 7	duygularıyla	duygu	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	_
-8	algılar	algıla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+8	algılar	algıla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	11	punct	_	_
 10	duygularıyla	duygu	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	11	obl	_	_
-11	yorumlar	yorumla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	8	conj	_	SpaceAfter=No
+11	yorumlar	yorumla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	conj	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	18	punct	_	_
 13	çocuğun	çocuk	NOUN	Noun	Case=Gen|Number=Sing|Person=3	15	nmod:poss	_	_
 14	duygu	duygu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	nmod:poss	_	_
@@ -4041,11 +4041,11 @@
 # text = Düşünmek istemedikçe düşünür, anımsamak istemedikçe anımsarsınız.
 1	Düşünmek	düşün	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	2	obj	_	_
 2	istemedikçe	iste	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	3	nmod	_	_
-3	düşünür	düşün	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	düşünür	düşün	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	7	punct	_	_
 5	anımsamak	anımsa	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	obj	_	_
 6	istemedikçe	iste	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	7	nmod	_	_
-7	anımsarsınız	anımsa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+7	anımsarsınız	anımsa	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-1726
@@ -4075,7 +4075,7 @@
 14	Ocak	ocak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	flat	_	_
 15	ikibinüç	ikibinüç	NUM	ANum	NumType=Card	13	flat	_	_
 16	olarak	olarak	ADP	PCNom	_	13	case	_	_
-17	belirlenirken	belirle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv|Voice=Pass	24	nmod	_	SpaceAfter=No
+17	belirlenirken	belirle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	24	nmod	_	SpaceAfter=No
 18	,	,	PUNCT	Punc	_	17	punct	_	_
 19	itfası	itfa	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	24	nsubj	_	_
 20	yirmisekiz	yirmisekiz	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	23	nmod:poss	_	_
@@ -4098,7 +4098,7 @@
 # sent_id = mst-1745
 # text = Birtakım açmaz sorular ve davranışlarla eleniyorlar.
 1	Birtakım	birtakım	ADJ	Adj	_	3	det	_	_
-2	açmaz	aç	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	3	acl	_	_
+2	açmaz	aç	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	3	acl	_	_
 3	sorular	soru	NOUN	Noun	Case=Nom|Number=Plur|Person=3	6	obj	_	_
 4	ve	ve	CCONJ	Conj	_	5	cc	_	_
 5	davranışlarla	davranış	NOUN	Noun	Case=Ins|Number=Plur|Person=3	3	conj	_	_
@@ -4118,7 +4118,7 @@
 9	ilişkin	ilişkin	ADP	PCDat	_	8	case	_	_
 10	benim	ben	PRON	Pers	Case=Gen|Number=Sing|Person=1|PronType=Prs	11	nmod:poss	_	_
 11	ütopyama	ütopya	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	12	obl	_	_
-12	gelebiliriz	gel	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+12	gelebiliriz	gel	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-1756
@@ -4173,17 +4173,17 @@
 2	,	,	PUNCT	Punc	_	5	punct	_	_
 3	aynı	aynı	ADJ	Adj	_	4	amod	_	_
 4	yerde	yer	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
-5	durur	dur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	8	nmod	_	_
+5	durur	dur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	_
 6	ve	ve	CCONJ	Conj	_	8	cc	_	_
 7	onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	8	obj	_	_
-8	bekler	bekle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+8	bekler	bekle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-1779
 # text = Sen politikacı olabilirsin.
 1	Sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
 2	politikacı	politikacı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
-3	olabilirsin	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	olabilirsin	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1783
@@ -4270,7 +4270,7 @@
 5	nasıl	nasıl	ADV	Adverb	_	7	advmod	_	_
 6	evini	ev	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obj	_	_
 7	terk	terk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-8	eder	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	compound:lvc	_	SpaceAfter=No
+8	eder	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	compound:lvc	_	SpaceAfter=No
 9	?	?	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-1821
@@ -4339,7 +4339,7 @@
 14	eşik	eşik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nsubj	_	_
 15	kişiden	kişi	NOUN	Noun	Case=Abl|Number=Sing|Person=3	16	nmod	_	_
 16	kişiye	kişi	NOUN	Noun	Case=Dat|Number=Sing|Person=3	17	obl	_	_
-17	değişir	değiş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	10	conj	_	SpaceAfter=No
+17	değişir	değiş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	10	conj	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-1853
@@ -4389,7 +4389,7 @@
 # text = Müşteriler dokunmayı sever.
 1	Müşteriler	müşteri	NOUN	Noun	Case=Nom|Number=Plur|Person=3	3	nsubj	_	_
 2	dokunmayı	dokun	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	3	obj	_	_
-3	sever	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	sever	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1870
@@ -4411,7 +4411,7 @@
 # text = İlla tuzlu olmaz.
 1	İlla	illa	ADV	Adverb	_	3	advmod	_	_
 2	tuzlu	tuzlu	ADJ	Adj	_	3	amod	_	_
-3	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+3	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1880
@@ -4491,12 +4491,12 @@
 5	yıla	yıl	NOUN	Noun	Case=Dat|Number=Sing|Person=3	7	nmod	_	_
 6	ait	ait	ADP	PCDat	_	5	case	_	_
 7	performansını	performans	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
-8	incelerken	incele	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	13	nmod	_	_
+8	incelerken	incele	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	13	nmod	_	_
 9	başlıca	başlıca	ADJ	Adj	_	12	amod	_	_
 10	üç	üç	NUM	ANum	NumType=Card	11	nummod	_	_
 11	ana	ana	ADJ	Adj	_	12	amod	_	_
 12	kategoriye	kategori	NOUN	Noun	Case=Dat|Number=Sing|Person=3	13	obl	_	_
-13	ayırabiliriz	ayır	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+13	ayırabiliriz	ayır	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 14	:	:	PUNCT	Punc	_	13	punct	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	13	punct	_	_
 
@@ -4539,7 +4539,7 @@
 
 # sent_id = mst-1940
 # text = Sayılmaz.
-1	Sayılmaz	say	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+1	Sayılmaz	say	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-1942
@@ -4560,7 +4560,7 @@
 14	değişim	değişim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	nmod:poss	_	_
 15	değerine	değer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obl	_	_
 16	dönüşmelerini	dönüş	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	conj	_	_
-17	gerektirir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+17	gerektirir	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-1954
@@ -4675,7 +4675,7 @@
 15-16	nedendir	_	_	_	_	_	_	_	_
 15	neden	neden	ADV	Ques	_	13	conj	_	_
 16	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	15	cop	_	_
-17	bilinmez	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	13	conj	_	SpaceAfter=No
+17	bilinmez	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Pass	13	conj	_	SpaceAfter=No
 18	,	,	PUNCT	Punc	_	17	punct	_	_
 19	vazgeçip	vazgeç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	20	nmod	_	_
 20	geri	geri	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	9	conj	_	_
@@ -4761,11 +4761,11 @@
 6	kanıtlanmasından	kanıtla	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	10	obj	_	_
 7	çok	çok	ADP	PCAbl	_	8	det	_	_
 8-9	yanlışlanabilirliğinden	_	_	_	_	_	_	_	_
-8	yanlışlanabilir	yanlışlan	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part	10	obj	_	_
+8	yanlışlanabilir	yanlışlan	VERB	Verb	Aspect=Hab|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Part	10	obj	_	_
 9	liğinden	lik	ADP	Ness	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	case	_	_
 10	sözedilmesi	sözet	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	11	obj	_	_
 11	gereğini	gerek	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	obj	_	_
-12	onarlarsa	ona	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+12	onarlarsa	ona	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	23	punct	_	_
 14	bildirilerinde	bildiri	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	15	nmod	_	_
 15	sözünü	söz	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	18	nmod	_	_
@@ -4860,7 +4860,7 @@
 # sent_id = mst-2054
 # text = Koluna girebilir miyim?
 1	Koluna	kol	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	0	root	_	_
-2	girebilir	gir	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound	_	_
+2	girebilir	gir	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	_
 3	miyim	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	1	aux:q	_	SpaceAfter=No
 4	?	?	PUNCT	Punc	_	1	punct	_	_
 
@@ -4871,7 +4871,7 @@
 3	adayımız	aday	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	5	nsubj	_	_
 4	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	3	aux:q	_	_
 5	geldi	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	6	obj	_	_
-6	dersiniz	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	dersiniz	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-2060
@@ -5112,7 +5112,7 @@
 4	teknoloji	teknoloji	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
 5	artık	artık	ADV	Adverb	_	12	advmod	_	_
 6	geri	geri	ADV	Adverb	_	7	advmod	_	_
-7	dönülmez	dön	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	8	acl	_	_
+7	dönülmez	dön	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	8	acl	_	_
 8	biçimde	biçim	NOUN	Noun	Case=Loc|Number=Sing|Person=3	12	obl	_	_
 9	bilimsel	bilimsel	ADJ	Adj	_	10	amod	_	_
 10	bilgi	bilgi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nmod:poss	_	_
@@ -5137,7 +5137,7 @@
 2	kısım	kısım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
 3	da	da	CCONJ	Conj	_	2	nmod	_	_
 4	vazo	vazo	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
-5	kırılır	kır	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	7	nmod	_	_
+5	kırılır	kır	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	7	nmod	_	_
 6	diye	diye	ADP	PCNom	_	5	case	_	_
 7	düşünüyor	düşün	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
@@ -5224,7 +5224,7 @@
 25	dönemde	dönem	NOUN	Noun	Case=Loc|Number=Sing|Person=3	26	obl	_	_
 26	bulunduğumuz	bulun	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	27	acl	_	_
 27	gerçeğini	gerçek	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	28	obj	_	_
-28	değiştirmez	değiş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Cau	16	conj	_	SpaceAfter=No
+28	değiştirmez	değiş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Cau	16	conj	_	SpaceAfter=No
 29	.	.	PUNCT	Punc	_	28	punct	_	_
 
 # sent_id = mst-2199
@@ -5356,7 +5356,7 @@
 13	etmeksizin	et	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	12	compound:lvc	_	_
 14	evden	ev	NOUN	Noun	Case=Abl|Number=Sing|Person=3	9	conj	_	_
 15	söz	söz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
-16	edemezsiniz	et	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Tense=Aor	15	compound:lvc	_	SpaceAfter=No
+16	edemezsiniz	et	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	15	compound:lvc	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-2254
@@ -5501,7 +5501,7 @@
 14	bu	bu	DET	Det	_	15	det	_	_
 15	çoluk	çoluk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	obl	_	_
 16	çocuğa	çocuk	NOUN	Noun	Case=Dat|Number=Sing|Person=3	15	compound:redup	_	_
-17	bırakılamaz	bırak	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	19	obj	_	_
+17	bırakılamaz	bırak	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Pass	19	obj	_	_
 18	"	"	PUNCT	Punc	_	17	punct	_	_
 19	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 20	.	.	PUNCT	Punc	_	19	punct	_	_
@@ -5521,7 +5521,7 @@
 11	daha	daha	ADV	Adverb	_	12	advmod	_	_
 12	hızlı	hızlı	ADJ	Adj	_	13	amod	_	_
 13	hareket	hareket	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-14	ederler	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	13	compound:lvc	_	SpaceAfter=No
+14	ederler	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	13	compound:lvc	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-2337
@@ -5542,7 +5542,7 @@
 5	beraber	beraber	ADV	Adverb	_	6	advmod	_	_
 6	yaşamanın	yaşa	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	nmod:poss	_	_
 7	bedelini	bedel	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
-8	ödersin	öde	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	10	obj	_	SpaceAfter=No
+8	ödersin	öde	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	10	obj	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 10	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
@@ -5681,7 +5681,7 @@
 16	daha	daha	ADV	Adverb	_	15	advmod:emph	_	_
 17	geriletmek	gerile	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	18	nmod	_	_
 18	mümkün	mümkün	ADJ	Adj	_	1	conj	_	_
-19	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	18	compound:lvc	_	SpaceAfter=No
+19	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	compound:lvc	_	SpaceAfter=No
 20	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-2407
@@ -5853,7 +5853,7 @@
 
 # sent_id = mst-2487
 # text = Anlarız.
-1	Anlarız	anla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+1	Anlarız	anla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-2488
@@ -5930,7 +5930,7 @@
 9	"	"	PUNCT	Punc	_	8	punct	_	_
 10	uçağının	uçak	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	compound	_	_
 11	üzüntüsünü	üzüntü	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	obj	_	_
-12	yaşarken	yaşa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	0	root	_	SpaceAfter=No
+12	yaşarken	yaşa	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	0	root	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	21	punct	_	_
 14	sabah	sabah	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	obl	_	_
 15	saatlerinde	saat	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	14	flat	_	_
@@ -6031,14 +6031,14 @@
 8	Can	Can	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	flat	_	_
 9	duysa	duy	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	nmod	_	_
 10	nasıl	nasıl	ADV	Adverb	_	11	advmod:emph	_	_
-11	darılır	darıl	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	3	conj	_	_
+11	darılır	darıl	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	conj	_	_
 12	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	11	obl	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-2561
 # text = Sonra yumuşatır.
 1	Sonra	sonra	ADV	Adverb	_	2	advmod	_	_
-2	yumuşatır	yumuşa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+2	yumuşatır	yumuşa	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-2563
@@ -6106,7 +6106,7 @@
 20	noter	noter	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	nmod:poss	_	_
 21	kağıtları	kağıt	ADJ	NAdj	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	18	conj	_	_
 22	dolaplara	dolap	NOUN	Noun	Case=Dat|Number=Plur|Person=3	23	obl	_	_
-23	sığmaz	sığ	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	24	advmod:emph	_	_
+23	sığmaz	sığ	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	24	advmod:emph	_	_
 24	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 25	.	.	PUNCT	Punc	_	24	punct	_	_
 
@@ -6132,11 +6132,11 @@
 18	bir	bir	NUM	ANum	NumType=Card	19	det	_	_
 19	muhbir	muhbir	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	21	nsubj	_	_
 20	sizi	siz	PRON	Pers	Case=Acc|Number=Plur|Person=2|PronType=Prs	21	obj	_	_
-21	gammazlar	gammazla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	26	obj	_	SpaceAfter=No
+21	gammazlar	gammazla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	26	obj	_	SpaceAfter=No
 22	,	,	PUNCT	Punc	_	23	punct	_	_
 23	başınız	baş	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	21	conj	_	_
 24	derde	dert	NOUN	Noun	Case=Dat|Number=Sing|Person=3	23	compound	_	_
-25	girebilir	gir	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	23	compound	_	_
+25	girebilir	gir	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	23	compound	_	_
 26	demişti	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	2	conj	_	SpaceAfter=No
 27	.	.	PUNCT	Punc	_	26	punct	_	_
 
@@ -6148,7 +6148,7 @@
 3	di	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	2	cop	_	_
 4	bunlar	bu	PRON	Demons	Case=Nom|Number=Plur|Person=3|PronType=Dem	2	nsubj	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	2	punct	_	_
-6	anlarsınız	anla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	2	conj	_	_
+6	anlarsınız	anla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	2	conj	_	_
 7	ya	ya	CCONJ	Conj	_	6	advmod:emph	_	SpaceAfter=No
 8	...	...	PUNCT	Punc	_	6	punct	_	_
 
@@ -6187,7 +6187,7 @@
 1	Kuru	kuru	ADJ	Adj	_	4	obj	_	_
 2	yemiş	yemiş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
 3	de	de	CCONJ	Conj	_	1	advmod:emph	_	_
-4	ister	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+4	ister	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 5	misin	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Pres	4	aux:q	_	SpaceAfter=No
 6	?	?	PUNCT	Punc	_	4	punct	_	_
 
@@ -6195,7 +6195,7 @@
 # text = Dışı seni yakar içi beni türünden.
 1	Dışı	dış	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nmod:poss	_	_
 2	seni	sen	PRON	Pers	Case=Acc|Number=Sing|Person=2|PronType=Prs	1	compound	_	_
-3	yakar	yak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound	_	_
+3	yakar	yak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	_
 4	içi	iç	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	compound	_	_
 5	beni	ben	NOUN	Noun	Case=Acc|Number=Sing|Person=3	1	compound	_	_
 6	türünden	tür	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	SpaceAfter=No
@@ -6271,7 +6271,7 @@
 19	bir	bir	NUM	ANum	NumType=Card	20	det	_	_
 20	erkekle	erkek	ADJ	NAdj	Case=Ins|Number=Sing|Person=3	21	amod	_	_
 21	sevişmeye	seviş	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	22	nmod	_	_
-22	kalkışmaz	kalkış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	29	nmod	_	SpaceAfter=No
+22	kalkışmaz	kalkış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	29	nmod	_	SpaceAfter=No
 23	,	,	PUNCT	Punc	_	24	punct	_	_
 24	öyle	öyle	ADV	Adverb	_	22	advmod	_	_
 25	değil	değil	VERB	Neg	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	24	cop	_	_
@@ -6338,7 +6338,7 @@
 # sent_id = mst-2676
 # text = Eğlence sürerken, Ömer'in yanı sıra iki çocuk daha, gözlerini tabaklardan, bardaklardan ayırmazlar; boşalan tabakları değiştirir, azalan içkileri tamamlar, yeni siparişleri alırlardı.
 1	Eğlence	eğlence	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
-2	sürerken	sür	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	15	nmod	_	SpaceAfter=No
+2	sürerken	sür	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	15	nmod	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	2	punct	_	_
 4	Ömer'in	Ömer	PROPN	Prop	Case=Gen|Number=Sing|Person=3	5	nmod:poss	_	_
 5	yanı	yan	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	amod	_	_
@@ -6351,15 +6351,15 @@
 12	tabaklardan	tabak	NOUN	Noun	Case=Abl|Number=Plur|Person=3	15	obl	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	14	punct	_	_
 14	bardaklardan	bardak	NOUN	Noun	Case=Abl|Number=Plur|Person=3	12	conj	_	_
-15	ayırmazlar	ayır	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+15	ayırmazlar	ayır	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 16	;	;	PUNCT	Punc	_	19	punct	_	_
 17	boşalan	boşal	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	18	acl	_	_
 18	tabakları	tabak	NOUN	Noun	Case=Acc|Number=Plur|Person=3	19	obj	_	_
-19	değiştirir	değiş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	15	conj	_	SpaceAfter=No
+19	değiştirir	değiş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	15	conj	_	SpaceAfter=No
 20	,	,	PUNCT	Punc	_	23	punct	_	_
 21	azalan	azal	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	22	acl	_	_
 22	içkileri	içki	NOUN	Noun	Case=Acc|Number=Plur|Person=3	23	obj	_	_
-23	tamamlar	tamamla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	15	conj	_	SpaceAfter=No
+23	tamamlar	tamamla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	15	conj	_	SpaceAfter=No
 24	,	,	PUNCT	Punc	_	27	punct	_	_
 25	yeni	yeni	ADJ	Adj	_	26	amod	_	_
 26	siparişleri	sipariş	NOUN	Noun	Case=Acc|Number=Plur|Person=3	27	obj	_	_
@@ -6447,7 +6447,7 @@
 6	Bey	bey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	compound	_	_
 7	eliyle	el	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obl	_	_
 8	sinek	sinek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
-9	kovar	kov	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	11	nmod	_	_
+9	kovar	kov	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	nmod	_	_
 10	gibi	gibi	ADP	PCNom	_	9	case	_	_
 11	yaparak	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	4	nmod	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
@@ -6542,7 +6542,7 @@
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	o	o	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	11	nsubj	_	_
 10	da	da	CCONJ	Conj	_	9	advmod:emph	_	_
-11	anlaşılabilir	anlaş	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+11	anlaşılabilir	anlaş	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-2768
@@ -6643,7 +6643,7 @@
 6	yakışan	yakış	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	acl	_	_
 7	ismi	isim	NOUN	Noun	Case=Acc|Number=Sing|Person=3	9	obj	_	_
 8	kolayca	kolayca	ADV	Adverb	_	9	advmod	_	_
-9	bulabiliriz	bul	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+9	bulabiliriz	bul	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2814
@@ -6709,7 +6709,7 @@
 # text = Bunun değerlendirilmesi gerekir.
 1	Bunun	bu	PRON	Demons	Case=Gen|Number=Sing|Person=3|PronType=Dem	2	obl	_	_
 2	değerlendirilmesi	değerlen	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=CauPass	3	obj	_	_
-3	gerekir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	gerekir	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-2850
@@ -6751,7 +6751,7 @@
 3	an	an	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
 4	ardına	art	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	_
 5	kadar	kadar	ADP	PCDat	_	4	case	_	_
-6	açılır	aç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	8	nmod	_	_
+6	açılır	aç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	8	nmod	_	_
 7	gibi	gibi	ADP	PCNom	_	6	case	_	_
 8	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	12	punct	_	_
@@ -6774,7 +6774,7 @@
 2	küçük	küçük	ADJ	Adj	_	1	compound:redup	_	_
 3	sürprizler	sürpriz	NOUN	Noun	Case=Nom|Number=Plur|Person=3	4	obj	_	_
 4	yapmaya	yap	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	obj	_	_
-5	başlar	başla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	başlar	başla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-2881
@@ -6840,7 +6840,7 @@
 # text = Harama su katmam.
 1	Harama	haram	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	2	amod	_	_
 2	su	su	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-3	katmam	kat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	2	compound	_	SpaceAfter=No
+3	katmam	kat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	2	compound	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-2911
@@ -7269,7 +7269,7 @@
 13	nedeni	neden	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obl	_	_
 14	olarak	olarak	ADP	PCNom	_	13	case	_	_
 15	buzlanmadan	buzlan	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	16	nmod	_	_
-16	bahsederken	bahset	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	20	nmod	_	_
+16	bahsederken	bahset	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	20	nmod	_	_
 17	ya	ya	CCONJ	Conj	_	20	cc	_	_
 18	bu	bu	DET	Det	_	19	det	_	_
 19	raporu	rapor	NOUN	Noun	Case=Acc|Number=Sing|Person=3	20	obj	_	_
@@ -7432,7 +7432,7 @@
 6	suya	su	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
 7	kuru	kuru	ADJ	Adj	_	8	amod	_	_
 8	ekmek	ekmek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
-9	doğrar	doğra	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	10	nmod	_	_
+9	doğrar	doğra	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	10	nmod	_	_
 10	yerlermiş	ye	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
@@ -7791,7 +7791,7 @@
 
 # sent_id = mst-3314
 # text = Okumayabilir mektubu, dedim.
-1	Okumayabilir	oku	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	4	obj	_	_
+1	Okumayabilir	oku	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	4	obj	_	_
 2	mektubu	mektup	NOUN	Noun	Case=Acc|Number=Sing|Person=3	1	obj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	1	punct	_	_
 4	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -8041,8 +8041,8 @@
 # sent_id = mst-3429
 # text = Arkamı döner dönmez hayatımda gördüğüm en güzel gözleri gördüm.
 1	Arkamı	arka	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	obj	_	_
-2	döner	dön	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	9	nmod	_	_
-3	dönmez	dön	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	2	compound	_	_
+2	döner	dön	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	nmod	_	_
+3	dönmez	dön	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	2	compound	_	_
 4	hayatımda	hayat	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	5	obl	_	_
 5	gördüğüm	gör	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	8	acl	_	_
 6	en	en	ADV	Adverb	_	7	advmod	_	_
@@ -8253,8 +8253,8 @@
 5	,	,	PUNCT	Punc	_	3	punct	_	_
 6	onun	o	PRON	Pers	Case=Gen|Number=Sing|Person=3|PronType=Prs	7	nmod:poss	_	_
 7	sorusunu	soru	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
-8	duyar	duy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	25	nmod	_	_
-9	duymaz	duy	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	8	compound	_	SpaceAfter=No
+8	duyar	duy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	25	nmod	_	_
+9	duymaz	duy	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	8	compound	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	8	punct	_	_
 11	yüzüme	yüz	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	12	obl	_	_
 12	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	14	acl	_	_
@@ -8262,7 +8262,7 @@
 14	yumruğa	yumruk	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	15	amod	_	_
 15	karşı	karşı	ADV	Adverb	_	17	advmod	_	_
 16	kolumu	kol	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	17	obj	_	_
-17	kaldırır	kal	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Cau	21	acl	_	_
+17	kaldırır	kal	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	21	acl	_	_
 18	gibi	gibi	ADP	PCNom	_	17	case	_	_
 19	içgüdüsel	içgüdüsel	ADJ	Adj	_	21	amod	_	_
 20	bir	bir	NUM	ANum	NumType=Card	21	det	_	_
@@ -8349,7 +8349,7 @@
 14	eskisinin	eski	ADJ	NAdj	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	nmod:poss	_	_
 15	öngörülerinin	öngörü	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	16	nsubj	_	_
 16	sınanmasıyla	sına	VERB	Verb	Aspect=Perf|Case=Ins|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	17	nmod	_	_
-17	gerçekleşir	gerçekleş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+17	gerçekleşir	gerçekleş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-3578
@@ -8379,7 +8379,7 @@
 # text = Yerime iyice yerleşirim.
 1	Yerime	yer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	3	obl	_	_
 2	iyice	iyice	ADV	Adverb	_	3	advmod	_	_
-3	yerleşirim	yerleş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	yerleşirim	yerleş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3594
@@ -8506,8 +8506,8 @@
 12	yaşamında	yaşam	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	obl	_	_
 13	başrol	başrol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	obj	_	_
 14	oynamasının	oyna	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	16	obj	_	_
-15	olmazsa	ol	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	16	nmod	_	_
-16	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	17	obj	_	_
+15	olmazsa	ol	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	16	nmod	_	_
+16	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	17	obj	_	_
 17	olduğuna	ol	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	18	acl	_	_
 18-19	inanmasıdır	_	_	_	_	_	_	_	SpaceAfter=No
 18	inanması	inan	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	0	root	_	_
@@ -8541,7 +8541,7 @@
 7	sol	sol	ADJ	Adj	_	8	nmod:poss	_	_
 8	göğsünün	göğüs	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	nmod:poss	_	_
 9	üstüne	üst	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	amod	_	_
-10	koyar	koy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+10	koyar	koy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	conj	_	_
 
 # sent_id = mst-3660
@@ -8921,7 +8921,7 @@
 # sent_id = mst-3800
 # text = Sonra çıkarsın alışverişe.
 1	Sonra	sonra	ADV	Adverb	_	2	advmod	_	_
-2	çıkarsın	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	0	root	_	_
+2	çıkarsın	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	_
 3	alışverişe	alışveriş	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	compound	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -8955,7 +8955,7 @@
 5	alıyorum	al	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	4	compound	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	7	punct	_	_
 7	demek	de	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nsubj	_	_
-8	geçer	geç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+8	geçer	geç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 9	aklınızın	akıl	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	8	compound	_	_
 10	bir	bir	NUM	ANum	NumType=Card	8	compound	_	_
 11	köşesinden	köşe	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	compound	_	SpaceAfter=No
@@ -9079,7 +9079,7 @@
 3	sonra	sonra	ADV	Adverb	_	0	root	_	_
 4	da	da	CCONJ	Conj	_	3	advmod:emph	_	_
 5	o	o	DET	Det	_	6	det	_	_
-6	dayanılmaz	dayan	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	7	acl	_	_
+6	dayanılmaz	dayan	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	7	acl	_	_
 7	bekleyişe	bekleyiş	NOUN	Noun	Case=Dat|Number=Sing|Person=3	14	obl	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	14	punct	_	_
 9	o	o	DET	Det	_	10	det	_	_
@@ -9087,7 +9087,7 @@
 11	etmesi	et	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	10	compound	_	_
 12	zor	zor	ADJ	Adj	_	13	amod	_	_
 13	gerilime	gerilim	NOUN	Noun	Case=Dat|Number=Sing|Person=3	14	obl	_	_
-14	alışır	alış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+14	alışır	alış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-3873
@@ -9198,7 +9198,7 @@
 5	ondokuz	ondokuz	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	14	nummod	_	_
 6	Ocak'a	Ocak	PROPN	Prop	Case=Dat|Number=Sing|Person=3	5	flat	_	_
 7	kadar	kadar	ADP	PCDat	_	5	case	_	_
-8	onarsa	ona	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	14	nmod	_	_
+8	onarsa	ona	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	14	nmod	_	_
 9	Akgündüz	Akgündüz	PROPN	Prop	Case=Nom|Number=Sing|Person=3	14	nsubj	_	_
 10	Siirt'te	Siirt	PROPN	Prop	Case=Loc|Number=Sing|Person=3	14	obl	_	_
 11	yapılacak	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	12	acl	_	_
@@ -9326,7 +9326,7 @@
 1	Selma	Selma	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	7	punct	_	_
 3	Bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	5	obl	_	_
-4	denenebilir	dene	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	5	obj	_	_
+4	denenebilir	dene	VERB	Verb	Aspect=Hab|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	5	obj	_	_
 5	görünüyor	görün	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	7	obj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	5	punct	_	_
 7	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -9513,7 +9513,7 @@
 10	üç	üç	NUM	ANum	NumType=Card	9	flat	_	_
 11	çoğunlukla	çoğunluk	NOUN	Noun	Case=Ins|Number=Sing|Person=3	12	obl	_	_
 12	alınması	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	13	nsubj	_	_
-13	gerekir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+13	gerekir	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-4067
@@ -9538,7 +9538,7 @@
 5	dahiler	dahi	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	1	conj	_	_
 6	tek	tek	ADJ	Adj	_	7	amod	_	_
 7	öğrenimle	öğrenim	NOUN	Noun	Case=Ins|Number=Sing|Person=3	8	obl	_	_
-8	yetinmezler	yet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+8	yetinmezler	yet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-4079
@@ -9613,7 +9613,7 @@
 3	hiçbir	hiçbir	DET	Det	_	6	obl	_	_
 4	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	fixed	_	_
 5	emin	emin	ADJ	Adj	_	6	obj	_	_
-6	olamam	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	1	conj	_	SpaceAfter=No
+6	olamam	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	1	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-4120
@@ -9687,9 +9687,9 @@
 2	bin	bin	NUM	ANum	NumType=Card	1	flat	_	_
 3	gayrimenkul	gayrimenkul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod	_	_
 4	birden	birden	ADV	Adverb	_	5	advmod	_	_
-5	satarsak	sat	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	7	nmod	_	_
+5	satarsak	sat	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	7	nmod	_	_
 6	piyasa	piyasa	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
-7	bozulur	boz	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+7	bozulur	boz	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-4150
@@ -9728,7 +9728,7 @@
 4	seçime	seçim	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
 5	yaklaşıldıkça	yaklaş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	7	nmod	_	_
 6	pozisyon	pozisyon	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
-7	alabilir	al	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+7	alabilir	al	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-4167
@@ -9889,7 +9889,7 @@
 7	gereksinimi	gereksinim	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
 8	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	acl	_	_
 9	herkes	herkes	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
-10	isterse	iste	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	24	nmod	_	_
+10	isterse	iste	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	24	nmod	_	_
 11	kendisi	kendi	PRON	Reflex	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	26	nsubj	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	26	punct	_	_
 13	minimum	minimum	ADJ	Adj	_	14	amod	_	_
@@ -9901,7 +9901,7 @@
 19	gecekondu	gecekondu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	obj	_	_
 20	yapım	yapım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	nmod:poss	_	_
 21	sürecine	süreç	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	22	nmod	_	_
-22	benzer	benze	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	23	acl	_	_
+22	benzer	benze	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	23	acl	_	_
 23	şekilde	şekil	NOUN	Noun	Case=Loc|Number=Sing|Person=3	15	conj	_	_
 24	gerçekleştirebilme	gerçekleş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	25	nmod:poss	_	_
 25	hakkına	hak	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	26	nmod	_	_
@@ -9974,11 +9974,11 @@
 15	sabah	sabah	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	obl	_	_
 16	kahvaltıda	kahvaltı	NOUN	Noun	Case=Loc|Number=Sing|Person=3	22	obl	_	_
 17	makarna	makarna	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	obj	_	_
-18	yer	ye	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	11	conj	_	SpaceAfter=No
+18	yer	ye	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	conj	_	SpaceAfter=No
 19	,	,	PUNCT	Punc	_	22	punct	_	_
 20	yağlı	yağlı	ADJ	Adj	_	21	amod	_	_
 21	et	et	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	obj	_	_
-22	yer	ye	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	11	conj	_	SpaceAfter=No
+22	yer	ye	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	conj	_	SpaceAfter=No
 23	.	.	PUNCT	Punc	_	22	punct	_	_
 
 # sent_id = mst-4268
@@ -10058,13 +10058,13 @@
 12	kesin	kesin	ADJ	Adj	_	14	amod	_	_
 13	bir	bir	NUM	ANum	NumType=Card	14	det	_	_
 14	şekilde	şekil	NOUN	Noun	Case=Loc|Number=Sing|Person=3	15	obl	_	_
-15	söylerler	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	21	nmod	_	_
+15	söylerler	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	21	nmod	_	_
 16	ki	ki	CCONJ	Conj	_	15	mark	_	SpaceAfter=No
 17	;	;	PUNCT	Punc	_	15	punct	_	_
-18	inanırsanız	inan	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	21	nmod	_	_
+18	inanırsanız	inan	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	21	nmod	_	_
 19	sonra	sonra	ADV	Adverb	_	21	advmod	_	_
 20	çok	çok	ADV	Adverb	_	21	advmod	_	_
-21	şaşırırsınız	şaşır	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+21	şaşırırsınız	şaşır	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 22	.	.	PUNCT	Punc	_	21	punct	_	_
 
 # sent_id = mst-4303
@@ -10095,7 +10095,7 @@
 8	yararlı	yararlı	ADJ	Adj	_	9	amod	_	_
 9	konutları	konut	NOUN	Noun	Case=Acc|Number=Plur|Person=3	10	obj	_	_
 10	yapmak	yap	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	11	nsubj	_	_
-11	gerekir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	13	nmod	_	_
+11	gerekir	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	13	nmod	_	_
 12	diye	diye	ADP	PCNom	_	11	case	_	_
 13	düşündüm	düşün	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	14	obj	_	_
 14	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -10157,7 +10157,7 @@
 24	AB'ye	Ab	NOUN	Abr	Abbr=Yes|Case=Dat|Number=Sing|Person=3	25	nmod	_	_
 25	üye	üye	NOUN	Noun	Case=Nom|Number=Sing|Person=3	27	obj	_	_
 26	olmasını	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	25	compound:lvc	_	_
-27	engelleyebilir	engelle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+27	engelleyebilir	engelle	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 28	.	.	PUNCT	Punc	_	27	punct	_	_
 
 # sent_id = mst-4343
@@ -10167,7 +10167,7 @@
 3-4	ederim	_	_	_	_	_	_	_	_
 3	eder	eder	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound:lvc	_	_
 4	im	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	2	cop	_	_
-5	kaçarım	kaç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	2	conj	_	_
+5	kaçarım	kaç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	2	conj	_	_
 6	uzaklara	uzak	ADJ	NAdj	Case=Dat|Number=Plur|Person=3	5	amod	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
@@ -10252,7 +10252,7 @@
 8	Rusya'da	Rusya	PROPN	Prop	Case=Loc|Number=Sing|Person=3	11	obl	_	_
 9	Başbakan'ı	Başbakan	PROPN	Prop	Case=Acc|Number=Sing|Person=3	11	obj	_	_
 10	bile	bile	ADV	Adverb	_	11	advmod	_	_
-11	bulamazsın	bul	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Tense=Aor	4	conj	_	SpaceAfter=No
+11	bulamazsın	bul	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	4	conj	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-4381
@@ -10260,7 +10260,7 @@
 1	O	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	da	da	CCONJ	Conj	_	1	advmod:emph	_	_
 3	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
-4	bekler	bekle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	bekler	bekle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4385
@@ -10338,7 +10338,7 @@
 
 # sent_id = mst-4414
 # text = Yenir sabah akşam, gündüz gece.
-1	Yenir	ye	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	_
+1	Yenir	ye	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	_
 2	sabah	sabah	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	obl	_	_
 3	akşam	akşam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound:redup	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	5	punct	_	_
@@ -10371,7 +10371,7 @@
 # text = Düşünmezsin tabii, hangi baba oğul iktidar kavgasına girmemiştir, kaç baba oğul her an patlamaya hazır öfkelerini dizginleyip sevip okşayabilmiştir birbirini.
 # Change 2.2/dev: mark 'kaç' as NUM
 # Change 2.2/dev: mark 'hangi' as DET
-1	Düşünmezsin	düşün	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Neg|Tense=Aor	0	root	_	_
+1	Düşünmezsin	düşün	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	0	root	_	_
 2	tabii	tabii	ADJ	Adj	_	1	amod	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	1	punct	_	_
 4	hangi	hangi	DET	Adj	_	5	det	_	_
@@ -10425,7 +10425,7 @@
 # text = Şimdi nasıl olur böyle bir şey, inanamıyorum.
 1	Şimdi	şimdi	ADV	Adverb	_	3	advmod	_	_
 2	nasıl	nasıl	ADV	Adverb	_	3	advmod	_	_
-3	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+3	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 4	böyle	böyle	ADJ	Adj	_	5	amod	_	_
 5	bir	bir	NUM	ANum	NumType=Card	3	nsubj	_	_
 6	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	compound	_	SpaceAfter=No
@@ -10520,7 +10520,7 @@
 # text = Neşesi yerine gelir gibi oldu.
 1	Neşesi	neşe	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	nsubj	_	_
 2	yerine	yer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
-3	gelir	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	compound	_	_
+3	gelir	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	compound	_	_
 4	gibi	gibi	ADP	PCNom	_	2	case	_	_
 5	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
@@ -10530,7 +10530,7 @@
 1	Yeniden	yeniden	ADV	Adverb	_	4	advmod	_	_
 2	sizi	siz	PRON	Pers	Case=Acc|Number=Plur|Person=2|PronType=Prs	3	obj	_	_
 3	düşünmeye	düşün	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	nmod	_	_
-4	başlayabilir	başla	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	başlayabilir	başla	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4492
@@ -10836,7 +10836,7 @@
 4	görüşmenin	görüşme	NOUN	Noun	Case=Gen|Number=Sing|Person=3	8	nmod:poss	_	_
 5	ipe	ip	NOUN	Noun	Case=Dat|Number=Sing|Person=3	8	obl	_	_
 6	sapa	sap	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	compound	_	_
-7	gelmez	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	5	compound	_	_
+7	gelmez	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	5	compound	_	_
 8	konuşmaları	konuş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	0	root	_	SpaceAfter=No
 9	...	...	PUNCT	Punc	_	8	punct	_	_
 
@@ -10897,7 +10897,7 @@
 2	:	:	PUNCT	Punc	_	7	punct	_	_
 3	Ayhan	Ayhan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	nsubj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	7	punct	_	_
-5	sanırım	san	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	1	conj	_	_
+5	sanırım	san	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	1	conj	_	_
 6	ondört	ondört	NUM	ANum	NumType=Card	7	nummod	_	_
 7-8	yaşındaydı	_	_	_	_	_	_	_	SpaceAfter=No
 7	yaşında	yaşında	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
@@ -10945,7 +10945,7 @@
 7	pişmanlıklarla	pişmanlık	NOUN	Noun	Case=Ins|Number=Plur|Person=3	10	obl	_	_
 8	ve	ve	CCONJ	Conj	_	9	cc	_	_
 9	sıkıntıyla	sıkıntı	NOUN	Noun	Case=Ins|Number=Sing|Person=3	7	conj	_	_
-10	uyanırım	uyan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+10	uyanırım	uyan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-4681
@@ -11068,7 +11068,7 @@
 9	bir	bir	NUM	ANum	NumType=Card	10	det	_	_
 10	an	an	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obl	_	_
 11	titrediğini	titre	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	12	obj	_	_
-12	hissederim	hisset	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+12	hissederim	hisset	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-4737
@@ -11323,7 +11323,7 @@
 9	alınması	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	4	conj	_	_
 10	durumunda	durum	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	obl	_	_
 11	işler	iş	NOUN	Noun	Case=Nom|Number=Plur|Person=3	12	nsubj	_	_
-12	karışabilir	karış	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+12	karışabilir	karış	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-4834
@@ -11425,7 +11425,7 @@
 # text = Bunu ne anlar ne de inanırdı.
 1	Bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	3	obj	_	_
 2	ne	ne	CCONJ	Conj	_	3	cc	_	_
-3	anlar	anla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+3	anlar	anla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 4	ne	ne	CCONJ	Conj	_	6	cc	_	_
 5	de	de	CCONJ	Conj	_	4	advmod:emph	_	_
 6	inanırdı	inan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	conj	_	SpaceAfter=No
@@ -11435,7 +11435,7 @@
 # text = Kabul etmek gerekir ki günümüz toplumu bağımlı bir toplum.
 1	Kabul	kabul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 2	etmek	et	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	1	compound:lvc	_	_
-3	gerekir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	4	nmod	_	_
+3	gerekir	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	nmod	_	_
 4	ki	ki	CCONJ	Conj	_	0	root	_	_
 5	günümüz	gün	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	6	nmod:poss	_	_
 6	toplumu	toplum	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	nsubj	_	_
@@ -11495,7 +11495,7 @@
 2	,	,	PUNCT	Punc	_	5	punct	_	_
 3	ikisine	iki	NUM	NNum	Case=Dat|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=3	5	nummod	_	_
 4	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
-5	uyar	uy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	uyar	uy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4909
@@ -11591,7 +11591,7 @@
 # sent_id = mst-4945
 # text = Beni görmez bile.
 1	Beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	_	_
-2	görmez	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	_
+2	görmez	gör	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
 3	bile	bile	ADV	Adverb	_	2	advmod:emph	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -11606,7 +11606,7 @@
 # text = Başka makineler oyalayamaz beni.
 1	Başka	başka	ADJ	Adj	_	2	amod	_	_
 2	makineler	makine	NOUN	Noun	Case=Nom|Number=Plur|Person=3	3	obj	_	_
-3	oyalayamaz	oyala	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	_
+3	oyalayamaz	oyala	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
 4	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -11706,10 +11706,10 @@
 2	birine	bir	NUM	NNum	Case=Dat|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=2	5	nummod	_	_
 3	bir	bir	NUM	ANum	NumType=Card	5	obj	_	_
 4	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	compound	_	_
-5	verirse	ver	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	8	nmod	_	SpaceAfter=No
+5	verirse	ver	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	5	punct	_	_
 7	acıdan	acı	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	8	amod	_	_
-8	büzülürüm	büz	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	_
+8	büzülürüm	büz	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	_
 9	yerimde	yer	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	8	obl	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	8	punct	_	_
 
@@ -11730,9 +11730,9 @@
 1	O	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	da	da	CCONJ	Conj	_	1	advmod:emph	_	_
 3	herkese	herkes	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
-4	gülümser	gülümse	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	gülümser	gülümse	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	6	punct	_	_
-6	şakalaşır	şakalaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	4	conj	_	SpaceAfter=No
+6	şakalaşır	şakalaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	conj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	15	punct	_	_
 8	saçlarına	saç	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	10	obl	_	_
 9	kurdele	kurdele	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
@@ -11921,7 +11921,7 @@
 # text = Artık sitede görüşürüz.
 1	Artık	artık	ADV	Adverb	_	3	advmod	_	_
 2	sitede	site	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
-3	görüşürüz	görüş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	görüşürüz	görüş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-5092
@@ -11952,11 +11952,11 @@
 4	her	her	DET	Det	_	7	nsubj	_	_
 5	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	compound	_	_
 6	birden	birden	ADV	Adverb	_	7	advmod	_	_
-7	tutuşur	tutuş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+7	tutuşur	tutuş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	11	punct	_	_
 9	ateş	ateş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obl	_	_
 10	gibi	gibi	ADP	PCNom	_	9	case	_	_
-11	yakar	yak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	conj	_	SpaceAfter=No
+11	yakar	yak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	conj	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-5106
@@ -12009,7 +12009,7 @@
 
 # sent_id = mst-5122
 # text = Görüşürüz. deyip kapattım.
-1	Görüşürüz	görüş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	3	obj	_	SpaceAfter=No
+1	Görüşürüz	görüş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	3	obj	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 3	deyip	dey	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	4	nmod	_	_
 4	kapattım	kapa	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
@@ -12177,11 +12177,11 @@
 # text = Eğer annem evlenirse ben bu evde yaşayamam.
 1	Eğer	eğer	CCONJ	Conj	_	3	nmod	_	_
 2	annem	anne	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	3	nsubj	_	_
-3	evlenirse	evlen	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	nmod	_	_
+3	evlenirse	evlen	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	nmod	_	_
 4	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	_	_
 5	bu	bu	DET	Det	_	6	det	_	_
 6	evde	ev	NOUN	Noun	Case=Loc|Number=Sing|Person=3	7	obl	_	_
-7	yaşayamam	yaşa	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+7	yaşayamam	yaşa	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-5218
@@ -12242,7 +12242,7 @@
 10	kalkmasına	kalk	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	compound	_	_
 11	neden	neden	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obj	_	_
 12	olacağını	olacak	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	compound:lvc	_	_
-13	belirtirken	belir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv|Voice=Cau	26	nmod	_	SpaceAfter=No
+13	belirtirken	belir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	26	nmod	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	13	punct	_	_
 15	Türklerin	Türk	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	16	nmod:poss	_	_
 16	yaşadığı	yaşa	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	21	acl	_	_
@@ -12263,11 +12263,11 @@
 # text = Bazen beni üzer, sonra birdenbire sevindirir.
 1	Bazen	bazen	ADV	Adverb	_	3	advmod	_	_
 2	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	3	obj	_	_
-3	üzer	üz	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	üzer	üz	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	7	punct	_	_
 5	sonra	sonra	ADV	Adverb	_	7	advmod	_	_
 6	birdenbire	birdenbire	ADV	Adverb	_	7	advmod	_	_
-7	sevindirir	sevin	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	3	conj	_	SpaceAfter=No
+7	sevindirir	sevin	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	3	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-5264
@@ -12318,7 +12318,7 @@
 6	olacağını	olacak	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obj	_	_
 7	duyunca	duy	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	11	nmod	_	_
 8	biraz	biraz	ADJ	Adj	_	9	det	_	_
-9	üzülür	üz	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	11	acl	_	_
+9	üzülür	üz	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	11	acl	_	_
 10	gibi	gibi	ADP	PCNom	_	9	case	_	_
 11	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
@@ -12457,7 +12457,7 @@
 6	İstanbul'dan	İstanbul	PROPN	Prop	Case=Abl|Number=Sing|Person=3	9	obl	_	_
 7	uçakla	uçak	NOUN	Noun	Case=Ins|Number=Sing|Person=3	9	obl	_	_
 8	Urfa'ya	Urfa	PROPN	Prop	Case=Dat|Number=Sing|Person=3	9	obl	_	_
-9	giderken	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	13	nmod	_	_
+9	giderken	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	13	nmod	_	_
 10	tesadüfen	tesadüfen	ADV	Adverb	_	13	advmod	_	_
 11	yanımda	yan	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	13	amod	_	_
 12	biri	biri	PRON	Quant	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	13	det	_	_
@@ -12568,7 +12568,7 @@
 12	,	,	PUNCT	Punc	_	21	punct	_	_
 13	akşam	akşam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	nsubj	_	_
 14	üzeri	üzer	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	compound	_	_
-15	yaklaşırken	yaklaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	21	nmod	_	SpaceAfter=No
+15	yaklaşırken	yaklaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	21	nmod	_	SpaceAfter=No
 16	,	,	PUNCT	Punc	_	15	punct	_	_
 17	kısa	kısa	ADJ	Adj	_	18	amod	_	_
 18	sürecek	sür	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	20	acl	_	_
@@ -12758,7 +12758,7 @@
 1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 2	uyduruk	uyduruk	ADJ	Adj	_	3	amod	_	_
 3	araba	araba	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
-4	silmem	sil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	6	obj	_	SpaceAfter=No
+4	silmem	sil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	6	obj	_	SpaceAfter=No
 5	!	!	PUNCT	Punc	_	4	punct	_	_
 6	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 7	sürücüye	sürücü	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	SpaceAfter=No
@@ -12768,14 +12768,14 @@
 # text = Kadınlar satın alırken daha mı detaylı inceleme yaparlar?.
 1	Kadınlar	kadın	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	8	nsubj	_	_
 2	satın	satın	ADV	Adverb	_	8	advmod	_	_
-3	alırken	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	2	compound	_	_
+3	alırken	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	2	compound	_	_
 4	daha	daha	ADV	Adverb	_	6	advmod	_	_
 5	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	4	aux:q	_	_
 6-7	detaylı	_	_	_	_	_	_	_	_
 6	detay	detay	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
 7	lı	li	ADP	With	_	6	case	_	_
 8	inceleme	incele	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	0	root	_	_
-9	yaparlar	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	8	compound:lvc	_	SpaceAfter=No
+9	yaparlar	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	8	compound:lvc	_	SpaceAfter=No
 10	?	?	PUNCT	Punc	_	8	punct	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	8	punct	_	_
 
@@ -12804,7 +12804,7 @@
 21	de	de	CCONJ	Conj	_	20	advmod:emph	_	_
 22	yine	yine	ADV	Adverb	_	23	advmod	_	_
 23	alanlara	alan	NOUN	Noun	Case=Dat|Number=Plur|Person=3	24	obl	_	_
-24	çıkarız	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	14	conj	_	SpaceAfter=No
+24	çıkarız	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	14	conj	_	SpaceAfter=No
 25	.	.	PUNCT	Punc	_	24	punct	_	_
 
 # sent_id = mst-5478
@@ -12849,7 +12849,7 @@
 1	Bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	3	nmod	_	_
 2	bir	bir	NUM	ANum	NumType=Card	3	det	_	_
 3	yol	yol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-4	gösterebilir	göster	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	3	compound	_	_
+4	gösterebilir	göster	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	compound	_	_
 5	misiniz	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	3	aux:q	_	SpaceAfter=No
 6	?	?	PUNCT	Punc	_	3	punct	_	_
 
@@ -12876,7 +12876,7 @@
 3	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	conj	_	_
 4	de	de	CCONJ	Conj	_	3	cc	_	_
 5	TV	tv	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	7	obl	_	_
-6	seyrederken	seyret	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	5	compound	_	_
+6	seyrederken	seyret	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	5	compound	_	_
 7	düşüneceğim	düşün	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Fut	0	root	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	10	punct	_	_
 9	niçin	niçin	ADV	Adverb	_	10	advmod	_	_
@@ -13022,7 +13022,7 @@
 
 # sent_id = mst-5568
 # text = Yapamam bunu.
-1	Yapamam	yap	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	_
+1	Yapamam	yap	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	_
 2	bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	1	obj	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
@@ -13035,7 +13035,7 @@
 5	kadar	kadar	ADP	PCDat	_	4	case	_	_
 6	yaramaz	yaramaz	ADJ	Adj	_	8	amod	_	_
 7	ki	ki	CCONJ	Conj	_	6	mark	_	_
-8	anlatamam	anlat	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+8	anlatamam	anlat	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-5573

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -2993,7 +2993,7 @@
 # text = Toplantıda DYP'li kadınlar, Çiller'in kendileriyle görüşmemesi üzerine, " En çok biz çalışıyoruz.
 1	Toplantıda	toplantı	NOUN	Noun	Case=Loc|Number=Sing|Person=3	9	nmod	_	_
 2-3	DYP'li	_	_	_	_	_	_	_	_
-2	DYP	Dyp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	4	compound	_	_
+2	DYP	DYP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	4	compound	_	_
 3	'li	li	ADP	With	_	2	case	_	_
 4	kadınlar	kadın	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	9	nsubj	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	9	punct	_	_
@@ -7240,7 +7240,7 @@
 
 # sent_id = mst-3101
 # text = İMKB'nin uzun vadeli ortalaması yuzon sent seviyesinden geçiyor.
-1	İMKB'nin	İmkb	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	5	nmod:poss	_	_
+1	İMKB'nin	İMKB	PROPN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	5	nmod:poss	_	_
 2	uzun	uzun	ADJ	Adj	_	3	amod	_	_
 3-4	vadeli	_	_	_	_	_	_	_	_
 3	vade	vade	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
@@ -11507,9 +11507,9 @@
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4911
-# text = İtü'lüdür ama dediğini bilen biridir Ayhan.
-1-3	İtü'lüdür	_	_	_	_	_	_	_	_
-1	İtü	İtü	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	_
+# text = İTÜ'lüdür ama dediğini bilen biridir Ayhan.
+1-3	İTÜ'lüdür	_	_	_	_	_	_	_	_
+1	İTÜ	İTÜ	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	_
 2	'lü	li	ADP	With	_	1	case	_	_
 3	dür	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	1	cop	_	_
 4	ama	ama	CCONJ	Conj	_	7	cc	_	_
@@ -12356,7 +12356,7 @@
 # sent_id = mst-5308
 # text = Aslında İMKB ve A tipi fon performansları arasındaki ilişki tamamen fon türleriyle ilintili.
 1	Aslında	aslında	ADV	Adverb	_	14	advmod	_	_
-2	İMKB	İmkb	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	nmod:poss	_	_
+2	İMKB	İMKB	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	nmod:poss	_	_
 3	ve	ve	CCONJ	Conj	_	6	cc	_	_
 4	A	a	INTJ	Interj	_	14	discourse	_	_
 5	tipi	tip	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	compound	_	_

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -5901,8 +5901,9 @@
 
 # sent_id = mst-2511
 # text = -Kaç numarada oturuyorsunuz.
+# Change 2.2/dev: mark 'kaç' as NUM
 1	-	-	PUNCT	Punc	_	0	root	_	SpaceAfter=No
-2	Kaç	kaç	ADJ	Adj	_	3	amod	_	_
+2	Kaç	kaç	NUM	Adj	NumType=Card	3	nummod	_	_
 3	numarada	numara	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 4	oturuyorsunuz	otur	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
@@ -7955,9 +7956,10 @@
 
 # sent_id = mst-3391
 # text = Her gün kaç çuval kağıt topluyor.
+# Change 2.2/dev: mark 'kaç' as NUM
 1	Her	her	DET	Det	_	6	obl	_	_
 2	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	fixed	_	_
-3	kaç	kaç	ADJ	Adj	_	4	amod	_	_
+3	kaç	kaç	NUM	Adj	NumType=Card	4	nummod	_	_
 4	çuval	çuval	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obj	_	_
 5	kağıt	kağıt	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	6	obj	_	_
 6	topluyor	topla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
@@ -10354,6 +10356,7 @@
 
 # sent_id = mst-4424
 # text = Düşünmezsin tabii, hangi baba oğul iktidar kavgasına girmemiştir, kaç baba oğul her an patlamaya hazır öfkelerini dizginleyip sevip okşayabilmiştir birbirini.
+# Change 2.2/dev: mark 'kaç' as NUM
 1	Düşünmezsin	düşün	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Neg|Tense=Aor	0	root	_	_
 2	tabii	tabii	ADJ	Adj	_	1	amod	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	1	punct	_	_
@@ -10364,7 +10367,7 @@
 8	kavgasına	kavga	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
 9	girmemiştir	gir	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Gen|Number=Sing|Person=3|Polarity=Neg|Tense=Past	1	conj	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	21	punct	_	_
-11	kaç	kaç	ADJ	Adj	_	12	amod	_	_
+11	kaç	kaç	NUM	Adj	NumType=Card	12	nummod	_	_
 12	baba	baba	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	nsubj	_	_
 13	oğul	oğul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	compound	_	_
 14	her	her	DET	Det	_	17	det	_	_

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -10258,15 +10258,14 @@
 
 # sent_id = mst-4385
 # text = Asıl yıkıcı darbe ise sömürgecilikle gelmişti.
+# Change 2.2/dev: merge -(y)IcI
 1	Asıl	asıl	ADJ	Adj	_	2	amod	_	_
-2-3	yıkıcı	_	_	_	_	_	_	_	_
-2	yık	yık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	4	nmod	_	_
-3	ıcı	ci	ADP	Agt	_	2	case	_	_
-4	darbe	darbe	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
-5	ise	ise	CCONJ	Conj	_	4	discourse	_	_
-6	sömürgecilikle	sömürgecilik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	7	obl	_	_
-7	gelmişti	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
-8	.	.	PUNCT	Punc	_	7	punct	_	_
+2	yıkıcı	yık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	acl	_	_
+3	darbe	darbe	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
+4	ise	ise	CCONJ	Conj	_	3	discourse	_	_
+5	sömürgecilikle	sömürgecilik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	6	obl	_	_
+6	gelmişti	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
+7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-4388
 # text = Erik çalmaya gittik öğretmenim, dedi.
@@ -11615,6 +11614,7 @@
 
 # sent_id = mst-4961
 # text = Ben: Müzik koyayım mı? Şöyle rahatlatıcı bir şeyler.
+# Change 2.2/dev: merge -(y)IcI
 1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	0	root	_	SpaceAfter=No
 2	:	:	PUNCT	Punc	_	4	punct	_	_
 3	Müzik	müzik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
@@ -11622,12 +11622,10 @@
 5	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	4	aux:q	_	SpaceAfter=No
 6	?	?	PUNCT	Punc	_	10	punct	_	_
 7	Şöyle	şöyle	ADV	Adverb	_	10	advmod	_	_
-8-9	rahatlatıcı	_	_	_	_	_	_	_	_
-8	rahatlat	rahatla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|Voice=Cau	10	nmod	_	_
-9	ıcı	ci	ADP	Agt	_	8	case	_	_
-10	bir	bir	NUM	ANum	NumType=Card	1	conj	_	_
-11	şeyler	şey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	10	compound	_	SpaceAfter=No
-12	.	.	PUNCT	Punc	_	10	punct	_	_
+8	rahatlatıcı	rahatla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	10	acl	_	_
+9	bir	bir	NUM	ANum	NumType=Card	10	det	_	_
+10	şeyler	şey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	3	compound	_	SpaceAfter=No
+11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-4966
 # text = Doğa yasaları Tanrı için de bağlayıcıdır ve doğa olaylarına istediği gibi müdahale hakkı Tanrı'nın elinden alınmıştır.
@@ -11780,29 +11778,28 @@
 
 # sent_id = mst-5031
 # text = Bu dönemde, bilimsel bulguların, teknoloji aracılığıyla üretime dönüşmesi, yani bilimin üretici güç yönü çok zayıftır.
+# Change 2.2/dev: merge -(y)IcI
 1	Bu	bu	DET	Det	_	2	det	_	_
-2	dönemde	dönem	NOUN	Noun	Case=Loc|Number=Sing|Person=3	19	obl	_	SpaceAfter=No
-3	,	,	PUNCT	Punc	_	19	punct	_	_
+2	dönemde	dönem	NOUN	Noun	Case=Loc|Number=Sing|Person=3	18	obl	_	SpaceAfter=No
+3	,	,	PUNCT	Punc	_	18	punct	_	_
 4	bilimsel	bilimsel	ADJ	Adj	_	5	amod	_	_
 5	bulguların	bulgu	NOUN	Noun	Case=Gen|Number=Plur|Person=3	10	nmod:poss	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	10	punct	_	_
 7	teknoloji	teknoloji	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
 8	aracılığıyla	aracılık	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obl	_	_
 9	üretime	üretim	NOUN	Noun	Case=Dat|Number=Sing|Person=3	10	obl	_	_
-10	dönüşmesi	dönüş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	19	nsubj	_	SpaceAfter=No
-11	,	,	PUNCT	Punc	_	17	punct	_	_
-12	yani	yani	CCONJ	Conj	_	17	cc	_	_
-13	bilimin	bilim	NOUN	Noun	Case=Gen|Number=Sing|Person=3	17	nmod:poss	_	_
-14-15	üretici	_	_	_	_	_	_	_	_
-14	üret	üre	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|Voice=Cau	16	nmod	_	_
-15	ici	ci	ADP	Agt	_	14	case	_	_
-16	güç	güç	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	17	nmod:poss	_	_
-17	yönü	yön	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	conj	_	_
-18	çok	çok	ADV	Adverb	_	19	advmod	_	_
-19-20	zayıftır	_	_	_	_	_	_	_	SpaceAfter=No
-19	zayıf	zayıf	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
-20	tır	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	19	cop	_	_
-21	.	.	PUNCT	Punc	_	19	punct	_	_
+10	dönüşmesi	dönüş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	18	nsubj	_	SpaceAfter=No
+11	,	,	PUNCT	Punc	_	16	punct	_	_
+12	yani	yani	CCONJ	Conj	_	16	cc	_	_
+13	bilimin	bilim	NOUN	Noun	Case=Gen|Number=Sing|Person=3	16	nmod:poss	_	_
+14	üretici	üre	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	15	acl	_	_
+15	güç	güç	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	16	nmod:poss	_	_
+16	yönü	yön	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	conj	_	_
+17	çok	çok	ADV	Adverb	_	18	advmod	_	_
+18-19	zayıftır	_	_	_	_	_	_	_	SpaceAfter=No
+18	zayıf	zayıf	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
+19	tır	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	18	cop	_	_
+20	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-5042
 # text = Birden hatırladı.

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -493,7 +493,7 @@
 9	,	,	PUNCT	Punc	_	11	punct	_	_
 10	büyük	büyük	ADJ	Adj	_	11	amod	_	_
 11	kelam	kelam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	conj	_	_
-12	etmezdi	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	11	compound:lvc	_	SpaceAfter=No
+12	etmezdi	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	11	compound:lvc	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-0234
@@ -872,7 +872,7 @@
 7	ve	ve	CCONJ	Conj	_	9	cc	_	_
 8	kaynar	kayna	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	9	acl	_	_
 9	suyla	su	NOUN	Noun	Case=Ins|Number=Sing|Person=3	6	conj	_	_
-10	yırtamazdım	yırt	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=AorPast	1	conj	_	_
+10	yırtamazdım	yırt	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Past	1	conj	_	_
 11	herhalde	herhalde	ADV	Adverb	_	10	advmod	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	10	punct	_	_
 
@@ -1281,7 +1281,7 @@
 12	Selo'yu	Selo	PROPN	Prop	Case=Acc|Number=Sing|Person=3	9	conj	_	_
 13	bu	bu	DET	Det	_	14	det	_	_
 14	tarafa	taraf	NOUN	Noun	Case=Dat|Number=Sing|Person=3	15	obl	_	_
-15	çekebilirdik	çek	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=AorPast	3	conj	_	SpaceAfter=No
+15	çekebilirdik	çek	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Past	3	conj	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-0544
@@ -1374,7 +1374,7 @@
 4	peynir	peynir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
 5	aynı	aynı	ADJ	Adj	_	6	amod	_	_
 6	tadı	tat	NOUN	Noun	Case=Acc|Number=Sing|Person=3	7	obj	_	_
-7	vermezmiş	ver	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
+7	vermezmiş	ver	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-0583
@@ -1947,7 +1947,7 @@
 # sent_id = mst-0850
 # text = Toz kondurmazdım vallahi mutluluğumuza.
 1	Toz	toz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	kondurmazdım	kon	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=AorPast|Voice=Cau	1	compound	_	_
+2	kondurmazdım	kon	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Past|Voice=Cau	1	compound	_	_
 3	vallahi	vallahi	ADV	Adverb	_	1	advmod	_	_
 4	mutluluğumuza	mutluluk	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	1	nmod	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	1	punct	_	_
@@ -2675,7 +2675,7 @@
 9	yakışan	yakış	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	acl	_	_
 10	bir	bir	NUM	ANum	NumType=Card	11	det	_	_
 11	sözcük	sözcük	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
-12	olamazdı	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	2	conj	_	SpaceAfter=No
+12	olamazdı	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Past	2	conj	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-1137
@@ -3020,7 +3020,7 @@
 7	hava	hava	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
 8	akımı	akım	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	conj	_	_
 9	taklit	taklit	ADJ	Adj	_	1	conj	_	_
-10	edilemezmiş	et	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast|Voice=Pass	9	compound:lvc	_	SpaceAfter=No
+10	edilemezmiş	et	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Past|Voice=Pass	9	compound:lvc	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-1288
@@ -3493,11 +3493,11 @@
 # Change 2.2/dev: merge -CA
 1	Onca	onca	ADJ	Adj	_	2	amod	_	_
 2	sopayı	sopa	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	nmod	_	_
-3	yerdi	ye	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	2	compound	_	_
+3	yerdi	ye	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	2	compound	_	_
 4	de	de	CCONJ	Conj	_	2	mark	_	_
 5	yine	yine	ADV	Adverb	_	7	advmod	_	_
 6	bildiğinden	bil	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	7	acl	_	_
-7	şaşmazdı	şaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
+7	şaşmazdı	şaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-1487
@@ -3776,7 +3776,7 @@
 10	de	de	CCONJ	Conj	_	9	advmod:emph	_	_
 11	bir	bir	NUM	ANum	NumType=Card	12	det	_	_
 12	usulsüzlük	usulsüzlük	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nsubj	_	_
-13	olabilirdi	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	7	conj	_	SpaceAfter=No
+13	olabilirdi	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Past	7	conj	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-1605
@@ -4051,7 +4051,7 @@
 # sent_id = mst-1726
 # text = Sonra barışırlardı.
 1	Sonra	sonra	ADV	Adverb	_	2	advmod	_	_
-2	barışırlardı	barış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+2	barışırlardı	barış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-1729
@@ -5736,7 +5736,7 @@
 4	an	an	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
 5	kül	kül	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
 6	gibi	gibi	ADP	PCNom	_	5	case	_	_
-7	sarardı	sar	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+7	sarardı	sar	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-2434
@@ -6071,7 +6071,7 @@
 9	çok	çok	ADV	Adverb	_	10	advmod	_	_
 10	geçmeden	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	11	nmod	_	_
 11	sıkılacaklarını	sıkıl	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	12	obj	_	_
-12	bilirdi	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+12	bilirdi	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 13	;	;	PUNCT	Punc	_	20	punct	_	_
 14	balıkçıların	balıkçı	NOUN	Noun	Case=Gen|Number=Plur|Person=3	20	nmod:poss	_	_
 15	da	da	CCONJ	Conj	_	14	advmod:emph	_	SpaceAfter=No
@@ -6363,7 +6363,7 @@
 24	,	,	PUNCT	Punc	_	27	punct	_	_
 25	yeni	yeni	ADJ	Adj	_	26	amod	_	_
 26	siparişleri	sipariş	NOUN	Noun	Case=Acc|Number=Plur|Person=3	27	obj	_	_
-27	alırlardı	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	15	conj	_	SpaceAfter=No
+27	alırlardı	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	15	conj	_	SpaceAfter=No
 28	.	.	PUNCT	Punc	_	27	punct	_	_
 
 # sent_id = mst-2693
@@ -6858,7 +6858,7 @@
 11	bunları	bu	PRON	Demons	Case=Acc|Number=Plur|Person=3|PronType=Dem	12	obj	_	_
 12	tartışmak	tartış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	14	nmod	_	_
 13	için	için	ADP	PCNom	_	12	case	_	_
-14	olamazdı	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	1	conj	_	SpaceAfter=No
+14	olamazdı	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Past	1	conj	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-2925
@@ -7216,7 +7216,7 @@
 4	günler	gün	NOUN	Noun	Case=Nom|Number=Plur|Person=3	7	obl	_	_
 5	çamaşır	çamaşır	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
 6	yıkamaya	yıka	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	nmod	_	_
-7	gidermiş	git	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+7	gidermiş	git	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-3092
@@ -7433,7 +7433,7 @@
 7	kuru	kuru	ADJ	Adj	_	8	amod	_	_
 8	ekmek	ekmek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
 9	doğrar	doğra	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	10	nmod	_	_
-10	yerlermiş	ye	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+10	yerlermiş	ye	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-3166
@@ -7910,7 +7910,7 @@
 # text = Ama pis içerdi.
 1	Ama	ama	CCONJ	Conj	_	0	root	_	_
 2	pis	pis	ADJ	Adj	_	3	amod	_	_
-3	içerdi	iç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	1	conj	_	SpaceAfter=No
+3	içerdi	iç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3368
@@ -8168,7 +8168,7 @@
 # sent_id = mst-3479
 # text = Kimse dokunmazmış.
 1	Kimse	kimse	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
-2	dokunmazmış	dokun	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
+2	dokunmazmış	dokun	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-3483
@@ -8603,11 +8603,11 @@
 6	sesiyle	ses	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nmod	_	_
 7	bir	bir	NUM	ANum	NumType=Card	8	det	_	_
 8	şarkı	şarkı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-9	söylerdi	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	8	compound	_	_
+9	söylerdi	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	8	compound	_	_
 10	(	(	PUNCT	Punc	_	13	punct	_	SpaceAfter=No
 11	arada	ara	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	13	amod	_	_
 12	mevlüt	mevlüt	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obj	_	_
-13	okurdu	oku	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	8	conj	_	SpaceAfter=No
+13	okurdu	oku	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	8	conj	_	SpaceAfter=No
 14	;	;	PUNCT	Punc	_	23	punct	_	_
 15	arada	ara	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	11	compound	_	_
 16	Kur'an	Kur'an	PROPN	Prop	Case=Nom|Number=Sing|Person=3	13	obj	_	SpaceAfter=No
@@ -8619,7 +8619,7 @@
 21	diyen	de	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	22	acl	_	_
 22	şarkıcıya	şarkıcı	NOUN	Noun	Case=Dat|Number=Sing|Person=3	23	obl	_	_
 23	taş	taş	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	8	conj	_	_
-24	çıkartırdı	çıkar	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast|Voice=Cau	23	compound	_	SpaceAfter=No
+24	çıkartırdı	çıkar	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	23	compound	_	SpaceAfter=No
 25	.	.	PUNCT	Punc	_	23	punct	_	_
 
 # sent_id = mst-3684
@@ -9526,7 +9526,7 @@
 6	içinde	iç	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	amod	_	_
 7	belediyeye	belediye	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
 8	ait	ait	ADP	PCDat	_	9	obj	_	_
-9	olabilirdi	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+9	olabilirdi	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-4072
@@ -11093,7 +11093,7 @@
 8	konuştuklarını	konuş	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	11	obj	_	_
 9	çok	çok	ADV	Adverb	_	11	advmod	_	_
 10	anlamak	anla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	11	obj	_	_
-11	isterdim	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	4	conj	_	SpaceAfter=No
+11	isterdim	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	4	conj	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-4751
@@ -11199,7 +11199,7 @@
 11	her	her	DET	Det	_	14	det	_	_
 12	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	compound	_	_
 13	alacağı	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	14	obj	_	_
-14	olurdu	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+14	olurdu	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-4799
@@ -11257,7 +11257,7 @@
 5	başka	başka	ADJ	Adj	_	6	amod	_	_
 6	türlü	türlü	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	8	amod	_	_
 7	mü	mü	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	6	aux:q	_	_
-8	olurdu	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+8	olurdu	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10-11	şimdiki	_	_	_	_	_	_	_	_
 10	şimdi	şimdi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
@@ -11428,7 +11428,7 @@
 3	anlar	anla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
 4	ne	ne	CCONJ	Conj	_	6	cc	_	_
 5	de	de	CCONJ	Conj	_	4	advmod:emph	_	_
-6	inanırdı	inan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	3	conj	_	SpaceAfter=No
+6	inanırdı	inan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-4881
@@ -11741,7 +11741,7 @@
 12	bir	bir	NUM	ANum	NumType=Card	13	det	_	_
 13	kız	kız	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	15	amod	_	_
 14	gibi	gibi	ADP	PCNom	_	13	case	_	_
-15	davranırdı	davran	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	4	conj	_	SpaceAfter=No
+15	davranırdı	davran	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	4	conj	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-5010
@@ -11767,7 +11767,7 @@
 # text = Yine bahse girebilirdim ki, Kemal de bunları düşünüyordu; hem de i) ler, ii) lerle.
 1	Yine	yine	ADV	Adverb	_	2	advmod	_	_
 2	bahse	bahis	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	nmod	_	_
-3	girebilirdim	gir	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	2	compound	_	_
+3	girebilirdim	gir	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Past	2	compound	_	_
 4	ki	ki	CCONJ	Conj	_	2	mark	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	9	punct	_	_
 6	Kemal	Kemal	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
@@ -12594,7 +12594,7 @@
 9	,	,	PUNCT	Punc	_	2	punct	_	_
 10	hiçbiri	hiçbiri	PRON	Quant	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	11	det	_	_
 11	adam	adam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obj	_	_
-12	olmazmış	ol	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	2	conj	_	_
+12	olmazmış	ol	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	2	conj	_	_
 13	onların	o	PRON	Pers	Case=Gen|Number=Plur|Person=3|PronType=Prs	10	nmod	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	12	punct	_	_
 
@@ -12889,7 +12889,7 @@
 16	televizyonu	televizyon	NOUN	Noun	Case=Acc|Number=Sing|Person=3	18	nmod	_	_
 17	açma	aç	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	18	nmod:poss	_	_
 18	hakkını	hak	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	obj	_	_
-19	kopardım	kop	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	7	conj	_	SpaceAfter=No
+19	kopardım	kop	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	7	conj	_	SpaceAfter=No
 20	.	.	PUNCT	Punc	_	19	punct	_	_
 
 # sent_id = mst-5517

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -6877,15 +6877,16 @@
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-2932
-# text = Yatırım indirimindeki yüzde ?9.8'likstopaj sıfırlansın, KDV oranları düşürülsün, enflasyon muhasebesine geçilsin, gider harcamaları kapsamı genişletilsin, vergi barışı düzenlemeleri yapılsın.
+# text = Yatırım indirimindeki yüzde 19.8'likstopaj sıfırlansın, KDV oranları düşürülsün, enflasyon muhasebesine geçilsin, gider harcamaları kapsamı genişletilsin, vergi barışı düzenlemeleri yapılsın.
+# Fixed 2.2/dev: original sentence ID: 22080000-69/1
 1	Yatırım	yatırım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2-3	indirimindeki	_	_	_	_	_	_	_	_
 2	indiriminde	indirim	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nmod	_	_
 3	ki	ki	ADP	Rel	_	2	case	_	_
 4	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	5	case	_	_
-5-6	?9.8'lik	_	_	_	_	_	_	_	SpaceAfter=No
-5	?	19.Ağu	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	7	nummod	_	_
-6	9.8'lik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	4	flat	_	_
+5-6	19.8'lik	_	_	_	_	_	_	_	SpaceAfter=No
+5	19.8	19	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	7	nummod	_	_
+6	'lik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	4	flat	_	_
 7	stopaj	stopaj	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
 8	sıfırlansın	sıfırla	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	12	punct	_	_

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -2627,7 +2627,7 @@
 3	süre	süre	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obl	_	_
 4	sonra	sonra	ADP	PCAbl	_	3	case	_	_
 5	ellerinde	el	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	6	obl	_	_
-6	olacaktı	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+6	olacaktı	ol	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-1112
@@ -4701,7 +4701,7 @@
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	iş	iş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 3	böyle	böyle	ADV	Adverb	_	4	advmod	_	_
-4	olmayacaktı	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=FutPast	0	root	_	SpaceAfter=No
+4	olmayacaktı	ol	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Fut,Past	0	root	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	12	punct	_	_
 6	çünkü	çünkü	CCONJ	Conj	_	12	cc	_	_
 7	çok	çok	ADV	Adverb	_	8	advmod	_	_
@@ -5047,7 +5047,7 @@
 2	sise	sis	NOUN	Noun	Case=Dat|Number=Sing|Person=3	3	nmod:poss	_	_
 3	isine	is	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 4	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
-5	girecekmiş	gir	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+5	girecekmiş	gir	VERB	Verb	Aspect=Prosp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-2130
@@ -5099,7 +5099,7 @@
 8	bir	bir	NUM	ANum	NumType=Card	10	nummod	_	_
 9	kez	kez	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	compound	_	_
 10	mola	mola	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-11	verilecekti	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast|Voice=Pass	10	compound	_	_
+11	verilecekti	ver	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past|Voice=Pass	10	compound	_	_
 12	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	10	nmod	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	10	punct	_	_
 
@@ -6935,7 +6935,7 @@
 5	yeni	yeni	ADJ	Adj	_	7	amod	_	_
 6	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
 7	ilişki	ilişki	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8	olacaktı	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+8	olacaktı	ol	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-2952
@@ -7384,7 +7384,7 @@
 8	çünkü	çünkü	CCONJ	Conj	_	11	cc	_	_
 9	onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	11	obj	_	_
 10	şehvetle	şehvet	NOUN	Noun	Case=Ins|Number=Sing|Person=3	11	obl	_	_
-11	öpmeyecektim	öp	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=FutPast	5	conj	_	SpaceAfter=No
+11	öpmeyecektim	öp	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Fut,Past	5	conj	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-3147
@@ -12825,7 +12825,7 @@
 14	yavaş	yavaş	ADJ	Adj	_	13	compound:redup	_	_
 15	bizim	biz	PRON	Pers	Case=Gen|Number=Plur|Person=1|PronType=Prs	16	nmod	_	_
 16	dilimizi	dil	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	17	obj	_	_
-17	öğrenecekti	öğren	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	5	conj	_	SpaceAfter=No
+17	öğrenecekti	öğren	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	5	conj	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-5487

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -690,6 +690,7 @@
 
 # sent_id = mst-0312
 # text = Milli Savunma, Jandarma ve Sahil Güvenlik Komutanlığı bu dönemde her ay ikibiniki cari ödeneklerinin yüzde on'u, diğer kuruluşlar ise yüzde sekiz'i kadar harcama yapabilecek.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Milli	milli	ADJ	Adj	_	25	nsubj	_	_
 2	Savunma	savun	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	1	flat	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	4	punct	_	_
@@ -710,7 +711,7 @@
 18	,	,	PUNCT	Punc	_	22	punct	_	_
 19	diğer	diğer	ADJ	Adj	_	20	det	_	_
 20	kuruluşlar	kuruluş	NOUN	Noun	Case=Nom|Number=Plur|Person=3	21	nmod	_	_
-21	ise	ise	CCONJ	Conj	_	25	nmod	_	_
+21	ise	i	AUX	Conj	_	25	nmod	_	_
 22	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	16	conj	_	_
 23	sekiz'i	sekiz	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=3	22	flat	_	_
 24	kadar	kadar	ADP	PCDat	_	16	case	_	_
@@ -2075,6 +2076,7 @@
 
 # sent_id = mst-0892
 # text = Tasarruf Mevduatı Sigorta Fonu, Pamukbank için yatırımcıların inceleme yapma süresini onüç Aralık ikibiniki, teklif verme süresini ise yirmi Aralık ikibiniki tarihine kadar uzattı.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Tasarruf	tasarruf	NOUN	Noun	Case=Nom|Number=Sing|Person=3	25	nsubj	_	_
 2	Mevduatı	mevduat	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	flat	_	_
 3	Sigorta	sigorta	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	flat	_	_
@@ -2093,7 +2095,7 @@
 16	teklif	teklif	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nmod:poss	_	_
 17	verme	ver	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	16	compound	_	_
 18	süresini	süre	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	25	obj	_	_
-19	ise	ise	CCONJ	Conj	_	18	discourse	_	_
+19	ise	i	AUX	Conj	_	18	discourse	_	_
 20	yirmi	yirmi	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	12	conj	_	_
 21	Aralık	aralık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	flat	_	_
 22	ikibiniki	ikibiniki	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	20	flat	_	_
@@ -3373,9 +3375,10 @@
 
 # sent_id = mst-1438
 # text = Irak meselesi ise gündemdeki yerini korurken Türkiye ile ABD'nin anlayış farklılığı sürüyor.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Irak	Irak	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	meselesi	mesele	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nsubj	_	_
-3	ise	ise	CCONJ	Conj	_	2	discourse	_	_
+3	ise	i	AUX	Conj	_	2	discourse	_	_
 4-5	gündemdeki	_	_	_	_	_	_	_	_
 4	gündemde	gündem	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	nmod:poss	_	_
 5	ki	ki	ADP	Rel	_	4	case	_	_
@@ -5402,8 +5405,9 @@
 
 # sent_id = mst-2278
 # text = Leblebi ise figürandır.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Leblebi	leblebi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+2	ise	i	AUX	Conj	_	1	discourse	_	_
 3-4	figürandır	_	_	_	_	_	_	_	SpaceAfter=No
 3	figüran	figüran	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 4	dır	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	3	cop	_	_
@@ -5984,11 +5988,12 @@
 
 # sent_id = mst-2544
 # text = Eşini kaybeden Aysun Ulusu ise acı haberi alınca astım krizi geçirdi.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Eşini	eş	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	obj	_	_
 2	kaybeden	kaybet	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	acl	_	_
 3	Aysun	Aysun	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
 4	Ulusu	Ulusu	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	flat	_	_
-5	ise	ise	CCONJ	Conj	_	3	discourse	_	_
+5	ise	i	AUX	Conj	_	3	discourse	_	_
 6	acı	acı	ADJ	Adj	_	7	amod	_	_
 7	haberi	haber	NOUN	Noun	Case=Acc|Number=Sing|Person=3	8	obj	_	_
 8	alınca	al	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	11	nmod	_	_
@@ -7545,6 +7550,7 @@
 
 # sent_id = mst-3218
 # text = ', bölgedeki bazı ülkelerde, iç faktörlerin, dış faktörlerden daha etkili olabileceğini vurguladıktan sonra, bölge ülkelerinin aksine, ' mali desteğinin sürdüğü ve NATO üyesi olan Türkiye'nin ise ekonomik programa sadık kalması halinde kredi notunun yükselebileceğini belirtiyor.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	'	'	PUNCT	Punc	_	2	punct	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	0	root	_	_
 3-4	bölgedeki	_	_	_	_	_	_	_	_
@@ -7577,7 +7583,7 @@
 29	üyesi	üye	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	30	nsubj	_	_
 30	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	26	conj	_	_
 31	Türkiye'nin	Türkiye	PROPN	Prop	Case=Gen|Number=Sing|Person=3	36	nmod:poss	_	_
-32	ise	ise	CCONJ	Conj	_	31	discourse	_	_
+32	ise	i	AUX	Conj	_	31	discourse	_	_
 33	ekonomik	ekonomik	ADJ	Adj	_	34	amod	_	_
 34	programa	program	NOUN	Noun	Case=Dat|Number=Sing|Person=3	36	obl	_	_
 35	sadık	sadık	ADJ	Adj	_	36	amod	_	_
@@ -10260,10 +10266,11 @@
 # sent_id = mst-4385
 # text = Asıl yıkıcı darbe ise sömürgecilikle gelmişti.
 # Change 2.2/dev: merge -(y)IcI
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Asıl	asıl	ADJ	Adj	_	2	amod	_	_
 2	yıkıcı	yık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	acl	_	_
 3	darbe	darbe	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
-4	ise	ise	CCONJ	Conj	_	3	discourse	_	_
+4	ise	i	AUX	Conj	_	3	discourse	_	_
 5	sömürgecilikle	sömürgecilik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	6	obl	_	_
 6	gelmişti	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
@@ -10352,8 +10359,9 @@
 
 # sent_id = mst-4420
 # text = Algılayan ise ruhtur.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Algılayan	algıla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	nsubj	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+2	ise	i	AUX	Conj	_	1	discourse	_	_
 3-4	ruhtur	_	_	_	_	_	_	_	SpaceAfter=No
 3	ruh	ruh	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 4	tur	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	3	cop	_	_
@@ -12592,8 +12600,9 @@
 
 # sent_id = mst-5394
 # text = Yarın ise biri üçyüzyetmişbir gün vadeli iskontolu tahvil, diğeri de üç ayda bir değişken faizli tahvil olmak üzere, iki ihale birden yapılacak.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Yarın	yarın	NOUN	Noun	Case=Nom|Number=Sing|Person=3	27	obl	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+2	ise	i	AUX	Conj	_	1	discourse	_	_
 3	biri	bir	NUM	NNum	Case=Acc|Number=Sing|NumType=Card|Person=3	21	nsubj	_	_
 4	üçyüzyetmişbir	üçyüzyetmişbir	NUM	ANum	NumType=Card	5	nummod	_	_
 5	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod	_	_

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -95,26 +95,25 @@
 
 # sent_id = mst-0049
 # text = ŞARKICIYI yakından görmek için gelenlerin izdihama neden olduğu açılışta, Aksüt, tören boyunca eşini yalnız bırakmadı.
+# Change 2.2/dev: merge -(y)An
 1	ŞARKICIYI	şarkıcı	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	obj	_	_
 2	yakından	yakın	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	3	amod	_	_
-3	görmek	gör	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nmod	_	_
+3	görmek	gör	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	nmod	_	_
 4	için	için	ADP	PCNom	_	3	case	_	_
-5-6	gelenlerin	_	_	_	_	_	_	_	_
-5	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	8	nsubj	_	_
-6	lerin	_	ADP	Zero	Case=Gen|Number=Plur|Person=3	5	case	_	_
-7	izdihama	izdiham	NOUN	Noun	Case=Dat|Number=Sing|Person=3	8	nmod	_	_
-8	neden	neden	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obj	_	_
-9	olduğu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	8	compound:lvc	_	_
-10	açılışta	açılış	NOUN	Noun	Case=Loc|Number=Sing|Person=3	17	obl	_	SpaceAfter=No
-11	,	,	PUNCT	Punc	_	17	punct	_	_
-12	Aksüt	Aksüt	PROPN	Prop	Case=Nom|Number=Sing|Person=3	17	nsubj	_	SpaceAfter=No
-13	,	,	PUNCT	Punc	_	17	punct	_	_
-14	tören	tören	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	obl	_	_
-15	boyunca	boyunca	ADP	PCNom	_	14	case	_	_
-16	eşini	eş	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	obj	_	_
-17	yalnız	yalnız	ADV	Adverb	_	0	root	_	_
-18	bırakmadı	bırak	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	17	conj	_	SpaceAfter=No
-19	.	.	PUNCT	Punc	_	17	punct	_	_
+5	gelenlerin	gel	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	7	csubj	_	_
+6	izdihama	izdiham	NOUN	Noun	Case=Dat|Number=Sing|Person=3	7	nmod	_	_
+7	neden	neden	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
+8	olduğu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	7	compound:lvc	_	_
+9	açılışta	açılış	NOUN	Noun	Case=Loc|Number=Sing|Person=3	16	obl	_	SpaceAfter=No
+10	,	,	PUNCT	Punc	_	16	punct	_	_
+11	Aksüt	Aksüt	PROPN	Prop	Case=Nom|Number=Sing|Person=3	16	nsubj	_	SpaceAfter=No
+12	,	,	PUNCT	Punc	_	16	punct	_	_
+13	tören	tören	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	obl	_	_
+14	boyunca	boyunca	ADP	PCNom	_	13	case	_	_
+15	eşini	eş	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obj	_	_
+16	yalnız	yalnız	ADV	Adverb	_	0	root	_	_
+17	bırakmadı	bırak	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	16	conj	_	SpaceAfter=No
+18	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-0057
 # text = Ancak savaş tehdidinin olduğu bir ortamda borsaya taze para gelmiyor.
@@ -1557,12 +1556,11 @@
 
 # sent_id = mst-0674
 # text = Araba beğenmeyene bakın.
+# Change 2.2/dev: merge -(y)An
 1	Araba	araba	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	obj	_	_
-2-3	beğenmeyene	_	_	_	_	_	_	_	_
-2	beğenmeyen	beğen	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	4	acl	_	_
-3	e	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	2	case	_	_
-4	bakın	bak	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	4	punct	_	_
+2	beğenmeyene	beğen	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|VerbForm=Part	3	advcl	_	_
+3	bakın	bak	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-0681
 # text = Dolayısıyla yeni dokümanlara ulaşmak, olayın gerçek yönlerini belgelemek ihtiyacı çok önemliydi.
@@ -2014,18 +2012,17 @@
 
 # sent_id = mst-0871
 # text = Biz leblebi diyinceye kadar pazar savrulur diyor Anadolu deyimi.
-1	Biz	biz	PRON	Pers	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	case	_	_
-2	leblebi	leblebi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
-3-4	diyinceye	_	_	_	_	_	_	_	_
-3	diyince	de	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	1	compound	_	_
-4	ye	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	1	compound	_	_
-5	kadar	kadar	ADP	PCDat	_	8	obj	_	_
-6	pazar	pazar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	compound	_	_
-7	savrulur	savrul	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	compound	_	_
-8	diyor	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	_
-9	Anadolu	Anadolu	PROPN	Prop	Case=Nom|Number=Sing|Person=3	10	nmod:poss	_	_
-10	deyimi	deyim	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nsubj	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	8	punct	_	_
+# Change 2.2/dev: merge -(y)IncA
+1	Biz	biz	PRON	Pers	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
+2	leblebi	leblebi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
+3	diyinceye	de	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	advcl	_	_
+4	kadar	kadar	ADP	PCDat	_	3	case	_	_
+5	pazar	pazar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
+6	savrulur	savrul	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	ccomp	_	_
+7	diyor	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	_
+8	Anadolu	Anadolu	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nmod:poss	_	_
+9	deyimi	deyim	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nsubj	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-0877
 # text = Hakikaten, dedi masadakilerin en yaşlısı, içişi de benziyor.
@@ -4226,6 +4223,7 @@
 
 # sent_id = mst-1800
 # text = CHP'nin Doğu ve Güneydoğu için hazırladığı demokratikleşme paketinde isteyenlere ana dillerini, devlet denetimindeki özel kurslarda öğrenme olanağı sağlanacağı ve üniversitelerde enstitü kurulacağı vaadinde bulunuldu.
+# Change 2.2/dev: merge -(y)An
 1	CHP'nin	Chp	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
 2	Doğu	doğu	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	6	amod	_	_
 3	ve	ve	CCONJ	Conj	_	4	cc	_	_
@@ -4233,29 +4231,27 @@
 5	için	için	ADP	PCNom	_	2	case	_	_
 6	hazırladığı	hazırla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	8	acl	_	_
 7	demokratikleşme	demokratikleş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nmod:poss	_	_
-8	paketinde	paket	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	26	nmod	_	_
-9-10	isteyenlere	_	_	_	_	_	_	_	_
-9	isteyen	iste	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	26	acl	_	_
-10	lere	_	ADP	Zero	Case=Dat|Number=Plur|Person=3	9	case	_	_
-11	ana	ana	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	19	obj	_	_
-12	dillerini	dil	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	11	compound	_	SpaceAfter=No
-13	,	,	PUNCT	Punc	_	19	punct	_	_
-14	devlet	devlet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	nmod:poss	_	_
-15-16	denetimindeki	_	_	_	_	_	_	_	_
-15	denetiminde	denetim	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	nmod	_	_
-16	ki	ki	ADP	Rel	_	15	case	_	_
-17	özel	özel	ADJ	Adj	_	18	amod	_	_
-18	kurslarda	kurs	NOUN	Noun	Case=Loc|Number=Plur|Person=3	21	obl	_	_
-19	öğrenme	öğren	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	20	nmod:poss	_	_
-20	olanağı	olanak	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	nsubj	_	_
-21	sağlanacağı	sağla	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	26	nmod:poss	_	_
-22	ve	ve	CCONJ	Conj	_	25	cc	_	_
-23	üniversitelerde	üniversite	NOUN	Noun	Case=Loc|Number=Plur|Person=3	25	obl	_	_
-24	enstitü	enstitü	NOUN	Noun	Case=Nom|Number=Sing|Person=3	25	nsubj	_	_
-25	kurulacağı	kur	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	21	conj	_	_
-26	vaadinde	vaat	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
-27	bulunuldu	bulun	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	26	compound:lvc	_	SpaceAfter=No
-28	.	.	PUNCT	Punc	_	26	punct	_	_
+8	paketinde	paket	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	25	nmod	_	_
+9	isteyenlere	iste	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	25	advcl	_	_
+10	ana	ana	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	18	obj	_	_
+11	dillerini	dil	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	10	compound	_	SpaceAfter=No
+12	,	,	PUNCT	Punc	_	18	punct	_	_
+13	devlet	devlet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	nmod:poss	_	_
+14-15	denetimindeki	_	_	_	_	_	_	_	_
+14	denetiminde	denetim	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	nmod	_	_
+15	ki	ki	ADP	Rel	_	14	case	_	_
+16	özel	özel	ADJ	Adj	_	17	amod	_	_
+17	kurslarda	kurs	NOUN	Noun	Case=Loc|Number=Plur|Person=3	20	obl	_	_
+18	öğrenme	öğren	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	19	nmod:poss	_	_
+19	olanağı	olanak	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	nsubj	_	_
+20	sağlanacağı	sağla	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	25	nmod:poss	_	_
+21	ve	ve	CCONJ	Conj	_	24	cc	_	_
+22	üniversitelerde	üniversite	NOUN	Noun	Case=Loc|Number=Plur|Person=3	24	obl	_	_
+23	enstitü	enstitü	NOUN	Noun	Case=Nom|Number=Sing|Person=3	24	nsubj	_	_
+24	kurulacağı	kur	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	20	conj	_	_
+25	vaadinde	vaat	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
+26	bulunuldu	bulun	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	25	compound:lvc	_	SpaceAfter=No
+27	.	.	PUNCT	Punc	_	25	punct	_	_
 
 # sent_id = mst-1816
 # text = Bizim yaşımızda bir çocuk nasıl evini terk eder?
@@ -4584,20 +4580,19 @@
 
 # sent_id = mst-1959
 # text = Orhan o geceyi tekrar yaşıyormuş gibi aynı heyecanla olanları Zeynep'e anlattı.
-1	Orhan	Orhan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
+# Change 2.2/dev: merge -(y)An
+1	Orhan	Orhan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
 2	o	o	DET	Det	_	3	det	_	_
 3	geceyi	gece	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	obj	_	_
 4	tekrar	tekrar	ADV	Adverb	_	5	advmod	_	_
-5	yaşıyormuş	yaşa	VERB	Verb	Aspect=Prog|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	12	nmod	_	_
+5	yaşıyormuş	yaşa	VERB	Verb	Aspect=Prog|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	11	nmod	_	_
 6	gibi	gibi	ADP	PCNom	_	5	case	_	_
 7	aynı	aynı	ADJ	Adj	_	8	amod	_	_
-8	heyecanla	heyecan	NOUN	Noun	Case=Ins|Number=Sing|Person=3	12	obl	_	_
-9-10	olanları	_	_	_	_	_	_	_	_
-9	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	12	obj	_	_
-10	ları	_	ADP	Zero	Case=Acc|Number=Plur|Person=3	9	case	_	_
-11	Zeynep'e	Zeynep	PROPN	Prop	Case=Dat|Number=Sing|Person=3	12	obl	_	_
-12	anlattı	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-13	.	.	PUNCT	Punc	_	12	punct	_	_
+8	heyecanla	heyecan	NOUN	Noun	Case=Ins|Number=Sing|Person=3	11	obl	_	_
+9	olanları	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	11	ccomp	_	_
+10	Zeynep'e	Zeynep	PROPN	Prop	Case=Dat|Number=Sing|Person=3	11	obl	_	_
+11	anlattı	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-1967
 # text = Duman çıktığına göre, ocak tütüyor, ocak tüttüğüne göre orada biri yaşıyor, diye düşünüp koşmaya başlamış.
@@ -4693,6 +4688,7 @@
 
 # sent_id = mst-1998
 # text = Bu iş böyle olmayacaktı, çünkü çok sık belimize dek suya giriyorduk ve kayalara serpiştirilmiş gibi birbirlerinden belli uzaklıklara dağılmış sevgililerin (yaz aşkları bunlar, o kadarını çakıyoruz), bu durumdan rahatsız olacaklarını düşünmeye başlamıştık.
+# Change 2.2/dev: merge kadar - ını
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	iş	iş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 3	böyle	böyle	ADV	Adverb	_	4	advmod	_	_
@@ -4713,26 +4709,24 @@
 18	belli	belli	ADJ	Adj	_	19	amod	_	_
 19	uzaklıklara	uzaklık	NOUN	Noun	Case=Dat|Number=Plur|Person=3	20	obl	_	_
 20	dağılmış	dağıl	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	21	nmod	_	_
-21	sevgililerin	sevgili	ADJ	NAdj	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=2	35	compound	_	_
+21	sevgililerin	sevgili	ADJ	NAdj	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=2	34	compound	_	_
 22	(	(	PUNCT	Punc	_	23	punct	_	SpaceAfter=No
 23	yaz	yaz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	appos	_	_
 24	aşkları	aşk	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	23	compound	_	_
 25	bunlar	bu	PRON	Demons	Case=Nom|Number=Plur|Person=3|PronType=Dem	23	nsubj	_	SpaceAfter=No
-26	,	,	PUNCT	Punc	_	37	punct	_	_
-27	o	o	DET	Det	_	29	det	_	_
-28-29	kadarını	_	_	_	_	_	_	_	_
-28	kadar	kadar	ADP	PCDat	_	30	obj	_	_
-29	ını	_	ADP	Zero	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	28	case	_	_
-30	çakıyoruz	çak	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	23	conj	_	SpaceAfter=No
-31	)	)	PUNCT	Punc	_	23	punct	_	SpaceAfter=No
-32	,	,	PUNCT	Punc	_	30	punct	_	_
-33	bu	bu	DET	Det	_	34	det	_	_
-34	durumdan	durum	NOUN	Noun	Case=Abl|Number=Sing|Person=3	35	obl	_	_
-35	rahatsız	rahatsız	ADJ	Adj	_	37	obj	_	_
-36	olacaklarını	olacak	ADJ	NAdj	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	35	compound:lvc	_	_
-37	düşünmeye	düşün	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	38	nmod	_	_
-38	başlamıştık	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pqp	4	conj	_	SpaceAfter=No
-39	.	.	PUNCT	Punc	_	38	punct	_	_
+26	,	,	PUNCT	Punc	_	36	punct	_	_
+27	o	o	DET	Det	_	28	det	_	_
+28	kadarını	kadar	ADP	PCDat	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	29	obj	_	_
+29	çakıyoruz	çak	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	23	conj	_	SpaceAfter=No
+30	)	)	PUNCT	Punc	_	23	punct	_	SpaceAfter=No
+31	,	,	PUNCT	Punc	_	29	punct	_	_
+32	bu	bu	DET	Det	_	33	det	_	_
+33	durumdan	durum	NOUN	Noun	Case=Abl|Number=Sing|Person=3	34	obl	_	_
+34	rahatsız	rahatsız	ADJ	Adj	_	36	obj	_	_
+35	olacaklarını	olacak	ADJ	NAdj	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	34	compound:lvc	_	_
+36	düşünmeye	düşün	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	37	nmod	_	_
+37	başlamıştık	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pqp	4	conj	_	SpaceAfter=No
+38	.	.	PUNCT	Punc	_	37	punct	_	_
 
 # sent_id = mst-2007
 # text = Hülya beni böyle öpüyorsa mutlaka başka birini başka türlü öpüyordur.
@@ -6274,24 +6268,23 @@
 
 # sent_id = mst-2654
 # text = Babam aklımdan geçenleri okumuşçasına Yutkunma ve gözlerini o kadar da çok açma! diye fısıldadı.
-1	Babam	baba	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	16	nsubj	_	_
+# Change 2.2/dev: merge -(y)An
+1	Babam	baba	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	15	nsubj	_	_
 2	aklımdan	akıl	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	3	obl	_	_
-3-4	geçenleri	_	_	_	_	_	_	_	_
-3	geçen	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	obj	_	_
-4	leri	_	ADP	Zero	Case=Acc|Number=Plur|Person=3	3	case	_	_
-5	okumuşçasına	oku	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbForm=Conv	16	nmod	_	_
-6	Yutkunma	yutkun	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	16	nmod	_	_
-7	ve	ve	CCONJ	Conj	_	13	cc	_	_
-8	gözlerini	göz	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	13	obj	_	_
-9	o	o	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	13	obl	_	_
-10	kadar	kadar	ADP	PCDat	_	9	case	_	_
-11	da	da	CCONJ	Conj	_	9	advmod:emph	_	_
-12	çok	çok	ADV	Adverb	_	13	advmod	_	_
-13	açma	aç	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	6	conj	_	SpaceAfter=No
-14	!	!	PUNCT	Punc	_	13	punct	_	_
-15	diye	diye	ADP	PCNom	_	6	case	_	_
-16	fısıldadı	fısılda	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-17	.	.	PUNCT	Punc	_	16	punct	_	_
+3	geçenleri	geç	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	4	ccomp	_	_
+4	okumuşçasına	oku	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbForm=Conv	15	nmod	_	_
+5	Yutkunma	yutkun	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	15	nmod	_	_
+6	ve	ve	CCONJ	Conj	_	12	cc	_	_
+7	gözlerini	göz	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	12	obj	_	_
+8	o	o	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	12	obl	_	_
+9	kadar	kadar	ADP	PCDat	_	8	case	_	_
+10	da	da	CCONJ	Conj	_	8	advmod:emph	_	_
+11	çok	çok	ADV	Adverb	_	12	advmod	_	_
+12	açma	aç	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	5	conj	_	SpaceAfter=No
+13	!	!	PUNCT	Punc	_	12	punct	_	_
+14	diye	diye	ADP	PCNom	_	5	case	_	_
+15	fısıldadı	fısılda	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-2663
 # text = Hükümdarın yetkilerinin kısmen de olsa sınırlandırılması, hükümdar da dahil herkesin uyması gereken bazı yasa ve kuralların ortaya çıkması, nesnel yasa kavramının doğmasına elverişli bir ortam hazırlar.
@@ -7858,12 +7851,11 @@
 
 # sent_id = mst-3345
 # text = Fakat başvuranları beğenmiyor.
-1	Fakat	fakat	CCONJ	Conj	_	0	root	_	_
-2-3	başvuranları	_	_	_	_	_	_	_	_
-2	başvuran	başvur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	obj	_	_
-3	ları	_	ADP	Zero	Case=Acc|Number=Plur|Person=3	2	case	_	_
-4	beğenmiyor	beğen	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	4	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Fakat	fakat	CCONJ	Conj	_	3	cc	_	_
+2	başvuranları	başvur	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	3	ccomp	_	_
+3	beğenmiyor	beğen	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3347
 # text = Şükran Hanım, o gece defterinin başına geçmedi.
@@ -8459,28 +8451,25 @@
 
 # sent_id = mst-3626
 # text = Hangisinin yorgun olduğunu belirlemesi ve yolculuğun ağır yükünü çekenlerle arkada boş kızakları çekenler arasında dönüşümü yapması gerekiyordu.
+# Change 2.2/dev: merge -(y)An
 1	Hangisinin	hangi	PRON	Ques	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obl	_	_
 2	yorgun	yorgun	ADJ	Adj	_	3	obj	_	_
 3	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	4	obj	_	_
-4	belirlemesi	belirle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	19	obj	_	_
-5	ve	ve	CCONJ	Conj	_	18	cc	_	_
+4	belirlemesi	belirle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	18	obj	_	_
+5	ve	ve	CCONJ	Conj	_	16	cc	_	_
 6	yolculuğun	yolculuk	NOUN	Noun	Case=Gen|Number=Sing|Person=3	8	nmod:poss	_	_
 7	ağır	ağır	ADJ	Adj	_	8	amod	_	_
 8	yükünü	yük	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obj	_	_
-9-10	çekenlerle	_	_	_	_	_	_	_	_
-9	çeken	çek	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	16	acl	_	_
-10	lerle	_	ADP	Zero	Case=Ins|Number=Plur|Person=3	9	case	_	_
-11	arkada	arka	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	14	amod	_	_
-12	boş	boş	ADJ	Adj	_	13	amod	_	_
-13	kızakları	kızak	NOUN	Noun	Case=Acc|Number=Plur|Person=3	14	obj	_	_
-14-15	çekenler	_	_	_	_	_	_	_	_
-14	çeken	çek	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	conj	_	_
-15	ler	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	14	case	_	_
-16	arasında	ara	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	amod	_	_
-17	dönüşümü	dönüşüm	NOUN	Noun	Case=Acc|Number=Sing|Person=3	18	obj	_	_
-18	yapması	yap	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	conj	_	_
-19	gerekiyordu	gerek	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
-20	.	.	PUNCT	Punc	_	19	punct	_	_
+9	çekenlerle	çek	VERB	Verb	Aspect=Perf|Case=Ins|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	14	acl	_	_
+10	arkada	arka	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	13	amod	_	_
+11	boş	boş	ADJ	Adj	_	12	amod	_	_
+12	kızakları	kızak	NOUN	Noun	Case=Acc|Number=Plur|Person=3	13	obj	_	_
+13	çekenler	çek	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	9	conj	_	_
+14	arasında	ara	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	amod	_	_
+15	dönüşümü	dönüşüm	NOUN	Noun	Case=Acc|Number=Sing|Person=3	16	obj	_	_
+16	yapması	yap	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	conj	_	_
+17	gerekiyordu	gerek	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
+18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-3640
 # text = Bağımlılığın her türünün ortak özelliği maddenin, kişinin ya da aktivitenin yaşamında başrol oynamasının olmazsa olmaz olduğuna inanmasıdır.
@@ -8514,14 +8503,13 @@
 
 # sent_id = mst-3650
 # text = Bütün vücudunu kızarıncaya kadar ovalamıştın.
+# Change 2.2/dev: merge -(y)IncA
 1	Bütün	bütün	ADJ	Adj	_	2	amod	_	_
-2	vücudunu	vücut	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	6	obj	_	_
-3-4	kızarıncaya	_	_	_	_	_	_	_	_
-3	kızarınca	kızar	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
-4	ya	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	3	case	_	_
-5	kadar	kadar	ADP	PCDat	_	3	case	_	_
-6	ovalamıştın	ovala	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	6	punct	_	_
+2	vücudunu	vücut	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	5	obj	_	_
+3	kızarıncaya	kızar	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	5	advcl	_	_
+4	kadar	kadar	ADP	PCDat	_	3	case	_	_
+5	ovalamıştın	ovala	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
+6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-3653
 # text = Arada, elini düğün fotoğrafının durduğu sol göğsünün üstüne koyar.
@@ -10215,17 +10203,16 @@
 
 # sent_id = mst-4368
 # text = Masadan kalkanlar, diğerlerini beklemeden yola koyulmuşlardı bile.
+# Change 2.2/dev: merge -(y)An
 1	Masadan	masa	NOUN	Noun	Case=Abl|Number=Sing|Person=3	2	obl	_	_
-2-3	kalkanlar	_	_	_	_	_	_	_	SpaceAfter=No
-2	kalkan	kalk	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	nsubj	_	_
-3	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	2	case	_	_
-4	,	,	PUNCT	Punc	_	2	punct	_	_
-5	diğerlerini	diğer	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	6	obj	_	_
-6	beklemeden	bekle	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	7	nmod	_	_
-7	yola	yol	NOUN	Noun	Case=Dat|Number=Sing|Person=3	0	root	_	_
-8	koyulmuşlardı	koy	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pqp|Voice=Pass	7	compound	_	_
-9	bile	bile	ADV	Adverb	_	7	advmod	_	SpaceAfter=No
-10	.	.	PUNCT	Punc	_	7	punct	_	_
+2	kalkanlar	kalk	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	6	csubj	_	SpaceAfter=No
+3	,	,	PUNCT	Punc	_	2	punct	_	_
+4	diğerlerini	diğer	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
+5	beklemeden	bekle	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	6	nmod	_	_
+6	yola	yol	NOUN	Noun	Case=Dat|Number=Sing|Person=3	0	root	_	_
+7	koyulmuşlardı	koy	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pqp|Voice=Pass	6	compound	_	_
+8	bile	bile	ADV	Adverb	_	6	advmod	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-4372
 # text = Hiç kullanmadım...
@@ -10693,12 +10680,11 @@
 
 # sent_id = mst-4560
 # text = Tamamlanmayana para yok.
-1-2	Tamamlanmayana	_	_	_	_	_	_	_	_
-1	Tamamlanmayan	tamamla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	4	acl	_	_
-2	a	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	1	case	_	_
-3	para	para	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
-4	yok	yok	ADJ	Adj	_	0	root	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	4	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Tamamlanmayana	tamamla	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	3	acl	_	_
+2	para	para	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
+3	yok	yok	ADJ	Adj	_	0	root	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-4565
 # text = Boru hattının inşası ' çok uluslu ' bir inşaat çalışmasına sahne olacak.
@@ -10953,14 +10939,13 @@
 
 # sent_id = mst-4686
 # text = Herkes biriktirdiği kadarıyla katkıda bulunacak.
-1	Herkes	herkes	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
-2	biriktirdiği	birik	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Cau	5	acl	_	_
-3-4	kadarıyla	_	_	_	_	_	_	_	_
-3	kadar	kadar	ADP	PCNom	_	2	case	_	_
-4	ıyla	_	ADP	Zero	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	case	_	_
-5	katkıda	katkı	NOUN	Noun	Case=Loc|Number=Sing|Person=3	0	root	_	_
-6	bulunacak	bulun	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	5	compound	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	5	punct	_	_
+# Change 2.2/dev: merge kadar + ıyla
+1	Herkes	herkes	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
+2	biriktirdiği	birik	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Cau	4	acl	_	_
+3	kadarıyla	kadar	ADP	PCNom	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	case	_	_
+4	katkıda	katkı	NOUN	Noun	Case=Loc|Number=Sing|Person=3	0	root	_	_
+5	bulunacak	bulun	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	4	compound	_	SpaceAfter=No
+6	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4691
 # text = Kadere inanıyorum.
@@ -11664,16 +11649,15 @@
 
 # sent_id = mst-4983
 # text = Rafları araştırdım, artanı dibinde kuruyemiş kavanozunun.
+# Change 2.2/dev: merge -(y)An
 1	Rafları	raf	NOUN	Noun	Case=Acc|Number=Plur|Person=3	2	obj	_	_
 2	araştırdım	araştır	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-3	,	,	PUNCT	Punc	_	6	punct	_	_
-4-5	artanı	_	_	_	_	_	_	_	_
-4	artan	art	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	nsubj	_	_
-5	ı	_	ADP	Zero	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	case	_	_
-6	dibinde	dip	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	conj	_	_
-7	kuruyemiş	kuruyemiş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
-8	kavanozunun	kavanoz	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nmod:poss	_	SpaceAfter=No
-9	.	.	PUNCT	Punc	_	2	punct	_	_
+3	,	,	PUNCT	Punc	_	5	punct	_	_
+4	artanı	art	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Part	5	csubj	_	_
+5	dibinde	dip	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	conj	_	_
+6	kuruyemiş	kuruyemiş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod:poss	_	_
+7	kavanozunun	kavanoz	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nmod:poss	_	SpaceAfter=No
+8	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-4989
 # text = Ya da hala anlayamıyor musunuz.
@@ -13080,21 +13064,20 @@
 
 # sent_id = mst-5594
 # text = Kanun çıksa dahi biz bunun yarısı kadarını uygulamaya devam edeceğiz " dedi.
-1	Kanun	kanun	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod	_	_
+# Change 2.2/dev: merge -(y)An
+1	Kanun	kanun	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nmod	_	_
 2	çıksa	çık	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	_
 3	dahi	dahi	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	1	advmod:emph	_	_
-4	biz	biz	PRON	Pers	Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	_	_
+4	biz	biz	PRON	Pers	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	_	_
 5	bunun	bu	PRON	Demons	Case=Gen|Number=Sing|Person=3|PronType=Dem	6	nmod:poss	_	_
 6	yarısı	yarı	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nmod:poss	_	_
-7-8	kadarını	_	_	_	_	_	_	_	_
-7	kadar	kadar	ADP	PCDat	_	9	obj	_	_
-8	ını	_	ADP	Zero	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	case	_	_
-9	uygulamaya	uygulama	NOUN	Noun	Case=Dat|Number=Sing|Person=3	10	nmod	_	_
-10	devam	devam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obj	_	_
-11	edeceğiz	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Fut	10	compound:lvc	_	_
-12	"	"	PUNCT	Punc	_	10	punct	_	_
-13	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-14	.	.	PUNCT	Punc	_	13	punct	_	_
+7	kadarını	kadar	ADP	PCDat	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
+8	uygulamaya	uygulama	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	nmod	_	_
+9	devam	devam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obj	_	_
+10	edeceğiz	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Fut	9	compound:lvc	_	_
+11	"	"	PUNCT	Punc	_	9	punct	_	_
+12	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-5605
 # text = Bu başlığı, Ankara'da hızla krize sürüklenen iktidar arayışıyla ilgili yazı yazma krizine girmişken dün akşamüstü icat ettim.

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -8461,7 +8461,8 @@
 # sent_id = mst-3626
 # text = Hangisinin yorgun olduğunu belirlemesi ve yolculuğun ağır yükünü çekenlerle arkada boş kızakları çekenler arasında dönüşümü yapması gerekiyordu.
 # Change 2.2/dev: merge -(y)An
-1	Hangisinin	hangi	PRON	Ques	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obl	_	_
+# Change 2.2/dev: mark 'hangi' as DET
+1	Hangisinin	hangi	DET	Ques	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
 2	yorgun	yorgun	ADJ	Adj	_	3	obj	_	_
 3	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	4	obj	_	_
 4	belirlemesi	belirle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	18	obj	_	_
@@ -10357,10 +10358,11 @@
 # sent_id = mst-4424
 # text = Düşünmezsin tabii, hangi baba oğul iktidar kavgasına girmemiştir, kaç baba oğul her an patlamaya hazır öfkelerini dizginleyip sevip okşayabilmiştir birbirini.
 # Change 2.2/dev: mark 'kaç' as NUM
+# Change 2.2/dev: mark 'hangi' as DET
 1	Düşünmezsin	düşün	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Neg|Tense=Aor	0	root	_	_
 2	tabii	tabii	ADJ	Adj	_	1	amod	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	1	punct	_	_
-4	hangi	hangi	ADJ	Adj	_	5	amod	_	_
+4	hangi	hangi	DET	Adj	_	5	det	_	_
 5	baba	baba	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
 6	oğul	oğul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	compound	_	_
 7	iktidar	iktidar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -3280,12 +3280,13 @@
 1	...	...	PUNCT	Punc	_	0	root	_	_
 
 # sent_id = mst-1410
-# text = Bana telefon ?derkenkiaceleciliği, sanırım, birşeylerden korktuğunu gösteriyor.
+# text = Bana telefon ederkenki aceleciliği, sanırım, birşeylerden korktuğunu gösteriyor.
+# Fixed 2.2/dev: original sentence ID: 0000613063/3
 1	Bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	2	nmod	_	_
 2	telefon	telefon	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod	_	_
-3-4	?derkenki	_	_	_	_	_	_	_	SpaceAfter=No
-3	?	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	2	compound:lvc	_	_
-4	derkenki	ki	ADP	Rel	_	2	case	_	_
+3-4	ederkenki	_	_	_	_	_	_	_	_
+3	ederken	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	2	compound:lvc	_	_
+4	ki	ki	ADP	Rel	_	2	case	_	_
 5	aceleciliği	acelecilik	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	nsubj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	11	punct	_	_
 7	sanırım	san	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	11	nmod	_	SpaceAfter=No
@@ -3622,10 +3623,11 @@
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-1533
-# text = ?edirlezzet?
-1-2	?edir	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	edir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	1	cop	_	_
+# text = Nedir lezzet?
+# Fixed 2.2/dev: original sentence ID: 001422111004/4
+1-2	Nedir	_	_	_	_	_	_	_	_
+1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
+2	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	1	cop	_	_
 3	lezzet	lezzet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	nsubj	_	SpaceAfter=No
 4	?	?	PUNCT	Punc	_	1	punct	_	_
 
@@ -4653,7 +4655,8 @@
 21	.	.	PUNCT	Punc	_	20	punct	_	_
 
 # sent_id = mst-1984
-# text = Öpüşmedikleri ya da birbirlerini mıncıklamadıkları zamanlar denize girmeye niyetlenen, ama her seferinde, ?edendirbilinmez, vazgeçip geri dönen, bizlere bakıp asıl amacımızın yüzmek değil, denize işemek olduğunu anlayacaklarından çekiniyoruz.
+# text = Öpüşmedikleri ya da birbirlerini mıncıklamadıkları zamanlar denize girmeye niyetlenen, ama her seferinde, nedendir bilinmez, vazgeçip geri dönen, bizlere bakıp asıl amacımızın yüzmek değil, denize işemek olduğunu anlayacaklarından çekiniyoruz.
+# Fixed 2.2/dev: original sentence ID: 00032161413/4
 1	Öpüşmedikleri	öpüş	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	6	acl	_	_
 2	ya	ya	CCONJ	Conj	_	1	compound	_	_
 3	da	da	CCONJ	Conj	_	1	compound	_	_
@@ -4668,9 +4671,9 @@
 12	her	her	DET	Det	_	13	det	_	_
 13	seferinde	sefer	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	obl	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	15	punct	_	_
-15-16	?edendir	_	_	_	_	_	_	_	SpaceAfter=No
-15	?	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	13	conj	_	_
-16	edendir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	15	cop	_	_
+15-16	nedendir	_	_	_	_	_	_	_	_
+15	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	13	conj	_	_
+16	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	15	cop	_	_
 17	bilinmez	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	13	conj	_	SpaceAfter=No
 18	,	,	PUNCT	Punc	_	17	punct	_	_
 19	vazgeçip	vazgeç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	20	nmod	_	_
@@ -4957,11 +4960,12 @@
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2089
-# text = Siz ?imsiniz? diye sordum ürkerek.
+# text = Siz kimsiniz? diye sordum ürkerek.
+# Fixed 2.2/dev: original sentence ID: 00099161425/1
 1	Siz	siz	PRON	Pers	Case=Nom|Number=Plur|Person=2|PronType=Prs	2	nsubj	_	_
-2-3	?imsiniz	_	_	_	_	_	_	_	SpaceAfter=No
-2	?	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	6	obl	_	_
-3	imsiniz	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	2	cop	_	_
+2-3	kimsiniz	_	_	_	_	_	_	_	SpaceAfter=No
+2	kim	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	6	obl	_	_
+3	siniz	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	2	cop	_	_
 4	?	?	PUNCT	Punc	_	6	punct	_	_
 5	diye	diye	ADP	PCNom	_	2	case	_	_
 6	sordum	sor	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
@@ -7380,7 +7384,8 @@
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-3147
-# text = Evenlerin, sadece geçmişini değil, geleceğini de arayan bu barışçı halkın kaderine tanıklık etmek üzere ?akutistan'dayım.
+# text = Evenlerin, sadece geçmişini değil, geleceğini de arayan bu barışçı halkın kaderine tanıklık etmek üzere Yakutistan'dayım.
+# Fixed 2.2/dev: original sentence ID:  00220160-2/1
 1	Evenlerin	Evenler	PROPN	Prop	Case=Gen|Number=Sing|Person=3	13	nmod:poss	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	12	punct	_	_
 3	sadece	sadece	ADV	Adverb	_	4	advmod	_	_
@@ -7397,9 +7402,9 @@
 14	tanıklık	tanıklık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nmod	_	_
 15	etmek	et	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	14	compound:lvc	_	_
 16	üzere	üzere	ADP	PCNom	_	14	case	_	_
-17-18	?akutistan'dayım	_	_	_	_	_	_	_	SpaceAfter=No
-17	?	Yakutistan	PROPN	Prop	Case=Loc|Number=Sing|Person=3	0	root	_	_
-18	akutistan'dayım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	17	cop	_	_
+17-18	Yakutistan'dayım	_	_	_	_	_	_	_	SpaceAfter=No
+17	Yakutistan'da	Yakutistan	PROPN	Prop	Case=Loc|Number=Sing|Person=3	0	root	_	_
+18	yım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	17	cop	_	_
 19	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-3157
@@ -9558,10 +9563,11 @@
 5	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-4090
-# text = ?erdeydin.
-1-2	?erdeydin	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	0	root	_	_
-2	erdeydin	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Past	1	cop	_	_
+# text = Nerdeydin.
+# Fixed 2.2/dev: original sentence ID:  00032161383/1
+1-2	Nerdeydin	_	_	_	_	_	_	_	SpaceAfter=No
+1	Nerde	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	0	root	_	_
+2	ydin	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Past	1	cop	_	_
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-4093
@@ -12579,11 +12585,12 @@
 24	.	.	PUNCT	Punc	_	22	punct	_	_
 
 # sent_id = mst-5389
-# text = Onlar ?ayoşmuş, aynı büyük amcam gibi, hiçbiri adam olmazmış onların.
+# text = Onlar hayoşmuş, aynı büyük amcam gibi, hiçbiri adam olmazmış onların.
+# Fixed 2.2/dev: original sentence ID:  00032161398/2
 1	Onlar	o	PRON	Pers	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	_	_
-2-3	?ayoşmuş	_	_	_	_	_	_	_	SpaceAfter=No
-2	?	hayoş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-3	ayoşmuş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	2	cop	_	_
+2-3	hayoşmuş	_	_	_	_	_	_	_	SpaceAfter=No
+2	hayoş	hayoş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
+3	muş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	2	cop	_	_
 4	,	,	PUNCT	Punc	_	12	punct	_	_
 5	aynı	aynı	ADJ	Adj	_	7	amod	_	_
 6	büyük	büyük	ADJ	Adj	_	7	amod	_	_

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -5083,10 +5083,11 @@
 
 # sent_id = mst-2144
 # text = On kilometrelik buz geçişinden önce son bir kez mola verilecekti burada.
+# Fix 2.2/dev: form with '_'
 1	On	on	NUM	ANum	NumType=Card	2	nummod	_	_
 2-3	kilometrelik	_	_	_	_	_	_	_	_
-2	_	kilometre	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod	_	_
-3	kilometrelik	_	ADJ	Adj	_	5	amod	_	_
+2	kilometre	kilometre	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod	_	_
+3	lik	lik	ADP	Ness	_	2	case	_	_
 4	buz	buz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
 5	geçişinden	geçiş	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nmod	_	_
 6	önce	önce	ADP	PCAbl	_	5	case	_	_
@@ -10719,11 +10720,12 @@
 
 # sent_id = mst-4571
 # text = Sesi şiir okurkenki gibi titriyordu.
+# Fix 2.2/dev: form with '_'
 1	Sesi	ses	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nsubj	_	_
 2	şiir	şiir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 3-5	okurkenki	_	_	_	_	_	_	_	_
-3	_	okur	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod	_	_
-4	okurken	i	AUX	Zero	Aspect=Perf|Mood=Ind|Tense=Pres|VerbForm=Conv	7	nmod	_	_
+3	okur	okur	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod	_	_
+4	ken	i	AUX	Zero	Aspect=Perf|Mood=Ind|Tense=Pres|VerbForm=Conv	7	nmod	_	_
 5	ki	ki	ADP	Rel	_	4	case	_	_
 6	gibi	gibi	ADP	PCNom	_	4	case	_	_
 7	titriyordu	titre	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -4991,11 +4991,12 @@
 
 # sent_id = mst-2105
 # text = Pasaklıyım var mı diyeceğin.
+# Change 2.2/dev: fix incorrect -mI annotation
 1-2	Pasaklıyım	_	_	_	_	_	_	_	_
 1	Pasaklı	pasaklı	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	3	amod	_	_
 2	yım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	1	cop	_	_
 3	var	var	ADJ	Adj	_	5	obj	_	_
-4	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	3	nmod	_	_
+4	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	3	aux:q	_	_
 5	diyeceğin	de	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=2|Polarity=Pos|Tense=Fut|VerbForm=Part	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -638,6 +638,7 @@
 
 # sent_id = mst-0298
 # text = Türkiye'nin bir an önce karar vermesini beklediklerini vurgulayan Unakıtan, ABD'nin müdahale için meşruiyet aradığını ve ikinci BM kararına ihtiyaç duyduğunu ifade ederek, şöyle konuştu: " Ancak ülkemize yönelik bir tehdidi ortadan kaldırma ve doğrudan müdahale etmek için de kimseden izin Allahaşkına gerek yok.
+# Change 2.2/dev: fix ordinal number
 1	Türkiye'nin	Türkiye	PROPN	Prop	Case=Gen|Number=Sing|Person=3	5	nmod	_	_
 2	bir	bir	NUM	ANum	NumType=Card	5	nummod	_	_
 3	an	an	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound	_	_
@@ -654,7 +655,7 @@
 14	meşruiyet	meşruiyet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	obj	_	_
 15	aradığını	ara	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	22	obj	_	_
 16	ve	ve	CCONJ	Conj	_	20	cc	_	_
-17	ikinci	ikinci	ADJ	Adj	_	19	amod	_	_
+17	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	19	amod	_	_
 18	BM	Bm	PROPN	Prop	Case=Nom|Number=Sing|Person=3	19	nmod:poss	_	_
 19	kararına	karar	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	nmod	_	_
 20	ihtiyaç	ihtiyaç	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	conj	_	_
@@ -3506,7 +3507,8 @@
 
 # sent_id = mst-1491
 # text = İkincisine başladık, gitti getirdi sallana sallana.
-1	İkincisine	ikinci	NUM	NNum	Case=Dat|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	2	amod	_	_
+# Change 2.2/dev: fix ordinal number
+1	İkincisine	iki	NUM	NNum	Case=Dat|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	2	amod	_	_
 2	başladık	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	4	punct	_	_
 4	gitti	git	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	2	conj	_	_
@@ -3964,7 +3966,8 @@
 
 # sent_id = mst-1687
 # text = Üçüncü gonk sesinden sonra perde açıldı ve bale başladı.
-1	Üçüncü	üçüncü	ADJ	Adj	_	3	amod	_	_
+# Change 2.2/dev: fix ordinal number
+1	Üçüncü	üç	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	3	amod	_	_
 2	gonk	gonk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 3	sesinden	ses	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	_
 4	sonra	sonra	ADP	PCAbl	_	3	case	_	_
@@ -5096,7 +5099,8 @@
 
 # sent_id = mst-2148
 # text = İkincisi de, teknoloji artık geri dönülmez biçimde bilimsel bilgi temeline oturmuş, bu yüzyılda Bilimsel Devrim'in bulgularının etkin bir teknolojik hasadı gerçekleşmiştir.
-1	İkincisi	ikinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	0	root	_	_
+# Change 2.2/dev: fix ordinal number
+1	İkincisi	iki	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	0	root	_	_
 2	de	de	CCONJ	Conj	_	1	advmod:emph	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	12	punct	_	_
 4	teknoloji	teknoloji	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
@@ -5905,6 +5909,7 @@
 
 # sent_id = mst-2516
 # text = Türkiye, önceki akşam düşen " Konya " uçağının üzüntüsünü yaşarken, sabah saatlerinde gelen ikinci uçak kazası haberiyle şoke oldu.
+# Change 2.2/dev: fix ordinal number
 1	Türkiye	Türkiye	PROPN	Prop	Case=Nom|Number=Sing|Person=3	12	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	12	punct	_	_
 3-4	önceki	_	_	_	_	_	_	_	_
@@ -5922,7 +5927,7 @@
 14	sabah	sabah	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	obl	_	_
 15	saatlerinde	saat	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	14	flat	_	_
 16	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	20	acl	_	_
-17	ikinci	ikinci	ADJ	Adj	_	19	amod	_	_
+17	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	19	amod	_	_
 18	uçak	uçak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	nmod:poss	_	_
 19	kazası	kaza	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	nmod:poss	_	_
 20	haberiyle	haber	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	obl	_	_
@@ -10444,7 +10449,8 @@
 
 # sent_id = mst-4461
 # text = Birinci bölümde, Doğu Perinçek ve Samir Amin, yirmi. yüzyıl olgularından hareketle yirmibir. yüzyıldaki olası ideolojik, politik, iktisadi eğilimleri tartışıyorlar.
-1	Birinci	birinci	ADJ	Adj	_	2	amod	_	_
+# Change 2.2/dev: fix ordinal number
+1	Birinci	bir	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	2	amod	_	_
 2	bölümde	bölüm	NOUN	Noun	Case=Loc|Number=Sing|Person=3	24	obl	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	24	punct	_	_
 4	Doğu	Doğu	PROPN	Prop	Case=Nom|Number=Sing|Person=3	24	nsubj	_	_
@@ -10518,8 +10524,9 @@
 
 # sent_id = mst-4495
 # text = On yedinci yüzyıl araştırmacılarının saptadığı seksenaltı bin Even nüfusu, üç yüzyıl sonra kırksekiz bin kişiye düşmüştü.
+# Change 2.2/dev: fix ordinal number
 1	On	on	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	4	nmod:poss	_	_
-2	yedinci	yedinci	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	1	flat	_	_
+2	yedinci	yedi	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	1	flat	_	_
 3	yüzyıl	yüzyıl	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	flat	_	_
 4	araştırmacılarının	araştırmacı	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	5	nmod:poss	_	_
 5	saptadığı	sapta	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	9	acl	_	_
@@ -12037,10 +12044,11 @@
 
 # sent_id = mst-5153
 # text = Recep'in bu koyda beşinci yılıydı.
+# Change 2.2/dev: fix ordinal number
 1	Recep'in	Recep	PROPN	Prop	Case=Gen|Number=Sing|Person=3	5	nmod	_	_
 2	bu	bu	DET	Det	_	3	det	_	_
 3	koyda	koy	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	nmod	_	_
-4	beşinci	beşinci	ADJ	Adj	_	5	amod	_	_
+4	beşinci	beş	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	5	amod	_	_
 5-6	yılıydı	_	_	_	_	_	_	_	SpaceAfter=No
 5	yılı	yıl	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 6	ydı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	5	cop	_	_

--- a/tr_imst-ud-test.conllu
+++ b/tr_imst-ud-test.conllu
@@ -334,13 +334,12 @@
 
 # sent_id = mst-0157
 # text = Kumral saçları hafifçe karışmıştı.
+# Change 2.2/dev: merge -CA
 1	Kumral	kumral	ADJ	Adj	_	2	amod	_	_
-2	saçları	saç	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	5	nsubj	_	_
-3-4	hafifçe	_	_	_	_	_	_	_	_
-3	hafif	hafif	ADJ	Adj	_	5	amod	_	_
-4	çe	ce	ADP	Ly	_	3	case	_	_
-5	karışmıştı	karış	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	5	punct	_	_
+2	saçları	saç	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
+3	hafifçe	hafifçe	ADV	Adverb	_	4	advmod	_	_
+4	karışmıştı	karış	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
+5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-0162
 # text = Köşkte görev yaptığında gözüyle görmüş.
@@ -2832,18 +2831,17 @@
 
 # sent_id = mst-1207
 # text = Mali Barış, yalnızca vergi borçlarını ve ihtilafları kapsamalı.
+# Change 2.2/dev: merge -CA
 1	Mali	mali	ADJ	Adj	_	2	amod	_	_
-2	Barış	barış	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	SpaceAfter=No
-3	,	,	PUNCT	Punc	_	10	punct	_	_
-4-5	yalnızca	_	_	_	_	_	_	_	_
-4	yalnız	yalnız	ADJ	Adj	_	10	amod	_	_
-5	ca	ce	ADP	AsIf	_	4	case	_	_
-6	vergi	vergi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod:poss	_	_
-7	borçlarını	borç	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	10	obj	_	_
-8	ve	ve	CCONJ	Conj	_	9	cc	_	_
-9	ihtilafları	ihtilaf	NOUN	Noun	Case=Acc|Number=Plur|Person=3	7	conj	_	_
-10	kapsamalı	kapsa	VERB	Verb	Aspect=Perf|Mood=Nec|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	10	punct	_	_
+2	Barış	barış	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	Punc	_	9	punct	_	_
+4	yalnızca	yalnızca	ADV	Adverb	_	9	advmod	_	_
+5	vergi	vergi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
+6	borçlarını	borç	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	9	obj	_	_
+7	ve	ve	CCONJ	Conj	_	8	cc	_	_
+8	ihtilafları	ihtilaf	NOUN	Noun	Case=Acc|Number=Plur|Person=3	6	conj	_	_
+9	kapsamalı	kapsa	VERB	Verb	Aspect=Perf|Mood=Nec|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-1213
 # text = Ne garip sözcükleri bulamıyorum.
@@ -3489,16 +3487,15 @@
 
 # sent_id = mst-1479
 # text = Onca sopayı yerdi de yine bildiğinden şaşmazdı.
-1-2	Onca	_	_	_	_	_	_	_	_
-1	On	on	NUM	ANum	NumType=Card	3	nummod	_	_
-2	ca	ce	ADP	AsIf	_	1	case	_	_
-3	sopayı	sopa	NOUN	Noun	Case=Acc|Number=Sing|Person=3	6	nmod	_	_
-4	yerdi	ye	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	3	compound	_	_
-5	de	de	CCONJ	Conj	_	3	mark	_	_
-6	yine	yine	ADV	Adverb	_	8	advmod	_	_
-7	bildiğinden	bil	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	8	acl	_	_
-8	şaşmazdı	şaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
-9	.	.	PUNCT	Punc	_	8	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Onca	onca	ADJ	Adj	_	2	amod	_	_
+2	sopayı	sopa	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	nmod	_	_
+3	yerdi	ye	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	2	compound	_	_
+4	de	de	CCONJ	Conj	_	2	mark	_	_
+5	yine	yine	ADV	Adverb	_	7	advmod	_	_
+6	bildiğinden	bil	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	7	acl	_	_
+7	şaşmazdı	şaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
+8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-1487
 # text = Dedi ki bu Mustafa Doğan bana.
@@ -6508,15 +6505,13 @@
 
 # sent_id = mst-2755
 # text = Bu aptalca düşüncelerinizi kimseye de anlatamıyorsunuz.
-1	Bu	bu	DET	Det	_	4	det	_	_
-2-3	aptalca	_	_	_	_	_	_	_	_
-2	aptal	aptal	ADJ	Adj	_	4	amod	_	_
-3	ca	ce	ADP	Ly	_	2	case	_	_
-4	düşüncelerinizi	düşünce	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=2	7	obj	_	_
-5	kimseye	kimse	NOUN	Noun	Case=Dat|Number=Sing|Person=3	7	obl	_	_
-6	de	de	CCONJ	Conj	_	5	advmod:emph	_	_
-7	anlatamıyorsunuz	anlat	VERB	Verb	Aspect=Prog|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
-8	.	.	PUNCT	Punc	_	7	punct	_	_
+1	Bu	bu	DET	Det	_	3	det	_	_
+2	aptalca	aptal	ADJ	Adj	_	3	amod	_	_
+3	düşüncelerinizi	düşünce	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=2	6	obj	_	_
+4	kimseye	kimse	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
+5	de	de	CCONJ	Conj	_	4	advmod:emph	_	_
+6	anlatamıyorsunuz	anlat	VERB	Verb	Aspect=Prog|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
+7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-2760
 # text = Seyretmekle de kalmadık.
@@ -6633,16 +6628,14 @@
 # text = Ancak bu sayede ona en yakışan ismi kolayca bulabiliriz.
 1	Ancak	ancak	ADV	Adverb	_	0	root	_	_
 2	bu	bu	DET	Det	_	3	det	_	_
-3	sayede	saye	NOUN	Noun	Case=Loc|Number=Sing|Person=3	10	obl	_	_
+3	sayede	saye	NOUN	Noun	Case=Loc|Number=Sing|Person=3	9	obl	_	_
 4	ona	o	PRON	Demons	Case=Dat|Number=Sing|Person=3|PronType=Dem	6	obl	_	_
 5	en	en	ADV	Adverb	_	6	advmod	_	_
 6	yakışan	yakış	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	acl	_	_
-7	ismi	isim	NOUN	Noun	Case=Acc|Number=Sing|Person=3	10	obj	_	_
-8-9	kolayca	_	_	_	_	_	_	_	_
-8	kolay	kolay	ADJ	Adj	_	10	amod	_	_
-9	ca	ce	ADP	Ly	_	8	case	_	_
-10	bulabiliriz	bul	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	10	punct	_	_
+7	ismi	isim	NOUN	Noun	Case=Acc|Number=Sing|Person=3	9	obj	_	_
+8	kolayca	kolayca	ADV	Adverb	_	9	advmod	_	_
+9	bulabiliriz	bul	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2814
 # text = Çok acil.
@@ -7502,13 +7495,11 @@
 5	gidip	git	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
 6	oturdum	otur	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	3	conj	_	_
 7-8	karşısındaki	_	_	_	_	_	_	_	_
-7	karşısında	karşı	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	amod	_	_
+7	karşısında	karşı	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	amod	_	_
 8	ki	ki	ADP	Rel	_	7	case	_	_
-9-10	uzakça	_	_	_	_	_	_	_	_
-9	uzak	uzak	ADJ	Adj	_	11	amod	_	_
-10	ça	ce	ADP	AsIf	_	9	case	_	_
-11	koltuğa	koltuk	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	SpaceAfter=No
-12	.	.	PUNCT	Punc	_	6	punct	_	_
+9	uzakça	uzakça	ADJ	Adj	_	10	amod	_	_
+10	koltuğa	koltuk	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	SpaceAfter=No
+11	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3204
 # text = Geri dönüyorsun ona.
@@ -8374,12 +8365,10 @@
 
 # sent_id = mst-3591
 # text = Yerime iyice yerleşirim.
-1	Yerime	yer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	4	obl	_	_
-2-3	iyice	_	_	_	_	_	_	_	_
-2	iyi	iyi	ADJ	Adj	_	4	amod	_	_
-3	ce	ce	ADP	Ly	_	2	case	_	_
-4	yerleşirim	yerleş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	4	punct	_	_
+1	Yerime	yer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	3	obl	_	_
+2	iyice	iyice	ADV	Adverb	_	3	advmod	_	_
+3	yerleşirim	yerleş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3594
 # text = Türker, bazılarının Irak'a askeri harekattan yana olduğunu belirtti ve " Bunu istedikleri gibi yapabilmenin ve belli bir kazanç sağlamanın yolu Ecevit ve ekibinin olmadığı bir parlamentodur " diye konuştu.
@@ -8722,10 +8711,8 @@
 # text = Öyle dedim kısaca.
 1	Öyle	öyle	ADV	Adverb	_	2	advmod	_	_
 2	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
-3-4	kısaca	_	_	_	_	_	_	_	SpaceAfter=No
-3	kısa	kısa	ADJ	Adj	_	2	amod	_	_
-4	ca	ce	ADP	Ly	_	3	case	_	_
-5	.	.	PUNCT	Punc	_	2	punct	_	_
+3	kısaca	kısaca	ADV	Adverb	_	2	advmod	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-3718
 # text = Nükhet söylemişti de.
@@ -10125,14 +10112,12 @@
 1	Ceza	ceza	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	4	punct	_	_
 3	kambur	kambur	ADJ	Adj	_	4	amod	_	_
-4	olduğundan	ol	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	8	acl	_	_
-5-6	yalnızca	_	_	_	_	_	_	_	_
-5	yalnız	yalnız	ADJ	Adj	_	8	amod	_	_
-6	ca	ce	ADP	Ly	_	5	case	_	_
-7	kafası	kafa	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nsubj	_	_
-8	görülebiliyor	gör	VERB	Verb	Aspect=Prog|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Pass	0	root	_	_
-9	masada	masa	NOUN	Noun	Case=Loc|Number=Sing|Person=3	8	obl	_	SpaceAfter=No
-10	.	.	PUNCT	Punc	_	8	punct	_	_
+4	olduğundan	ol	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	7	acl	_	_
+5	yalnızca	yalnızca	ADV	Adverb	_	7	advmod	_	_
+6	kafası	kafa	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nsubj	_	_
+7	görülebiliyor	gör	VERB	Verb	Aspect=Prog|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Pass	0	root	_	_
+8	masada	masa	NOUN	Noun	Case=Loc|Number=Sing|Person=3	7	obl	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-4329
 # text = Eski İngiliz parlamenter Linn Linn da Batı'nın vaatlerine güvenerek beklemenin yanlış olduğunu ifade ederek, şunları kaydetti: " ABD istese Rum Kesimi'nin AB'ye üye olmasını engelleyebilir.
@@ -11100,17 +11085,15 @@
 
 # sent_id = mst-4751
 # text = Açıkça kınamaktan kaçınan sabırlı davranışları cabası.
-1-2	Açıkça	_	_	_	_	_	_	_	_
-1	Açık	açık	ADJ	Adj	_	3	amod	_	_
-2	ça	ce	ADP	Ly	_	1	case	_	_
-3	kınamaktan	kına	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	nmod	_	_
-4	kaçınan	kaçın	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	acl	_	_
-5-6	sabırlı	_	_	_	_	_	_	_	_
-5	sabır	sabır	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
-6	lı	li	ADP	With	_	5	case	_	_
-7	davranışları	davranış	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	8	nsubj	_	_
-8	cabası	caba	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	SpaceAfter=No
-9	.	.	PUNCT	Punc	_	8	punct	_	_
+1	Açıkça	açıkça	ADV	Adverb	_	2	advmod	_	_
+2	kınamaktan	kına	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	3	nmod	_	_
+3	kaçınan	kaçın	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	acl	_	_
+4-5	sabırlı	_	_	_	_	_	_	_	_
+4	sabır	sabır	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
+5	lı	li	ADP	With	_	4	case	_	_
+6	davranışları	davranış	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	7	nsubj	_	_
+7	cabası	caba	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	SpaceAfter=No
+8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-4762
 # text = Uzanıp masanın üzerinde duran sigara paketinden bir sigara alarak, parmaklarının ucunda tuttu.

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -89,22 +89,21 @@
 
 # sent_id = mst-0017
 # text = " Buradaki üst düzey görüşmelerimizde turizm için ellerinden geleni yapacaklarını söylediler.
-1	"	"	PUNCT	Punc	_	0	root	_	_
+# Change 2.2/dev: merge -(y)An
+1	"	"	PUNCT	Punc	_	12	punct	_	_
 2-3	Buradaki	_	_	_	_	_	_	_	_
 2	Burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	nmod	_	_
 3	ki	ki	ADP	Rel	_	2	case	_	_
 4	üst	üst	ADJ	Adj	_	5	amod	_	_
 5	düzey	düzey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
-6	görüşmelerimizde	görüşme	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=1	13	obl	_	_
-7	turizm	turizm	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
+6	görüşmelerimizde	görüşme	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=1	12	obl	_	_
+7	turizm	turizm	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obl	_	_
 8	için	için	ADP	PCNom	_	7	case	_	_
-9	ellerinden	el	NOUN	Noun	Case=Abl|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	13	case	_	_
-10-11	geleni	_	_	_	_	_	_	_	_
-10	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	compound	_	_
-11	i	_	ADP	Zero	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	compound	_	_
-12	yapacaklarını	yap	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	13	obj	_	_
-13	söylediler	söyle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
-14	.	.	PUNCT	Punc	_	13	punct	_	_
+9	ellerinden	el	NOUN	Noun	Case=Abl|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	12	case	_	_
+10	geleni	gel	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Part	9	compound	_	_
+11	yapacaklarını	yap	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	12	obj	_	_
+12	söylediler	söyle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-0018
 # text = Gel bak, sana evi göstereyim.
@@ -203,34 +202,33 @@
 
 # sent_id = mst-0031
 # text = Yasal Valium, Diazem gibi haplardan eroine geçenler arasında beni en çok şaşkınlığa düşüren kişi, yetmiş yaşlarında şık giyimli bir kadın oldu.
-1	Yasal	yasal	ADJ	Adj	_	25	nsubj	_	_
+# Change 2.2/dev: merge -(y)An
+1	Yasal	yasal	ADJ	Adj	_	24	nsubj	_	_
 2	Valium	Valium	PROPN	Prop	Case=Nom|Number=Sing|Person=3	1	compound	_	SpaceAfter=No
-3	,	,	PUNCT	Punc	_	25	punct	_	_
-4	Diazem	Diazem	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	obl	_	_
+3	,	,	PUNCT	Punc	_	24	punct	_	_
+4	Diazem	Diazem	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
 5	gibi	gibi	ADP	PCNom	_	4	case	_	_
-6	haplardan	hap	NOUN	Noun	Case=Abl|Number=Plur|Person=3	9	obl	_	_
-7	eroine	eroin	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
-8-9	geçenler	_	_	_	_	_	_	_	_
-8	geçen	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	nmod:poss	_	_
-9	ler	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	8	case	_	_
-10	arasında	ara	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	amod	_	_
-11	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	14	obj	_	_
-12	en	en	ADV	Adverb	_	13	advmod	_	_
-13	çok	çok	ADJ	Adj	_	14	amod	_	_
-14	şaşkınlığa	şaşkınlık	NOUN	Noun	Case=Dat|Number=Sing|Person=3	16	nmod	_	_
-15	düşüren	düşür	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	14	compound	_	_
-16	kişi	kişi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	25	nsubj	_	SpaceAfter=No
-17	,	,	PUNCT	Punc	_	25	punct	_	_
-18	yetmiş	yetmiş	NUM	ANum	NumType=Card	19	nummod	_	_
-19	yaşlarında	yaş	ADJ	NAdj	Case=Loc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	24	amod	_	_
-20	şık	şık	ADJ	Adj	_	21	amod	_	_
-21-22	giyimli	_	_	_	_	_	_	_	_
-21	giyim	giyim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	24	obl	_	_
-22	li	li	ADP	With	_	21	case	_	_
-23	bir	bir	NUM	ANum	NumType=Card	24	det	_	_
-24	kadın	kadın	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	25	nsubj	_	_
-25	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-26	.	.	PUNCT	Punc	_	25	punct	_	_
+6	haplardan	hap	NOUN	Noun	Case=Abl|Number=Plur|Person=3	8	obl	_	_
+7	eroine	eroin	NOUN	Noun	Case=Dat|Number=Sing|Person=3	8	obl	_	_
+8	geçenler	geç	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	9	nmod:poss	_	_
+9	arasında	ara	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	amod	_	_
+10	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	13	obj	_	_
+11	en	en	ADV	Adverb	_	12	advmod	_	_
+12	çok	çok	ADJ	Adj	_	13	amod	_	_
+13	şaşkınlığa	şaşkınlık	NOUN	Noun	Case=Dat|Number=Sing|Person=3	15	nmod	_	_
+14	düşüren	düşür	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	13	compound	_	_
+15	kişi	kişi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	24	nsubj	_	SpaceAfter=No
+16	,	,	PUNCT	Punc	_	24	punct	_	_
+17	yetmiş	yetmiş	NUM	ANum	NumType=Card	18	nummod	_	_
+18	yaşlarında	yaş	ADJ	NAdj	Case=Loc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	23	amod	_	_
+19	şık	şık	ADJ	Adj	_	20	amod	_	_
+20-21	giyimli	_	_	_	_	_	_	_	_
+20	giyim	giyim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	obl	_	_
+21	li	li	ADP	With	_	20	case	_	_
+22	bir	bir	NUM	ANum	NumType=Card	23	det	_	_
+23	kadın	kadın	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	24	nsubj	_	_
+24	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+25	.	.	PUNCT	Punc	_	24	punct	_	_
 
 # sent_id = mst-0033
 # text = Penceresinden görünendir.
@@ -424,27 +422,25 @@
 
 # sent_id = mst-0055
 # text = Asıl düğümü çözmek ve en önemlisi hukuksal alt yapıyı sağlam temellere oturtabilmek için dokümanların tamamına ulaşmak gerekiyordu.
+# Change 2.2/dev: önem + li + si
 1	Asıl	asıl	ADJ	Adj	_	2	amod	_	_
-2	düğümü	düğüm	NOUN	Noun	Case=Acc|Number=Sing|Person=3	18	obl	_	_
+2	düğümü	düğüm	NOUN	Noun	Case=Acc|Number=Sing|Person=3	16	obl	_	_
 3	çözmek	çöz	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	2	compound	_	_
-4	ve	ve	CCONJ	Conj	_	13	cc	_	_
+4	ve	ve	CCONJ	Conj	_	11	cc	_	_
 5	en	en	ADV	Adverb	_	6	advmod	_	_
-6-8	önemlisi	_	_	_	_	_	_	_	_
-6	önem	önem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
-7	li	li	ADP	With	_	6	case	_	_
-8	si	_	ADP	Zero	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	case	_	_
-9	hukuksal	hukuksal	ADJ	Adj	_	11	amod	_	_
-10	alt	alt	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	11	compound	_	_
-11	yapıyı	yapı	NOUN	Noun	Case=Acc|Number=Sing|Person=3	13	obj	_	_
-12	sağlam	sağlam	ADJ	Adj	_	13	amod	_	_
-13	temellere	temel	ADJ	NAdj	Case=Dat|Number=Plur|Person=3	2	conj	_	_
-14	oturtabilmek	otur	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	13	compound	_	_
-15	için	için	ADP	PCNom	_	2	case	_	_
-16	dokümanların	doküman	NOUN	Noun	Case=Gen|Number=Plur|Person=3	17	nmod:poss	_	_
-17	tamamına	tamam	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	amod	_	_
-18	ulaşmak	ulaş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	19	obj	_	_
-19	gerekiyordu	gerek	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
-20	.	.	PUNCT	Punc	_	19	punct	_	_
+6	önemlisi	önemli	ADJ	Adj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obl	_	_
+7	hukuksal	hukuksal	ADJ	Adj	_	9	amod	_	_
+8	alt	alt	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	9	compound	_	_
+9	yapıyı	yapı	NOUN	Noun	Case=Acc|Number=Sing|Person=3	11	obj	_	_
+10	sağlam	sağlam	ADJ	Adj	_	11	amod	_	_
+11	temellere	temel	ADJ	NAdj	Case=Dat|Number=Plur|Person=3	2	conj	_	_
+12	oturtabilmek	otur	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	11	compound	_	_
+13	için	için	ADP	PCNom	_	2	case	_	_
+14	dokümanların	doküman	NOUN	Noun	Case=Gen|Number=Plur|Person=3	15	nmod:poss	_	_
+15	tamamına	tamam	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	amod	_	_
+16	ulaşmak	ulaş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	17	obj	_	_
+17	gerekiyordu	gerek	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
+18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-0058
 # text = Bayındır Sokak'taki bekar evimden çıktım.
@@ -3220,44 +3216,43 @@
 
 # sent_id = mst-0367
 # text = Bilimde bu tür mucizevi elatmalara yer olmadığı gibi, varlığı, Tanrı'ya inananlar için tehlike yaratır: diferansiyel eşitliklerinizdeki matematiksel tekillikleri daha iyi bir modelle ortadan kaldırdığınızda Tanrınız da tekillikle birlikte ortadan kalkar.
+# Change 2.2/dev: merge -(y)An
 1	Bilimde	bilim	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	nmod	_	_
 2	bu	bu	DET	Det	_	5	det	_	_
 3	tür	tür	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound	_	_
 4	mucizevi	mucizevi	ADJ	Adj	_	5	amod	_	_
 5	elatmalara	elatma	NOUN	Noun	Case=Dat|Number=Plur|Person=3	6	nmod	_	_
-6	yer	yer	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nmod	_	_
+6	yer	yer	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	nmod	_	_
 7	olmadığı	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	6	compound	_	_
 8	gibi	gibi	ADP	PCNom	_	6	case	_	SpaceAfter=No
-9	,	,	PUNCT	Punc	_	16	punct	_	_
-10	varlığı	varlık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	nsubj	_	SpaceAfter=No
-11	,	,	PUNCT	Punc	_	16	punct	_	_
+9	,	,	PUNCT	Punc	_	15	punct	_	_
+10	varlığı	varlık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	nsubj	_	SpaceAfter=No
+11	,	,	PUNCT	Punc	_	15	punct	_	_
 12	Tanrı'ya	Tanrı	PROPN	Prop	Case=Dat|Number=Sing|Person=3	13	obl	_	_
-13-14	inananlar	_	_	_	_	_	_	_	_
-13	inanan	inan	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	16	acl	_	_
-14	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	13	case	_	_
-15	için	için	ADP	PCNom	_	13	case	_	_
-16	tehlike	tehlike	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-17	yaratır	yarat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	16	compound	_	SpaceAfter=No
-18	:	:	PUNCT	Punc	_	34	punct	_	_
-19	diferansiyel	diferansiyel	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	nmod	_	_
-20-21	eşitliklerinizdeki	_	_	_	_	_	_	_	_
-20	eşitliklerinizde	eşitlik	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=2	19	compound	_	_
-21	ki	ki	ADP	Rel	_	19	case	_	_
-22	matematiksel	matematiksel	ADJ	Adj	_	23	amod	_	_
-23	tekillikleri	tekillik	NOUN	Noun	Case=Acc|Number=Plur|Person=3	28	obj	_	_
-24	daha	daha	ADV	Adverb	_	25	advmod	_	_
-25	iyi	iyi	ADJ	Adj	_	27	amod	_	_
-26	bir	bir	NUM	ANum	NumType=Card	27	det	_	_
-27	modelle	model	NOUN	Noun	Case=Ins|Number=Sing|Person=3	28	obl	_	_
-28	ortadan	orta	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	34	amod	_	_
-29	kaldırdığınızda	kal	VERB	Verb	Aspect=Perf|Case=Loc|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Cau	28	compound	_	_
-30	Tanrınız	tanrı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	34	nsubj	_	_
-31	da	da	CCONJ	Conj	_	30	advmod:emph	_	_
-32	tekillikle	tekillik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	33	nmod	_	_
-33	birlikte	birlik	NOUN	Noun	Case=Loc|Number=Sing|Person=3	34	obl	_	_
-34	ortadan	orta	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	16	conj	_	_
-35	kalkar	kalk	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	34	compound	_	SpaceAfter=No
-36	.	.	PUNCT	Punc	_	34	punct	_	_
+13	inananlar	inan	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	15	acl	_	_
+14	için	için	ADP	PCNom	_	13	case	_	_
+15	tehlike	tehlike	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
+16	yaratır	yarat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	15	compound	_	SpaceAfter=No
+17	:	:	PUNCT	Punc	_	33	punct	_	_
+18	diferansiyel	diferansiyel	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	nmod	_	_
+19-20	eşitliklerinizdeki	_	_	_	_	_	_	_	_
+19	eşitliklerinizde	eşitlik	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=2	18	compound	_	_
+20	ki	ki	ADP	Rel	_	18	case	_	_
+21	matematiksel	matematiksel	ADJ	Adj	_	22	amod	_	_
+22	tekillikleri	tekillik	NOUN	Noun	Case=Acc|Number=Plur|Person=3	27	obj	_	_
+23	daha	daha	ADV	Adverb	_	24	advmod	_	_
+24	iyi	iyi	ADJ	Adj	_	26	amod	_	_
+25	bir	bir	NUM	ANum	NumType=Card	26	det	_	_
+26	modelle	model	NOUN	Noun	Case=Ins|Number=Sing|Person=3	27	obl	_	_
+27	ortadan	orta	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	33	amod	_	_
+28	kaldırdığınızda	kal	VERB	Verb	Aspect=Perf|Case=Loc|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Cau	27	compound	_	_
+29	Tanrınız	tanrı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	33	nsubj	_	_
+30	da	da	CCONJ	Conj	_	29	advmod:emph	_	_
+31	tekillikle	tekillik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	32	nmod	_	_
+32	birlikte	birlik	NOUN	Noun	Case=Loc|Number=Sing|Person=3	33	obl	_	_
+33	ortadan	orta	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	15	conj	_	_
+34	kalkar	kalk	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	33	compound	_	SpaceAfter=No
+35	.	.	PUNCT	Punc	_	33	punct	_	_
 
 # sent_id = mst-0371
 # text = Hadi hadi söyletme beni..
@@ -3357,6 +3352,7 @@
 
 # sent_id = mst-0381
 # text = İnsanları ikiye ayırıyor annem (sayacağı iki kalem de olsa mutlaka parmaklarını avucuna kapatarak sayacak; birincisi yaşayanlar (bunlar başkalarını da yaşatıyor), ikincisi yaşayanları seyredenler (bunlar da başkalarının sırtına yük oluyorlar).
+# Change 2.2/dev: merge -(y)An
 1	İnsanları	insan	NOUN	Noun	Case=Acc|Number=Plur|Person=3	3	obj	_	_
 2	ikiye	iki	NUM	NNum	Case=Dat|Number=Sing|NumType=Card|Person=3	3	nummod	_	_
 3	ayırıyor	ayır	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	_
@@ -3374,32 +3370,26 @@
 15	sayacak	say	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	3	conj	_	SpaceAfter=No
 16	;	;	PUNCT	Punc	_	15	punct	_	_
 17	birincisi	birinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	18	amod	_	_
-18-19	yaşayanlar	_	_	_	_	_	_	_	_
-18	yaşayan	yaşa	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	30	nmod	_	_
-19	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	18	case	_	_
-20	(	(	PUNCT	Punc	_	24	punct	_	SpaceAfter=No
-21	bunlar	bu	PRON	Demons	Case=Nom|Number=Plur|Person=3|PronType=Dem	24	nsubj	_	_
-22	başkalarını	başka	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	24	obj	_	_
-23	da	da	CCONJ	Conj	_	22	advmod:emph	_	_
-24	yaşatıyor	yaşa	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Cau	18	parataxis	_	SpaceAfter=No
-25	)	)	PUNCT	Punc	_	24	punct	_	SpaceAfter=No
-26	,	,	PUNCT	Punc	_	24	punct	_	_
-27	ikincisi	ikinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	30	amod	_	_
-28-29	yaşayanları	_	_	_	_	_	_	_	_
-28	yaşayan	yaşa	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	30	obj	_	_
-29	ları	_	ADP	Zero	Case=Acc|Number=Plur|Person=3	28	case	_	_
-30-31	seyredenler	_	_	_	_	_	_	_	_
-30	seyreden	seyret	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	nsubj	_	_
-31	ler	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	30	case	_	_
-32	(	(	PUNCT	Punc	_	30	punct	_	SpaceAfter=No
-33	bunlar	bu	PRON	Demons	Case=Nom|Number=Plur|Person=3|PronType=Dem	36	nsubj	_	_
-34	da	da	CCONJ	Conj	_	33	advmod:emph	_	_
-35	başkalarının	başka	ADJ	NAdj	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	36	nmod:poss	_	_
-36	sırtına	sırt	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	31	parataxis	_	_
-37	yük	yük	NOUN	Noun	Case=Nom|Number=Sing|Person=3	36	compound	_	_
-38	oluyorlar	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	36	compound	_	SpaceAfter=No
-39	)	)	PUNCT	Punc	_	30	punct	_	SpaceAfter=No
-40	.	.	PUNCT	Punc	_	30	punct	_	_
+18	yaşayanlar	yaşa	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	28	nmod	_	_
+19	(	(	PUNCT	Punc	_	23	punct	_	SpaceAfter=No
+20	bunlar	bu	PRON	Demons	Case=Nom|Number=Plur|Person=3|PronType=Dem	23	nsubj	_	_
+21	başkalarını	başka	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	23	obj	_	_
+22	da	da	CCONJ	Conj	_	21	advmod:emph	_	_
+23	yaşatıyor	yaşa	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Cau	18	parataxis	_	SpaceAfter=No
+24	)	)	PUNCT	Punc	_	23	punct	_	SpaceAfter=No
+25	,	,	PUNCT	Punc	_	23	punct	_	_
+26	ikincisi	ikinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	28	amod	_	_
+27	yaşayanları	yaşa	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	28	ccomp	_	_
+28	seyredenler	seyret	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	3	nsubj	_	_
+29	(	(	PUNCT	Punc	_	28	punct	_	SpaceAfter=No
+30	bunlar	bu	PRON	Demons	Case=Nom|Number=Plur|Person=3|PronType=Dem	33	nsubj	_	_
+31	da	da	CCONJ	Conj	_	30	advmod:emph	_	_
+32	başkalarının	başka	ADJ	NAdj	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	33	nmod:poss	_	_
+33	sırtına	sırt	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	28	parataxis	_	_
+34	yük	yük	NOUN	Noun	Case=Nom|Number=Sing|Person=3	33	compound	_	_
+35	oluyorlar	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	33	compound	_	SpaceAfter=No
+36	)	)	PUNCT	Punc	_	28	punct	_	SpaceAfter=No
+37	.	.	PUNCT	Punc	_	28	punct	_	_
 
 # sent_id = mst-0384
 # text = Golf de oynarlar.
@@ -4160,20 +4150,19 @@
 
 # sent_id = mst-0465
 # text = Bizi kıyaslayan, karşılaştıranlar bilsinler ki... Biz, yarışta değiliz.
+# Change 2.2/dev: merge -(y)An
 1	Bizi	biz	PRON	Pers	Case=Acc|Number=Plur|Person=1|PronType=Prs	2	obj	_	_
-2	kıyaslayan	kıyasla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	nsubj	_	SpaceAfter=No
-3	,	,	PUNCT	Punc	_	5	punct	_	_
-4-5	karşılaştıranlar	_	_	_	_	_	_	_	_
-4	karşılaştıran	karşılaş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	2	conj	_	_
-5	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	4	case	_	_
-6	bilsinler	bil	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
-7	ki	ki	CCONJ	Conj	_	11	cc	_	SpaceAfter=No
-8	...	...	PUNCT	Punc	_	6	punct	_	_
-9	Biz	biz	PRON	Pers	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	_	SpaceAfter=No
-10	,	,	PUNCT	Punc	_	6	punct	_	_
-11	yarışta	yarış	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	conj	_	_
-12	değiliz	değil	VERB	Neg	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Neg|Tense=Pres	11	cop	_	SpaceAfter=No
-13	.	.	PUNCT	Punc	_	11	punct	_	_
+2	kıyaslayan	kıyasla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	csubj	_	SpaceAfter=No
+3	,	,	PUNCT	Punc	_	4	punct	_	_
+4	karşılaştıranlar	karşılaş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	2	conj	_	_
+5	bilsinler	bil	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
+6	ki	ki	CCONJ	Conj	_	10	cc	_	SpaceAfter=No
+7	...	...	PUNCT	Punc	_	5	punct	_	_
+8	Biz	biz	PRON	Pers	Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	_	SpaceAfter=No
+9	,	,	PUNCT	Punc	_	5	punct	_	_
+10	yarışta	yarış	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	conj	_	_
+11	değiliz	değil	VERB	Neg	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Neg|Tense=Pres	10	cop	_	SpaceAfter=No
+12	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-0468
 # text = Baksanıza hallerine... diyerek Mahmut'un masasını işaret etti.
@@ -4824,25 +4813,24 @@
 
 # sent_id = mst-0536
 # text = Partinin bu hale gelmesine neden olanların artık yönlendirme yapmaya hakkı yoktur " diye konuştu.
+# Change 2.2/dev: merge -(y)An
 1	Partinin	parti	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
 2	bu	bu	DET	Det	_	3	det	_	_
 3	hale	hal	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
 4	gelmesine	gel	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	nmod	_	_
-5	neden	neden	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nmod:poss	_	_
-6-7	olanların	_	_	_	_	_	_	_	_
-6	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	compound:lvc	_	_
-7	ların	_	ADP	Zero	Case=Gen|Number=Plur|Person=3	5	case	_	_
-8	artık	artık	ADV	Adverb	_	11	advmod	_	_
-9	yönlendirme	yönlen	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	11	nmod	_	_
-10	yapmaya	yap	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	compound:lvc	_	_
-11	hakkı	hak	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	ccomp	_	_
-12-13	yoktur	_	_	_	_	_	_	_	_
-12	yok	yok	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	11	compound	_	_
-13	tur	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	11	cop	_	_
-14	"	"	PUNCT	Punc	_	11	punct	_	_
-15	diye	diye	ADP	PCNom	_	11	case	_	_
-16	konuştu	konuş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-17	.	.	PUNCT	Punc	_	16	punct	_	_
+5	neden	neden	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod:poss	_	_
+6	olanların	ol	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	5	compound:lvc	_	_
+7	artık	artık	ADV	Adverb	_	10	advmod	_	_
+8	yönlendirme	yönlen	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	10	nmod	_	_
+9	yapmaya	yap	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	compound:lvc	_	_
+10	hakkı	hak	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	ccomp	_	_
+11-12	yoktur	_	_	_	_	_	_	_	_
+11	yok	yok	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	10	compound	_	_
+12	tur	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	10	cop	_	_
+13	"	"	PUNCT	Punc	_	10	punct	_	_
+14	diye	diye	ADP	PCNom	_	10	case	_	_
+15	konuştu	konuş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-0537
 # text = Anayasalar en büyük toplumsal uzlaşma ile düzenlenmesi gereken metinlerdir.
@@ -5625,6 +5613,7 @@
 
 # sent_id = mst-0639
 # text = Keskin toplum eleştirisi, esprili ve zeki özeleştiri, bir çeşit kara mizah, bilgi düzeylerinin çok üstünde bir entelektüel performans onlarla tanışanları şaşırtır ve çarpar.
+# Change 2.2/dev: merge -(y)An
 1	Keskin	keskin	ADJ	Adj	_	3	amod	_	_
 2	toplum	toplum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 3	eleştirisi	eleştiri	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	26	nsubj	_	SpaceAfter=No
@@ -5649,13 +5638,11 @@
 21	entelektüel	entelektüel	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	22	amod	_	_
 22	performans	performans	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	conj	_	_
 23	onlarla	on	NUM	NNum	Case=Ins|Number=Plur|NumType=Card|Person=3	25	nummod	_	_
-24-25	tanışanları	_	_	_	_	_	_	_	_
-24	tanışan	tanış	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	26	obj	_	_
-25	ları	_	ADP	Zero	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	24	case	_	_
-26	şaşırtır	şaşır	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	_
-27	ve	ve	CCONJ	Conj	_	28	cc	_	_
-28	çarpar	çarp	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	26	conj	_	SpaceAfter=No
-29	.	.	PUNCT	Punc	_	28	punct	_	_
+24	tanışanları	tanış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Part	26	ccomp	_	_
+25	şaşırtır	şaşır	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	_
+26	ve	ve	CCONJ	Conj	_	28	cc	_	_
+27	çarpar	çarp	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	26	conj	_	SpaceAfter=No
+28	.	.	PUNCT	Punc	_	28	punct	_	_
 
 # sent_id = mst-0641
 # text = Viski bardağını aldı, dikip bitirdi.
@@ -5946,11 +5933,10 @@
 
 # sent_id = mst-0679
 # text = Bilene rastlamadım.
-1-2	Bilene	_	_	_	_	_	_	_	_
-1	Bilen	bil	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	acl	_	_
-2	e	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	1	case	_	_
-3	rastlamadım	rastla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
-4	.	.	PUNCT	Punc	_	3	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Bilene	bil	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	2	advcl	_	_
+2	rastlamadım	rastla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
+3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0680
 # text = O halde? Bilmeyecek ne var?
@@ -6258,16 +6244,15 @@
 
 # sent_id = mst-0713
 # text = Bu Türkiye Kuzey Kıbrıs'tan vazgeçene kadar sürecek.
-1	Bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	8	nsubj	_	_
+# Change 2.2/dev: merge -(y)An
+1	Bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	7	nsubj	_	_
 2	Türkiye	Türkiye	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
 3	Kuzey	kuzey	ADJ	Adj	_	5	amod	_	_
 4	Kıbrıs'tan	Kıbrıs	PROPN	Prop	Case=Abl|Number=Sing|Person=3	3	flat	_	_
-5-6	vazgeçene	_	_	_	_	_	_	_	_
-5	vazgeçen	vazgeç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	8	acl	_	_
-6	e	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	5	case	_	_
-7	kadar	kadar	ADP	PCDat	_	5	case	_	_
-8	sürecek	sür	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	SpaceAfter=No
-9	.	.	PUNCT	Punc	_	8	punct	_	_
+5	vazgeçene	vazgeç	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	7	advcl	_	_
+6	kadar	kadar	ADP	PCDat	_	5	case	_	_
+7	sürecek	sür	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	SpaceAfter=No
+8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-0714
 # text = Telefonda sesi biraz üzgün gibiydi.
@@ -6582,25 +6567,24 @@
 
 # sent_id = mst-0747
 # text = Ancak Irak konusunun sürekli gündemde kalıyor olması orta vadeli düşünenler için ciddi bir tehdit.
-1	Ancak	ancak	CCONJ	Conj	_	0	root	_	_
+# Change 2.2/dev: merge -(y)An
+1	Ancak	ancak	CCONJ	Conj	_	14	cc	_	_
 2	Irak	Irak	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 3	konusunun	konu	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nmod:poss	_	_
 4	sürekli	sürekli	ADV	Adverb	_	6	advmod	_	_
 5	gündemde	gündem	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
 6	kalıyor	kal	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	7	obj	_	_
-7	olması	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	16	nsubj	_	_
+7	olması	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	15	nsubj	_	_
 8	orta	orta	ADJ	Adj	_	9	amod	_	_
 9-10	vadeli	_	_	_	_	_	_	_	_
 9	vade	vade	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obl	_	_
 10	li	li	ADP	With	_	9	case	_	_
-11-12	düşünenler	_	_	_	_	_	_	_	_
-11	düşünen	düşün	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	16	acl	_	_
-12	ler	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	11	case	_	_
-13	için	için	ADP	PCNom	_	11	case	_	_
-14	ciddi	ciddi	ADJ	Adj	_	16	amod	_	_
-15	bir	bir	NUM	ANum	NumType=Card	16	det	_	_
-16	tehdit	tehdit	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	SpaceAfter=No
-17	.	.	PUNCT	Punc	_	16	punct	_	_
+11	düşünenler	düşün	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	15	acl	_	_
+12	için	için	ADP	PCNom	_	11	case	_	_
+13	ciddi	ciddi	ADJ	Adj	_	15	amod	_	_
+14	bir	bir	NUM	ANum	NumType=Card	15	det	_	_
+15	tehdit	tehdit	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
+16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-0751
 # text = Timur, uyuşturucu kullanırken etrafımda olan biten her şeyin benimle ilgili olduğunu sanıyordum.
@@ -7058,37 +7042,37 @@
 
 # sent_id = mst-0805
 # text = Rumların, Kıbrıs Türklerine yönelik uygulayacağı tedbirler ve AB'nin KKTC'yi IMF'nin-Akp'lilerin ederek Türk tarafındaki bazı çevrelere yapacağı yardım, halkta bölünmeye yol açabilir.
+# Change 2.2/dev: merge li + lerin
 1	Rumların	Rum	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	6	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	6	punct	_	_
 3	Kıbrıs	Kıbrıs	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
 4	Türklerine	Türk	ADJ	NAdj	Case=Dat|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	3	compound	_	_
 5	yönelik	yönelik	ADP	PCDat	_	3	case	_	_
 6	uygulayacağı	uygula	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	7	acl	_	_
-7	tedbirler	tedbir	NOUN	Noun	Case=Nom|Number=Plur|Person=3	27	nsubj	_	_
-8	ve	ve	CCONJ	Conj	_	22	cc	_	_
-9	AB'nin	Ab	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	16	nmod	_	_
-10	KKTC'yi	Kktc	NOUN	Abr	Abbr=Yes|Case=Acc|Number=Sing|Person=3	16	obj	_	_
+7	tedbirler	tedbir	NOUN	Noun	Case=Nom|Number=Plur|Person=3	26	nsubj	_	_
+8	ve	ve	CCONJ	Conj	_	21	cc	_	_
+9	AB'nin	Ab	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	15	nmod	_	_
+10	KKTC'yi	Kktc	NOUN	Abr	Abbr=Yes|Case=Acc|Number=Sing|Person=3	15	obj	_	_
 11	IMF'nin	Imf	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	9	conj	_	SpaceAfter=No
-12	-	-	PUNCT	Punc	_	15	punct	_	SpaceAfter=No
-13-15	Akp'lilerin	_	_	_	_	_	_	_	_
+12	-	-	PUNCT	Punc	_	14	punct	_	SpaceAfter=No
+13-14	Akp'lilerin	_	_	_	_	_	_	_	_
 13	Akp	Akp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	9	conj	_	_
-14	'li	li	ADP	With	_	13	case	_	_
-15	lerin	_	ADP	Zero	Case=Gen|Number=Plur|Person=3	13	case	_	_
-16	ederek	et	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	22	nmod	_	_
-17	Türk	Türk	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	18	nmod:poss	_	_
-18-19	tarafındaki	_	_	_	_	_	_	_	_
-18	tarafında	taraf	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	nmod	_	_
-19	ki	ki	ADP	Rel	_	18	case	_	_
-20	bazı	bazı	DET	Det	_	21	det	_	_
-21	çevrelere	çevre	NOUN	Noun	Case=Dat|Number=Plur|Person=3	22	obj	_	_
-22	yapacağı	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	7	conj	_	_
-23	yardım	yardım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	compound:lvc	_	SpaceAfter=No
-24	,	,	PUNCT	Punc	_	22	punct	_	_
-25	halkta	halk	NOUN	Noun	Case=Loc|Number=Sing|Person=3	26	obl	_	_
-26	bölünmeye	böl	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	27	nmod	_	_
-27	yol	yol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-28	açabilir	aç	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	27	compound	_	SpaceAfter=No
-29	.	.	PUNCT	Punc	_	27	punct	_	_
+14	'lilerin	li	ADP	With	Case=Gen|Number=Plur|Person=3	13	case	_	_
+15	ederek	et	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	21	nmod	_	_
+16	Türk	Türk	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	17	nmod:poss	_	_
+17-18	tarafındaki	_	_	_	_	_	_	_	_
+17	tarafında	taraf	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	nmod	_	_
+18	ki	ki	ADP	Rel	_	17	case	_	_
+19	bazı	bazı	DET	Det	_	20	det	_	_
+20	çevrelere	çevre	NOUN	Noun	Case=Dat|Number=Plur|Person=3	21	obj	_	_
+21	yapacağı	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	7	conj	_	_
+22	yardım	yardım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	compound:lvc	_	SpaceAfter=No
+23	,	,	PUNCT	Punc	_	21	punct	_	_
+24	halkta	halk	NOUN	Noun	Case=Loc|Number=Sing|Person=3	25	obl	_	_
+25	bölünmeye	böl	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	26	nmod	_	_
+26	yol	yol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
+27	açabilir	aç	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	26	compound	_	SpaceAfter=No
+28	.	.	PUNCT	Punc	_	27	punct	_	_
 
 # sent_id = mst-0807
 # text = Bu konudan bahsettim.
@@ -7329,15 +7313,14 @@
 
 # sent_id = mst-0836
 # text = Bunu yapmayanların yöneticileri şahsen sorumlu tutulacaklar.
+# Change 2.2/dev: merge -(y)An
 1	Bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	2	det	_	_
-2-3	yapmayanların	_	_	_	_	_	_	_	_
-2	yapmayan	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	4	nmod:poss	_	_
-3	ların	_	ADP	Zero	Case=Gen|Number=Plur|Person=3	2	case	_	_
-4	yöneticileri	yönetici	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	7	nsubj	_	_
-5	şahsen	şahsen	ADV	Adverb	_	6	advmod	_	_
-6	sorumlu	sorumlu	ADJ	Adj	_	7	obj	_	_
-7	tutulacaklar	tut	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Fut|Voice=Pass	0	root	_	SpaceAfter=No
-8	.	.	PUNCT	Punc	_	7	punct	_	_
+2	yapmayanların	yap	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Pres|VerbForm=Part	3	nmod:poss	_	_
+3	yöneticileri	yönetici	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	6	nsubj	_	_
+4	şahsen	şahsen	ADV	Adverb	_	5	advmod	_	_
+5	sorumlu	sorumlu	ADJ	Adj	_	6	obj	_	_
+6	tutulacaklar	tut	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Fut|Voice=Pass	0	root	_	SpaceAfter=No
+7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-0838
 # text = Nasıl olur.
@@ -9102,13 +9085,12 @@
 
 # sent_id = mst-1012
 # text = Vazo almak isteyenler çoğunlukta.
+# Change 2.2/dev: merge -(y)An
 1	Vazo	vazo	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	obj	_	_
 2	almak	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	3	obj	_	_
-3-4	isteyenler	_	_	_	_	_	_	_	_
-3	isteyen	iste	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	nsubj	_	_
-4	ler	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	3	case	_	_
-5	çoğunlukta	çoğunluk	NOUN	Noun	Case=Loc|Number=Sing|Person=3	0	root	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	5	punct	_	_
+3	isteyenler	iste	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	4	nsubj	_	_
+4	çoğunlukta	çoğunluk	NOUN	Noun	Case=Loc|Number=Sing|Person=3	0	root	_	SpaceAfter=No
+5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-1014
 # text = Melek bana yardım edersen çocuklarla başa çıkarım, dedi üsteleyerek Memo.
@@ -9905,12 +9887,11 @@
 
 # sent_id = mst-1096
 # text = Katana içeri girdi.
-1-2	Katana	_	_	_	_	_	_	_	_
-1	Katan	kat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	nsubj	_	_
-2	a	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	1	case	_	_
-3	içeri	içeri	NOUN	Noun	Case=Dat|Number=Sing|Person=3	0	root	_	_
-4	girdi	gir	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	compound	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	3	punct	_	_
+# Change 2.2/dev: fix wrong analysis of proper name Katana
+1	Katana	Katana	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
+2	içeri	içeri	NOUN	Noun	Case=Dat|Number=Sing|Person=3	0	root	_	_
+3	girdi	gir	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	compound	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1098
 # text = Görgü tanıklarının ifadesine göre havada çarpışan uçaklar, İnkaya mevkiindeki ormanlık alanda ateş topu halinde düştü.
@@ -11511,18 +11492,17 @@
 
 # sent_id = mst-1285
 # text = Ama zaten buraya daha çok klasik dansı sevenler geliyor.
-1	Ama	ama	CCONJ	Conj	_	0	root	_	_
-2	zaten	zaten	ADV	Adverb	_	10	advmod	_	_
-3	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	10	obl	_	_
+# Change 2.2/dev: merge -(y)An
+1	Ama	ama	CCONJ	Conj	_	9	cc	_	_
+2	zaten	zaten	ADV	Adverb	_	9	advmod	_	_
+3	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
 4	daha	daha	ADV	Adverb	_	5	advmod	_	_
 5	çok	çok	ADV	Adverb	_	8	advmod	_	_
 6	klasik	klasik	ADJ	Adj	_	7	amod	_	_
 7	dansı	dans	NOUN	Noun	Case=Acc|Number=Sing|Person=3	8	obj	_	_
-8-9	sevenler	_	_	_	_	_	_	_	_
-8	seven	sev	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	nsubj	_	_
-9	ler	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	8	case	_	_
-10	geliyor	gel	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	10	punct	_	_
+8	sevenler	sev	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	9	nsubj	_	_
+9	geliyor	gel	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-1286
 # text = Kadınlar rahatça mağazada dolaşmaya, satış elemanlarıyla konuşmaya, ürünleri incelemeye, sorular sormaya, ürünleri denemeye ve sonunda satın almaya daha yatkın.
@@ -13251,14 +13231,13 @@
 
 # sent_id = mst-1477
 # text = Beyan edenden az vergi alınsın.
-1	Beyan	beyan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obl	_	_
-2-3	edenden	_	_	_	_	_	_	_	_
-2	eden	et	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	1	compound:lvc	_	_
-3	den	_	ADP	Zero	Case=Abl|Number=Sing|Person=3	1	case	_	_
-4	az	az	ADJ	Adj	_	5	amod	_	_
-5	vergi	vergi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
-6	alınsın	al	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	6	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Beyan	beyan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
+2	edenden	et	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	1	compound:lvc	_	_
+3	az	az	ADJ	Adj	_	4	amod	_	_
+4	vergi	vergi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
+5	alınsın	al	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
+6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1478
 # text = Korkunç bir şey bu! diye mırıldandım.
@@ -14048,19 +14027,19 @@
 
 # sent_id = mst-1567
 # text = Yunanlıların savaşım verdikleri konulardan biri de budur.
-1-3	Yunanlıların	_	_	_	_	_	_	_	_
-1	Yunan	Yunan	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	4	compound	_	_
-2	lı	li	ADP	With	_	1	case	_	_
-3	ların	_	ADP	Zero	Case=Gen|Number=Plur|Person=3	1	case	_	_
-4	savaşım	savaşım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
-5	verdikleri	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	6	acl	_	_
-6	konulardan	konu	NOUN	Noun	Case=Abl|Number=Plur|Person=3	7	nmod:poss	_	_
-7	biri	biri	PRON	Quant	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	9	nsubj	_	_
-8	de	de	CCONJ	Conj	_	7	advmod:emph	_	_
-9-10	budur	_	_	_	_	_	_	_	SpaceAfter=No
-9	bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	0	root	_	_
-10	dur	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	9	cop	_	_
-11	.	.	PUNCT	Punc	_	9	punct	_	_
+# Change 2.2/dev: merge lı + ların
+1-2	Yunanlıların	_	_	_	_	_	_	_	_
+1	Yunan	Yunan	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	3	compound	_	_
+2	lıların	li	ADP	With	Case=Gen|Number=Plur|Person=3	1	case	_	_
+3	savaşım	savaşım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
+4	verdikleri	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	5	acl	_	_
+5	konulardan	konu	NOUN	Noun	Case=Abl|Number=Plur|Person=3	6	nmod:poss	_	_
+6	biri	biri	PRON	Quant	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	8	nsubj	_	_
+7	de	de	CCONJ	Conj	_	6	advmod:emph	_	_
+8-9	budur	_	_	_	_	_	_	_	SpaceAfter=No
+8	bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	0	root	_	_
+9	dur	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	8	cop	_	_
+10	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-1569
 # text = İnceleme elemanı kim Sodexho.
@@ -14804,25 +14783,23 @@
 
 # sent_id = mst-1651
 # text = Bütün bu patırtılar, Sıkıntı, İhsan, Katana Muharrem gibileriyle arkadaşlık etmemden kaynaklanıyor.
+# Change 2.2/dev: fix wrong analysis of proper name Katana
+# Change 2.2/dev: merge gibi + leriyle
 1	Bütün	bütün	ADJ	Adj	_	3	amod	_	_
 2	bu	bu	DET	Det	_	3	det	_	_
-3	patırtılar	patırtı	NOUN	Noun	Case=Nom|Number=Plur|Person=3	16	nsubj	_	SpaceAfter=No
+3	patırtılar	patırtı	NOUN	Noun	Case=Nom|Number=Plur|Person=3	14	nsubj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	5	punct	_	_
 5	Sıkıntı	sıkıntı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	conj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	5	punct	_	_
-7	İhsan	İhsan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	13	nmod:poss	_	SpaceAfter=No
-8	,	,	PUNCT	Punc	_	11	punct	_	_
-9-10	Katana	_	_	_	_	_	_	_	_
-9	Katan	kat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	conj	_	_
-10	a	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	9	case	_	_
-11	Muharrem	Muharrem	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	flat	_	_
-12-13	gibileriyle	_	_	_	_	_	_	_	_
-12	gibi	gibi	ADP	PCNom	_	14	case	_	_
-13	leriyle	_	ADP	Zero	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	12	case	_	_
-14	arkadaşlık	arkadaşlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	obl	_	_
-15	etmemden	et	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	14	compound:lvc	_	_
-16	kaynaklanıyor	kaynakla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
-17	.	.	PUNCT	Punc	_	16	punct	_	_
+7	İhsan	İhsan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	nmod:poss	_	SpaceAfter=No
+8	,	,	PUNCT	Punc	_	10	punct	_	_
+9	Katana	Katana	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	conj	_	_
+10	Muharrem	Muharrem	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	conj	_	_
+11	gibileriyle	gibi	ADP	PCNom	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	12	obl	_	_
+12	arkadaşlık	arkadaşlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
+13	etmemden	et	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	12	compound:lvc	_	_
+14	kaynaklanıyor	kaynakla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
+15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-1652
 # text = Haber vermemesi çok tuhaf.
@@ -15161,14 +15138,13 @@
 
 # sent_id = mst-1694
 # text = Katana, Ramiz'in sırtına çıktı.
-1-2	Katana	_	_	_	_	_	_	_	SpaceAfter=No
-1	Katan	kat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	nsubj	_	_
-2	a	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	1	case	_	_
-3	,	,	PUNCT	Punc	_	1	punct	_	_
-4	Ramiz'in	Ramiz	PROPN	Prop	Case=Gen|Number=Sing|Person=3	5	nmod:poss	_	_
-5	sırtına	sırt	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	_
-6	çıktı	çık	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	6	punct	_	_
+# Change 2.2/dev: fix wrong analysis of proper name Katana
+1	Katana	Katana	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nsubj	_	SpaceAfter=No
+2	,	,	PUNCT	Punc	_	1	punct	_	_
+3	Ramiz'in	Ramiz	PROPN	Prop	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
+4	sırtına	sırt	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
+5	çıktı	çık	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1696
 # text = Ardahan Savcısı diye bir kart bastırmış.
@@ -16700,21 +16676,20 @@
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-1865
-# text = Varlıklarını gerçek parçacıklar gibi duyumsat�ncaya dek metafizik dünyanın öğeleri olarak alınmalıdırlar.
+# text = Varlıklarını gerçek parçacıklar gibi duyumsatıncaya dek metafizik dünyanın öğeleri olarak alınmalıdırlar.
+# Change 2.2/dev: merge -(y)An
 1	Varlıklarını	varlık	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
 2	gerçek	gerçek	ADJ	Adj	_	3	amod	_	_
 3	parçacıklar	parçacık	NOUN	Noun	Case=Nom|Number=Plur|Person=3	5	obl	_	_
 4	gibi	gibi	ADP	PCNom	_	3	case	_	_
-5-6	duyumsat�ncaya	_	_	_	_	_	_	_	_
-5	duyumsat�nca	duyumsa	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	12	nmod	_	_
-6	ya	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	5	case	_	_
-7	dek	dek	ADP	PCDat	_	5	case	_	_
-8	metafizik	metafizik	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	9	compound	_	_
-9	dünyanın	dünya	NOUN	Noun	Case=Gen|Number=Sing|Person=3	10	nmod:poss	_	_
-10	öğeleri	öğe	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	12	obj	_	_
-11	olarak	olarak	ADP	PCNom	_	10	case	_	_
-12	alınmalıdırlar	al	VERB	Verb	Aspect=Perf|Mood=GenNec|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
-13	.	.	PUNCT	Punc	_	12	punct	_	_
+5	duyumsatıncaya	duyumsa	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	11	nmod	_	_
+6	dek	dek	ADP	PCDat	_	5	case	_	_
+7	metafizik	metafizik	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	8	compound	_	_
+8	dünyanın	dünya	NOUN	Noun	Case=Gen|Number=Sing|Person=3	9	nmod:poss	_	_
+9	öğeleri	öğe	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	11	obj	_	_
+10	olarak	olarak	ADP	PCNom	_	9	case	_	_
+11	alınmalıdırlar	al	VERB	Verb	Aspect=Perf|Mood=GenNec|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
+12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-1867
 # text = Doğu Anadolu'da ulaşımın zor olduğu arazide dev boruların taşınması ve inşaat makinelerinin geçmesi için yapılacak yollar, bölgedeki sarp arazide yeni ulaşım olanakları sağlayacak.
@@ -17728,16 +17703,15 @@
 
 # sent_id = mst-1988
 # text = Beğenili bakışları üstümüzde gelip geçenin.
+# Change 2.2/dev: merge -(y)An
 1-2	Beğenili	_	_	_	_	_	_	_	_
 1	Beğeni	beğeni	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod	_	_
 2	li	li	ADP	With	_	1	case	_	_
 3	bakışları	bakış	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
 4	üstümüzde	üst	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	0	root	_	_
 5	gelip	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
-6-7	geçenin	_	_	_	_	_	_	_	SpaceAfter=No
-6	geçen	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	acl	_	_
-7	in	_	ADP	Zero	Case=Gen|Number=Sing|Person=3	6	case	_	_
-8	.	.	PUNCT	Punc	_	6	punct	_	_
+6	geçenin	geç	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	3	acl	_	SpaceAfter=No
+7	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1989
 # text = ), bozkurtlar (Canis lupus l.
@@ -18011,6 +17985,7 @@
 
 # sent_id = mst-2006
 # text = Kamu Personeli Seçme Sınavı Sistemini değiştireceklerini kaydeden Şahin, şimdiye kadar sınavı kazananların haklarının saklı tutulacağını, ancak bundan böyle her yıl ihtiyaç kadar alım için yeni sınavlar yapılacağını belirtti.
+# Change 2.2/dev: merge -(y)An
 1	Kamu	kamu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obj	_	_
 2	Personeli	personel	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	compound	_	_
 3	Seçme	Seçme	PROPN	Prop	Case=Nom|Number=Sing|Person=3	1	compound	_	_
@@ -18018,34 +17993,32 @@
 5	Sistemini	sistem	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	compound	_	_
 6	değiştireceklerini	değiş	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Cau	7	obj	_	_
 7	kaydeden	kaydet	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	8	acl	_	_
-8	Şahin	Şahin	PROPN	Prop	Case=Nom|Number=Sing|Person=3	32	nsubj	_	SpaceAfter=No
-9	,	,	PUNCT	Punc	_	32	punct	_	_
+8	Şahin	Şahin	PROPN	Prop	Case=Nom|Number=Sing|Person=3	31	nsubj	_	SpaceAfter=No
+9	,	,	PUNCT	Punc	_	31	punct	_	_
 10	şimdiye	şimdi	NOUN	Noun	Case=Dat|Number=Sing|Person=3	13	obl	_	_
 11	kadar	kadar	ADP	PCDat	_	10	case	_	_
 12	sınavı	sınav	NOUN	Noun	Case=Acc|Number=Sing|Person=3	13	obj	_	_
-13-14	kazananların	_	_	_	_	_	_	_	_
-13	kazanan	kazan	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	15	acl	_	_
-14	ların	_	ADP	Zero	Case=Gen|Number=Plur|Person=3	13	case	_	_
-15	haklarının	hak	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	18	obj	_	_
-16-17	saklı	_	_	_	_	_	_	_	_
-16	sak	sak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	obl	_	_
-17	lı	li	ADP	With	_	16	case	_	_
-18	tutulacağını	tut	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	32	obj	_	SpaceAfter=No
-19	,	,	PUNCT	Punc	_	18	punct	_	_
-20	ancak	ancak	CCONJ	Conj	_	18	cc	_	_
-21	bundan	bu	PRON	Demons	Case=Abl|Number=Sing|Person=3|PronType=Dem	22	obl	_	_
-22	böyle	böyle	ADV	Adverb	_	24	advmod	_	_
-23	her	her	DET	Det	_	31	obl	_	_
-24	yıl	yıl	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	fixed	_	_
-25	ihtiyaç	ihtiyaç	NOUN	Noun	Case=Nom|Number=Sing|Person=3	31	obl	_	_
-26	kadar	kadar	ADP	PCNom	_	25	case	_	_
-27	alım	alım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	31	obl	_	_
-28	için	için	ADP	PCNom	_	27	case	_	_
-29	yeni	yeni	ADJ	Adj	_	30	amod	_	_
-30	sınavlar	sınav	NOUN	Noun	Case=Nom|Number=Plur|Person=3	31	obj	_	_
-31	yapılacağını	yap	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	32	obj	_	_
-32	belirtti	belir	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
-33	.	.	PUNCT	Punc	_	32	punct	_	_
+13	kazananların	kazan	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	14	nmod:poss	_	_
+14	haklarının	hak	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	17	obj	_	_
+15-16	saklı	_	_	_	_	_	_	_	_
+15	sak	sak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	obl	_	_
+16	lı	li	ADP	With	_	15	case	_	_
+17	tutulacağını	tut	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	31	obj	_	SpaceAfter=No
+18	,	,	PUNCT	Punc	_	17	punct	_	_
+19	ancak	ancak	CCONJ	Conj	_	17	cc	_	_
+20	bundan	bu	PRON	Demons	Case=Abl|Number=Sing|Person=3|PronType=Dem	21	obl	_	_
+21	böyle	böyle	ADV	Adverb	_	23	advmod	_	_
+22	her	her	DET	Det	_	30	obl	_	_
+23	yıl	yıl	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	fixed	_	_
+24	ihtiyaç	ihtiyaç	NOUN	Noun	Case=Nom|Number=Sing|Person=3	30	obl	_	_
+25	kadar	kadar	ADP	PCNom	_	24	case	_	_
+26	alım	alım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	30	obl	_	_
+27	için	için	ADP	PCNom	_	26	case	_	_
+28	yeni	yeni	ADJ	Adj	_	29	amod	_	_
+29	sınavlar	sınav	NOUN	Noun	Case=Nom|Number=Plur|Person=3	30	obj	_	_
+30	yapılacağını	yap	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	31	obj	_	_
+31	belirtti	belir	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
+32	.	.	PUNCT	Punc	_	31	punct	_	_
 
 # sent_id = mst-2008
 # text = Birden Erkekler Parkı önümüzde belirdi.
@@ -18074,6 +18047,7 @@
 
 # sent_id = mst-2010
 # text = Bir o, bir ben, hiç önceden kararlaştırmadan, kendiliğinden bir o, bir ben, olup bitenleri anlatmaya başladık... dese diye, sabırsızlana sabırsızlana dinledim onu.
+# Change 2.2/dev: merge -(y)An
 1	Bir	bir	NUM	ANum	NumType=Card	2	nummod	_	_
 2	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	9	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	5	punct	_	_
@@ -18082,7 +18056,7 @@
 6	,	,	PUNCT	Punc	_	5	punct	_	_
 7	hiç	hiç	ADV	Adverb	_	9	advmod	_	_
 8	önceden	önceden	ADV	Adverb	_	9	advmod	_	_
-9	kararlaştırmadan	kararlaş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv|Voice=Cau	21	nmod	_	SpaceAfter=No
+9	kararlaştırmadan	kararlaş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv|Voice=Cau	20	nmod	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	11	punct	_	_
 11	kendiliğinden	kendiliğinden	ADV	Adverb	_	9	advmod	_	_
 12	bir	bir	NUM	ANum	NumType=Card	13	nummod	_	_
@@ -18091,21 +18065,19 @@
 15	bir	bir	NUM	ANum	NumType=Card	16	nummod	_	_
 16	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	conj	_	SpaceAfter=No
 17	,	,	PUNCT	Punc	_	16	punct	_	_
-18	olup	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	20	nmod	_	_
-19-20	bitenleri	_	_	_	_	_	_	_	_
-19	biten	bit	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	21	obj	_	_
-20	leri	_	ADP	Zero	Case=Acc|Number=Plur|Person=3	19	case	_	_
-21	anlatmaya	anlat	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	22	nmod	_	_
-22	başladık	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	24	obj	_	SpaceAfter=No
-23	...	...	PUNCT	Punc	_	22	punct	_	_
-24	dese	de	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	29	nmod	_	_
-25	diye	diye	ADP	PCNom	_	24	case	_	SpaceAfter=No
-26	,	,	PUNCT	Punc	_	24	punct	_	_
-27	sabırsızlana	sabırsızlan	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	29	nmod	_	_
-28	sabırsızlana	sabırsızlan	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	27	compound	_	_
-29	dinledim	dinle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
-30	onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	29	obj	_	SpaceAfter=No
-31	.	.	PUNCT	Punc	_	29	punct	_	_
+18	olup	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	19	nmod	_	_
+19	bitenleri	bit	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	20	obj	_	_
+20	anlatmaya	anlat	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	21	nmod	_	_
+21	başladık	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	23	obj	_	SpaceAfter=No
+22	...	...	PUNCT	Punc	_	21	punct	_	_
+23	dese	de	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	28	nmod	_	_
+24	diye	diye	ADP	PCNom	_	23	case	_	SpaceAfter=No
+25	,	,	PUNCT	Punc	_	23	punct	_	_
+26	sabırsızlana	sabırsızlan	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	28	nmod	_	_
+27	sabırsızlana	sabırsızlan	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	26	compound	_	_
+28	dinledim	dinle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
+29	onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	28	obj	_	SpaceAfter=No
+30	.	.	PUNCT	Punc	_	28	punct	_	_
 
 # sent_id = mst-2013
 # text = Babama sabah kahvesi, bize de çikolata ikram etti.
@@ -19043,15 +19015,14 @@
 
 # sent_id = mst-2111
 # text = Bugünün Türkiye'sinde yaşayanlar çözecekler Türkiye'nin sorunlarını.
+# Change 2.2/dev: merge -(y)An
 1	Bugünün	bugün	NOUN	Noun	Case=Gen|Number=Sing|Person=3	2	nmod:poss	_	_
-2	Türkiye'sinde	Türkiye	PROPN	Prop	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obl	_	_
-3-4	yaşayanlar	_	_	_	_	_	_	_	_
-3	yaşayan	yaşa	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	nsubj	_	_
-4	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	3	case	_	_
-5	çözecekler	çöz	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
-6	Türkiye'nin	Türkiye	PROPN	Prop	Case=Gen|Number=Sing|Person=3	7	nmod:poss	_	_
-7	sorunlarını	sorun	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	SpaceAfter=No
-8	.	.	PUNCT	Punc	_	5	punct	_	_
+2	Türkiye'sinde	Türkiye	PROPN	Prop	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obl	_	_
+3	yaşayanlar	yaşa	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	4	nsubj	_	_
+4	çözecekler	çöz	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
+5	Türkiye'nin	Türkiye	PROPN	Prop	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
+6	sorunlarını	sorun	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	SpaceAfter=No
+7	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2112
 # text = Ne işe mi yarardı.
@@ -19490,28 +19461,28 @@
 
 # sent_id = mst-2159
 # text = Chp'lilerin tarım ve sağlık sektörüne destek amacıyla verdiği önergeler ise " gider Başesgioğlu " olduğu gerekçesiyle kabul edilmedi.
-1-3	Chp'lilerin	_	_	_	_	_	_	_	_
-1	Chp	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	10	nmod:poss	_	_
-2	'li	li	ADP	With	_	1	case	_	_
-3	lerin	_	ADP	Zero	Case=Gen|Number=Plur|Person=3	1	case	_	_
-4	tarım	tarım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod:poss	_	_
-5	ve	ve	CCONJ	Conj	_	6	cc	_	_
-6	sağlık	sağlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	conj	_	_
-7	sektörüne	sektör	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obl	_	_
-8	destek	destek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nmod	_	_
-9	amacıyla	amaç	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obl	_	_
-10	verdiği	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	11	nmod	_	_
-11	önergeler	önerge	NOUN	Noun	Case=Nom|Number=Plur|Person=3	12	nmod	_	_
-12	ise	ise	CCONJ	Conj	_	19	nmod	_	_
-13	"	"	PUNCT	Punc	_	14	punct	_	_
-14	gider	gider	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	obj	_	_
-15	Başesgioğlu	Başesgioğlu	PROPN	Prop	Case=Nom|Number=Sing|Person=3	14	compound	_	_
-16	"	"	PUNCT	Punc	_	14	punct	_	_
-17	olduğu	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	18	acl	_	_
-18	gerekçesiyle	gerekçe	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	obj	_	_
-19	kabul	kabul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-20	edilmedi	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past|Voice=Pass	19	compound:lvc	_	SpaceAfter=No
-21	.	.	PUNCT	Punc	_	19	punct	_	_
+# Change 2.2/dev: merge li + lerin
+1-2	Chp'lilerin	_	_	_	_	_	_	_	_
+1	Chp	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	9	nmod:poss	_	_
+2	'lilerin	li	ADP	With	Case=Gen|Number=Plur|Person=3	1	case	_	_
+3	tarım	tarım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
+4	ve	ve	CCONJ	Conj	_	5	cc	_	_
+5	sağlık	sağlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	conj	_	_
+6	sektörüne	sektör	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
+7	destek	destek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod	_	_
+8	amacıyla	amaç	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
+9	verdiği	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	10	nmod	_	_
+10	önergeler	önerge	NOUN	Noun	Case=Nom|Number=Plur|Person=3	11	nmod	_	_
+11	ise	ise	CCONJ	Conj	_	18	nmod	_	_
+12	"	"	PUNCT	Punc	_	13	punct	_	_
+13	gider	gider	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	obj	_	_
+14	Başesgioğlu	Başesgioğlu	PROPN	Prop	Case=Nom|Number=Sing|Person=3	13	compound	_	_
+15	"	"	PUNCT	Punc	_	13	punct	_	_
+16	olduğu	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	17	acl	_	_
+17	gerekçesiyle	gerekçe	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	obj	_	_
+18	kabul	kabul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
+19	edilmedi	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past|Voice=Pass	18	compound:lvc	_	SpaceAfter=No
+20	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-2162
 # text = İhracattaki olumlu gelişmeleri devam ettirmenin öncelikli hedeflerinden olduğunu belirten Esgin, şunları kaydetti: " Amacımız, ikibinbeş yılında ihracatın ciro içindeki payını yüzde elli'ye çıkarmak.
@@ -20808,24 +20779,23 @@
 
 # sent_id = mst-2305
 # text = Boyunlarında tahtadan bir tasma veya renkli kumaş bağlı olanlar, süt veren dişilerdi.
-1	Boyunlarında	boyun	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	10	obl	_	_
+# Change 2.2/dev: merge -(y)An
+1	Boyunlarında	boyun	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	9	obl	_	_
 2	tahtadan	tahta	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	4	amod	_	_
 3	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
-4	tasma	tasma	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obj	_	_
+4	tasma	tasma	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
 5	veya	veya	CCONJ	Conj	_	4	cc	_	_
 6	renkli	renkli	ADJ	Adj	_	7	amod	_	_
 7	kumaş	kumaş	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	8	amod	_	_
-8	bağlı	bağlı	ADJ	Adj	_	10	amod	_	_
-9-10	olanlar	_	_	_	_	_	_	_	SpaceAfter=No
-9	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	14	case	_	_
-10	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	9	conj	_	_
-11	,	,	PUNCT	Punc	_	14	punct	_	_
-12	süt	süt	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obj	_	_
-13	veren	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	14	acl	_	_
-14-15	dişilerdi	_	_	_	_	_	_	_	SpaceAfter=No
-14	dişiler	dişi	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	0	root	_	_
-15	di	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	14	cop	_	_
-16	.	.	PUNCT	Punc	_	14	punct	_	_
+8	bağlı	bağlı	ADJ	Adj	_	9	amod	_	_
+9	olanlar	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	13	case	_	SpaceAfter=No
+10	,	,	PUNCT	Punc	_	13	punct	_	_
+11	süt	süt	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obj	_	_
+12	veren	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	13	acl	_	_
+13-14	dişilerdi	_	_	_	_	_	_	_	SpaceAfter=No
+13	dişiler	dişi	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	0	root	_	_
+14	di	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	13	cop	_	_
+15	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-2306
 # text = Burası Birinci Ada.
@@ -21188,20 +21158,19 @@
 
 # sent_id = mst-2351
 # text = Bu öngörülerin doğruluğunu sınayacak olanlar yine gözlem ve deneylerdir.
+# Change 2.2/dev: merge -(y)An
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	öngörülerin	öngörü	NOUN	Noun	Case=Gen|Number=Plur|Person=3	3	nmod:poss	_	_
 3	doğruluğunu	doğruluk	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
-4	sınayacak	sına	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	6	acl	_	_
-5-6	olanlar	_	_	_	_	_	_	_	_
-5	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	8	acl	_	_
-6	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	5	case	_	_
-7	yine	yine	ADV	Adverb	_	10	advmod	_	_
-8	gözlem	gözlem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod	_	_
-9	ve	ve	CCONJ	Conj	_	10	cc	_	_
-10-11	deneylerdir	_	_	_	_	_	_	_	SpaceAfter=No
-10	deney	deney	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-11	lerdir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Plur|Person=3|Tense=Pres	10	cop	_	_
-12	.	.	PUNCT	Punc	_	10	punct	_	_
+4	sınayacak	sına	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	5	acl	_	_
+5	olanlar	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	7	acl	_	_
+6	yine	yine	ADV	Adverb	_	9	advmod	_	_
+7	gözlem	gözlem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nmod	_	_
+8	ve	ve	CCONJ	Conj	_	9	cc	_	_
+9-10	deneylerdir	_	_	_	_	_	_	_	SpaceAfter=No
+9	deneyler	deney	NOUN	Noun	Case=Nom|Number=Plur|Person=3	0	root	_	_
+10	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	9	cop	_	_
+11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2353
 # text = Nasıl yaptığımı anımsamıyorum.
@@ -21487,13 +21456,12 @@
 
 # sent_id = mst-2388
 # text = -Yazdığın kadarını okurum.
-1	-	-	PUNCT	Punc	_	0	root	_	SpaceAfter=No
-2	Yazdığın	yaz	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	4	nmod:poss	_	_
-3-4	kadarını	_	_	_	_	_	_	_	_
-3	kadar	kadar	ADP	PCDat	_	5	obj	_	_
-4	ını	_	ADP	Zero	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	case	_	_
-5	okurum	oku	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	5	punct	_	_
+# Change 2.2/dev: merge kadar + ını
+1	-	-	PUNCT	Punc	_	4	punct	_	SpaceAfter=No
+2	Yazdığın	yaz	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	3	nmod:poss	_	_
+3	kadarını	kadar	ADP	PCDat	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
+4	okurum	oku	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2389
 # text = Beraberce korkunç bir sahne yarattık.
@@ -22257,8 +22225,9 @@
 
 # sent_id = mst-2481
 # text = Babam, Ali'nin annesi Nihan teyzeden kağıt kalem isteyerek yapmamız gerekenleri tüm ayrıntılarıyla yazdı.
-1	Babam	baba	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	15	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	Punc	_	15	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Babam	baba	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	14	nsubj	_	SpaceAfter=No
+2	,	,	PUNCT	Punc	_	14	punct	_	_
 3	Ali'nin	Ali	PROPN	Prop	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
 4	annesi	anne	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nmod	_	_
 5	Nihan	Nihan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
@@ -22266,14 +22235,12 @@
 7	kağıt	kağıt	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	9	obj	_	_
 8	kalem	kalem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	compound	_	_
 9	isteyerek	iste	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	10	nmod	_	_
-10	yapmamız	yap	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	12	nmod	_	_
-11-12	gerekenleri	_	_	_	_	_	_	_	_
-11	gereken	gerek	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	15	obj	_	_
-12	leri	_	ADP	Zero	Case=Acc|Number=Plur|Person=3	11	case	_	_
-13	tüm	tüm	DET	Det	_	14	det	_	_
-14	ayrıntılarıyla	ayrıntı	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	15	obl	_	_
-15	yazdı	yaz	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-16	.	.	PUNCT	Punc	_	15	punct	_	_
+10	yapmamız	yap	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	11	ccomp	_	_
+11	gerekenleri	gerek	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	14	ccomp	_	_
+12	tüm	tüm	DET	Det	_	13	det	_	_
+13	ayrıntılarıyla	ayrıntı	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	14	obl	_	_
+14	yazdı	yaz	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-2483
 # text = Ama en kolayı şu saman sarısı saçlarından ve takma kirpiklerinden kurtulmaktı.
@@ -23560,28 +23527,28 @@
 
 # sent_id = mst-2612
 # text = Yaralılardan Burak Altındağ'ın abisi Vecdi Altındağ da, kardeşinin bilgisayar mühendisi olduğunu ve iş için Diyarbakır'a gittiğini belirtti.
-1-3	Yaralılardan	_	_	_	_	_	_	_	_
-1	Yara	yara	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod	_	_
-2	lı	li	ADP	With	_	1	case	_	_
-3	lardan	_	ADP	Zero	Case=Abl|Number=Plur|Person=3	1	case	_	_
-4	Burak	Burak	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
-5	Altındağ'ın	Altındağ	PROPN	Prop	Case=Gen|Number=Sing|Person=3	4	flat	_	_
-6	abisi	abis	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	nsubj	_	_
-7	Vecdi	Vecdi	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
-8	Altındağ	Altındağ	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	flat	_	_
-9	da	da	CCONJ	Conj	_	7	advmod:emph	_	SpaceAfter=No
-10	,	,	PUNCT	Punc	_	20	punct	_	_
-11	kardeşinin	kardeş	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	nmod:poss	_	_
-12	bilgisayar	bilgisayar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	obl	_	_
-13	mühendisi	mühendis	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	compound	_	_
-14	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	20	obj	_	_
-15	ve	ve	CCONJ	Conj	_	19	cc	_	_
-16	iş	iş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	obl	_	_
-17	için	için	ADP	PCNom	_	16	case	_	_
-18	Diyarbakır'a	Diyarbakır	PROPN	Prop	Case=Dat|Number=Sing|Person=3	19	obl	_	_
-19	gittiğini	git	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	14	conj	_	_
-20	belirtti	belir	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
-21	.	.	PUNCT	Punc	_	20	punct	_	_
+# Change 2.2/dev: merge lı + lardan
+1-2	Yaralılardan	_	_	_	_	_	_	_	_
+1	Yara	yara	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod	_	_
+2	lılardan	li	ADP	With	Case=Abl|Number=Plur|Person=3	1	case	_	_
+3	Burak	Burak	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
+4	Altındağ'ın	Altındağ	PROPN	Prop	Case=Gen|Number=Sing|Person=3	3	flat	_	_
+5	abisi	abis	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	nsubj	_	_
+6	Vecdi	Vecdi	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nmod	_	_
+7	Altındağ	Altındağ	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	flat	_	_
+8	da	da	CCONJ	Conj	_	6	advmod:emph	_	SpaceAfter=No
+9	,	,	PUNCT	Punc	_	19	punct	_	_
+10	kardeşinin	kardeş	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	nmod:poss	_	_
+11	bilgisayar	bilgisayar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
+12	mühendisi	mühendis	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	compound	_	_
+13	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	19	obj	_	_
+14	ve	ve	CCONJ	Conj	_	18	cc	_	_
+15	iş	iş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	obl	_	_
+16	için	için	ADP	PCNom	_	15	case	_	_
+17	Diyarbakır'a	Diyarbakır	PROPN	Prop	Case=Dat|Number=Sing|Person=3	18	obl	_	_
+18	gittiğini	git	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	13	conj	_	_
+19	belirtti	belir	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
+20	.	.	PUNCT	Punc	_	19	punct	_	_
 
 # sent_id = mst-2614
 # text = Biliyordum seveceklerini.
@@ -24131,26 +24098,25 @@
 # sent_id = mst-2670
 # text = Bütün bu olasılıklardan daha da can sıkıcı olanı, zamansız uyanan ayıların civarda olabileceği endişesiydi.
 # Change 2.2/dev: merge -(y)IcI
+# Change 2.2/dev: merge -(y)An
 1	Bütün	bütün	ADJ	Adj	_	3	det	_	_
 2	bu	bu	DET	Det	_	3	det	_	_
 3	olasılıklardan	olasılık	NOUN	Noun	Case=Abl|Number=Plur|Person=3	6	nmod	_	_
 4	daha	daha	ADV	Adverb	_	6	advmod	_	_
 5	da	da	CCONJ	Conj	_	4	advmod:emph	_	_
-6	can	can	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
+6	can	can	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
 7	sıkıcı	sık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	compound	_	_
-8-9	olanı	_	_	_	_	_	_	_	SpaceAfter=No
-8	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	16	nsubj	_	_
-9	ı	_	ADP	Zero	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	case	_	_
-10	,	,	PUNCT	Punc	_	8	punct	_	_
-11	zamansız	zamansız	ADJ	Adj	_	12	amod	_	_
-12	uyanan	uyan	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	13	acl	_	_
-13	ayıların	ayı	NOUN	Noun	Case=Gen|Number=Plur|Person=3	15	nmod:poss	_	_
-14	civarda	civar	NOUN	Noun	Case=Loc|Number=Sing|Person=3	15	obl	_	_
-15	olabileceği	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	16	nmod:poss	_	_
-16-17	endişesiydi	_	_	_	_	_	_	_	SpaceAfter=No
-16	endişesi	endişe	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
-17	ydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	16	cop	_	_
-18	.	.	PUNCT	Punc	_	16	punct	_	_
+8	olanı	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Part	15	csubj	_	SpaceAfter=No
+9	,	,	PUNCT	Punc	_	7	punct	_	_
+10	zamansız	zamansız	ADJ	Adj	_	11	amod	_	_
+11	uyanan	uyan	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	12	acl	_	_
+12	ayıların	ayı	NOUN	Noun	Case=Gen|Number=Plur|Person=3	14	nmod:poss	_	_
+13	civarda	civar	NOUN	Noun	Case=Loc|Number=Sing|Person=3	14	obl	_	_
+14	olabileceği	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	15	nmod:poss	_	_
+15-16	endişesiydi	_	_	_	_	_	_	_	SpaceAfter=No
+15	endişesi	endişe	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
+16	ydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	15	cop	_	_
+17	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-2671
 # text = Öğleden sonra kanallar kıyısında dolaşırken, sanki uzun yıllardır buradaymışım, hep de kanallar kıyısında dolaşıp durmakla vakit tüketirmişim gibi geliyordu bana.
@@ -24273,17 +24239,16 @@
 
 # sent_id = mst-2684
 # text = Ramiz yerine oturana dek de gözlüklerinin üstünden izledi.
+# Change 2.2/dev: merge -(y)An
 1	Ramiz	Ramiz	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	yerine	yer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obl	_	_
-3-4	oturana	_	_	_	_	_	_	_	_
-3	oturan	otur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	acl	_	_
-4	a	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	3	case	_	_
-5	dek	dek	ADP	PCDat	_	3	case	_	_
-6	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
-7	gözlüklerinin	gözlük	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	8	nmod:poss	_	_
-8	üstünden	üst	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	amod	_	_
-9	izledi	izle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-10	.	.	PUNCT	Punc	_	9	punct	_	_
+3	oturana	otur	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	8	acl	_	_
+4	dek	dek	ADP	PCDat	_	3	case	_	_
+5	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
+6	gözlüklerinin	gözlük	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	7	nmod:poss	_	_
+7	üstünden	üst	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	amod	_	_
+8	izledi	izle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-2686
 # text = Saffet, en çok iki türkü için izin verirdi bu gösteriye.
@@ -26117,35 +26082,32 @@
 
 # sent_id = mst-2900
 # text = Melek her zamanki yerinde, ümitle gelene geçene flasterlerini ve kalemlerini uzatıyordu, ama nafile; kimsenin ona aldırdığı yoktu.
-1	Melek	Melek	PROPN	Prop	Case=Nom|Number=Sing|Person=3	15	nsubj	_	_
+# Change 2.2/dev: merge -(y)An
+1	Melek	Melek	PROPN	Prop	Case=Nom|Number=Sing|Person=3	13	nsubj	_	_
 2	her	her	DET	Det	_	5	nmod	_	_
 3-4	zamanki	_	_	_	_	_	_	_	_
 3	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	fixed	_	_
 4	ki	ki	ADP	Rel	_	3	case	_	_
-5	yerinde	yer	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obl	_	SpaceAfter=No
-6	,	,	PUNCT	Punc	_	15	punct	_	_
-7	ümitle	ümit	NOUN	Noun	Case=Ins|Number=Sing|Person=3	15	obl	_	_
-8-9	gelene	_	_	_	_	_	_	_	_
-8	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	compound:redup	_	_
-9	e	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	8	case	_	_
-10-11	geçene	_	_	_	_	_	_	_	_
-10	geçen	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	15	acl	_	_
-11	e	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	10	case	_	_
-12	flasterlerini	flaster	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	15	obj	_	_
-13	ve	ve	CCONJ	Conj	_	14	cc	_	_
-14	kalemlerini	kalem	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	12	conj	_	_
-15	uzatıyordu	uza	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
-16	,	,	PUNCT	Punc	_	18	punct	_	_
-17	ama	ama	CCONJ	Conj	_	18	cc	_	_
-18	nafile	nafile	ADJ	Adj	_	15	conj	_	SpaceAfter=No
-19	;	;	PUNCT	Punc	_	23	punct	_	_
-20	kimsenin	kimse	NOUN	Noun	Case=Gen|Number=Sing|Person=3	22	obl	_	_
-21	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	22	nmod:poss	_	_
-22	aldırdığı	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Cau	23	acl	_	_
-23-24	yoktu	_	_	_	_	_	_	_	SpaceAfter=No
-23	yok	yok	ADV	Adverb	_	15	advmod	_	_
-24	tu	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	23	cop	_	_
-25	.	.	PUNCT	Punc	_	23	punct	_	_
+5	yerinde	yer	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	obl	_	SpaceAfter=No
+6	,	,	PUNCT	Punc	_	13	punct	_	_
+7	ümitle	ümit	NOUN	Noun	Case=Ins|Number=Sing|Person=3	13	obl	_	_
+8	gelene	gel	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	9	compound:redup	_	_
+9	geçene	geç	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	13	acl	_	_
+10	flasterlerini	flaster	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	13	obj	_	_
+11	ve	ve	CCONJ	Conj	_	12	cc	_	_
+12	kalemlerini	kalem	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	10	conj	_	_
+13	uzatıyordu	uza	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
+14	,	,	PUNCT	Punc	_	16	punct	_	_
+15	ama	ama	CCONJ	Conj	_	16	cc	_	_
+16	nafile	nafile	ADJ	Adj	_	13	conj	_	SpaceAfter=No
+17	;	;	PUNCT	Punc	_	21	punct	_	_
+18	kimsenin	kimse	NOUN	Noun	Case=Gen|Number=Sing|Person=3	20	obl	_	_
+19	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	20	nmod:poss	_	_
+20	aldırdığı	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Cau	21	acl	_	_
+21-22	yoktu	_	_	_	_	_	_	_	SpaceAfter=No
+21	yok	yok	ADV	Adverb	_	13	advmod	_	_
+22	tu	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	21	cop	_	_
+23	.	.	PUNCT	Punc	_	21	punct	_	_
 
 # sent_id = mst-2903
 # text = CHP Genel Sekreter Yardımcısı Algan Hacaloğlu'nun hazırladığı pakette, " Kürt sorunu " ve " Güneydoğu sorunu " ifadeleri yerine " etnik duyarlılıklara demokratik çözüm " ve " kültürel çoğulculuk " kavramları tercih edildi.
@@ -27601,17 +27563,16 @@
 
 # sent_id = mst-3085
 # text = Onu tanıyanlar Bakırköy'de en yatmayacak insan diye tanımlıyor.
-1	Onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	3	obl	_	_
-2-3	tanıyanlar	_	_	_	_	_	_	_	_
-2	tanıyan	tanı	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	nsubj	_	_
-3	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	2	case	_	_
-4	Bakırköy'de	Bakırköy	PROPN	Prop	Case=Loc|Number=Sing|Person=3	6	obl	_	_
-5	en	en	ADV	Adverb	_	6	advmod	_	_
-6	yatmayacak	yat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Fut|VerbForm=Part	7	acl	_	_
-7	insan	insan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
-8	diye	diye	ADP	PCNom	_	7	case	_	_
-9	tanımlıyor	tanımla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
-10	.	.	PUNCT	Punc	_	9	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	2	obl	_	_
+2	tanıyanlar	tanı	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	8	nsubj	_	_
+3	Bakırköy'de	Bakırköy	PROPN	Prop	Case=Loc|Number=Sing|Person=3	5	obl	_	_
+4	en	en	ADV	Adverb	_	5	advmod	_	_
+5	yatmayacak	yat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Fut|VerbForm=Part	6	acl	_	_
+6	insan	insan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
+7	diye	diye	ADP	PCNom	_	6	case	_	_
+8	tanımlıyor	tanımla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-3087
 # text = Resmi bütün yollar kapalıydı.
@@ -28024,23 +27985,22 @@
 
 # sent_id = mst-3123
 # text = Onun çetrefil, kimi zaman açmazlarla dolu ruhunun içindeyiz demek, dedim.
-1	Onun	o	PRON	Pers	Case=Gen|Number=Sing|Person=3|PronType=Prs	9	nmod:poss	_	_
-2	çetrefil	çetrefil	ADJ	Adj	_	9	amod	_	SpaceAfter=No
-3	,	,	PUNCT	Punc	_	8	punct	_	_
+# Change 2.2/dev: fix açmaz VERB -> NOUN
+1	Onun	o	PRON	Pers	Case=Gen|Number=Sing|Person=3|PronType=Prs	8	nmod:poss	_	_
+2	çetrefil	çetrefil	ADJ	Adj	_	8	amod	_	SpaceAfter=No
+3	,	,	PUNCT	Punc	_	7	punct	_	_
 4	kimi	kimi	DET	Det	_	5	det	_	_
-5	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
-6-7	açmazlarla	_	_	_	_	_	_	_	_
-6	açmaz	aç	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	8	nmod	_	_
-7	larla	_	ADP	Zero	Case=Ins|Number=Plur|Person=3	6	case	_	_
-8	dolu	dolu	ADJ	Adj	_	2	conj	_	_
-9	ruhunun	ruh	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nmod	_	_
-10-11	içindeyiz	_	_	_	_	_	_	_	_
-10	içinde	içinde	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	ccomp	_	_
-11	yiz	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Tense=Pres	10	cop	_	_
-12	demek	demek	ADV	Adverb	_	10	advmod	_	SpaceAfter=No
-13	,	,	PUNCT	Punc	_	14	punct	_	_
-14	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-15	.	.	PUNCT	Punc	_	14	punct	_	_
+5	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
+6	açmazlarla	açmaz	NOUN	Noun	Case=Ins|Number=Plur|Person=3	7	nmod	_	_
+7	dolu	dolu	ADJ	Adj	_	2	conj	_	_
+8	ruhunun	ruh	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	nmod	_	_
+9-10	içindeyiz	_	_	_	_	_	_	_	_
+9	içinde	içinde	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	ccomp	_	_
+10	yiz	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Tense=Pres	9	cop	_	_
+11	demek	demek	ADV	Adverb	_	9	advmod	_	SpaceAfter=No
+12	,	,	PUNCT	Punc	_	13	punct	_	_
+13	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-3125
 # text = Ölüsünü eve getirdiklerinde, diyorum, elimi masanın hizasında tutarak, şu kadarcık bir çocuktum.
@@ -28545,21 +28505,20 @@
 
 # sent_id = mst-3174
 # text = Gidenin arkasından ağlayan partililer, gelecek başkan adaylarıyla da dirsek temasına geçti.
-1-2	Gidenin	_	_	_	_	_	_	_	_
-1	Giden	git	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	nmod:poss	_	_
-2	in	_	ADP	Zero	Case=Gen|Number=Sing|Person=3	1	case	_	_
-3	arkasından	arka	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	amod	_	_
-4	ağlayan	ağla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	acl	_	_
-5	partililer	partili	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	11	nsubj	_	SpaceAfter=No
-6	,	,	PUNCT	Punc	_	11	punct	_	_
-7	gelecek	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	9	acl	_	_
-8	başkan	başkan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nmod:poss	_	_
-9	adaylarıyla	aday	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	11	nmod	_	_
-10	da	da	CCONJ	Conj	_	9	advmod:emph	_	_
-11	dirsek	dirsek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-12	temasına	temas	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	compound	_	_
-13	geçti	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	11	compound	_	SpaceAfter=No
-14	.	.	PUNCT	Punc	_	11	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Gidenin	git	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	2	nmod:poss	_	_
+2	arkasından	arka	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	amod	_	_
+3	ağlayan	ağla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	acl	_	_
+4	partililer	partili	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	10	nsubj	_	SpaceAfter=No
+5	,	,	PUNCT	Punc	_	10	punct	_	_
+6	gelecek	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	8	acl	_	_
+7	başkan	başkan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
+8	adaylarıyla	aday	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	10	nmod	_	_
+9	da	da	CCONJ	Conj	_	8	advmod:emph	_	_
+10	dirsek	dirsek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
+11	temasına	temas	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	compound	_	_
+12	geçti	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	10	compound	_	SpaceAfter=No
+13	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-3175
 # text = kirk yıl önce bulunmuş değildir.
@@ -29553,24 +29512,24 @@
 # sent_id = mst-3285
 # text = Bir de en önemlisi, ot toplayıcılığı vardı halk arasında.
 # Change 2.2/dev: merge -(y)IcI
-1	Bir	bir	NUM	ANum	NumType=Card	11	nummod	_	_
+# Change 2.2/dev: merge li + si
+1	Bir	bir	NUM	ANum	NumType=Card	10	nummod	_	_
 2	de	de	CCONJ	Conj	_	1	advmod:emph	_	_
-3	en	en	ADV	Adverb	_	6	advmod	_	_
-4-6	önemlisi	_	_	_	_	_	_	_	SpaceAfter=No
-4	önem	önem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obl	_	_
-5	li	li	ADP	With	_	4	case	_	_
-6	si	_	ADP	Zero	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	case	_	_
-7	,	,	PUNCT	Punc	_	11	punct	_	_
-8	ot	ot	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
-9-10	toplayıcılığı	_	_	_	_	_	_	_	_
-9	toplayıcı	topla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	csubj	_	_
-10	lığı	lik	ADP	Ness	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	case	_	_
-11-12	vardı	_	_	_	_	_	_	_	_
-11	var	var	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
-12	dı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	11	cop	_	_
-13	halk	halk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	nmod:poss	_	_
-14	arasında	ara	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	amod	_	SpaceAfter=No
-15	.	.	PUNCT	Punc	_	11	punct	_	_
+3	en	en	ADV	Adverb	_	4	advmod	_	_
+4-5	önemlisi	_	_	_	_	_	_	_	SpaceAfter=No
+4	önem	önem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obl	_	_
+5	lisi	li	ADP	With	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	case	_	_
+6	,	,	PUNCT	Punc	_	10	punct	_	_
+7	ot	ot	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
+8-9	toplayıcılığı	_	_	_	_	_	_	_	_
+8	toplayıcı	topla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	csubj	_	_
+9	lığı	lik	ADP	Ness	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	case	_	_
+10-11	vardı	_	_	_	_	_	_	_	_
+10	var	var	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
+11	dı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	10	cop	_	_
+12	halk	halk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nmod:poss	_	_
+13	arasında	ara	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	amod	_	SpaceAfter=No
+14	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-3286
 # text = Komutanlar, bu açıklamaların Başbakan ve resmi yetkililer tarafından da yapılmasında fayda olacağını ifade ettiler.
@@ -30662,27 +30621,26 @@
 
 # sent_id = mst-3415
 # text = Şahin, " BDDK istese de istemese de kamuda rahatlama için emekliliği gelenleri emekli etmeyi düşünüyoruz " dedi.
-1	Şahin	Şahin	PROPN	Prop	Case=Nom|Number=Sing|Person=3	19	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	Punc	_	19	punct	_	_
-3	"	"	PUNCT	Punc	_	17	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Şahin	Şahin	PROPN	Prop	Case=Nom|Number=Sing|Person=3	18	nsubj	_	SpaceAfter=No
+2	,	,	PUNCT	Punc	_	18	punct	_	_
+3	"	"	PUNCT	Punc	_	16	punct	_	_
 4	BDDK	Bddk	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
-5	istese	iste	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	17	nmod	_	_
+5	istese	iste	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	16	nmod	_	_
 6	de	de	CCONJ	Conj	_	5	advmod:emph	_	_
 7	istemese	iste	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	5	conj	_	_
 8	de	de	CCONJ	Conj	_	7	advmod:emph	_	_
 9	kamuda	kamu	NOUN	Noun	Case=Loc|Number=Sing|Person=3	10	obl	_	_
-10	rahatlama	rahatla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	15	nmod	_	_
+10	rahatlama	rahatla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	14	nmod	_	_
 11	için	için	ADP	PCNom	_	10	case	_	_
 12	emekliliği	emeklilik	NOUN	Noun	Case=Acc|Number=Sing|Person=3	13	nsubj	_	_
-13-14	gelenleri	_	_	_	_	_	_	_	_
-13	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	15	obj	_	_
-14	leri	_	ADP	Zero	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	13	case	_	_
-15	emekli	emekli	ADJ	Adj	_	17	obj	_	_
-16	etmeyi	et	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	15	compound:lvc	_	_
-17	düşünüyoruz	düşün	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	19	obj	_	_
-18	"	"	PUNCT	Punc	_	17	punct	_	_
-19	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-20	.	.	PUNCT	Punc	_	19	punct	_	_
+13	gelenleri	gel	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Part	14	obj	_	_
+14	emekli	emekli	ADJ	Adj	_	16	obj	_	_
+15	etmeyi	et	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	14	compound:lvc	_	_
+16	düşünüyoruz	düşün	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	18	obj	_	_
+17	"	"	PUNCT	Punc	_	16	punct	_	_
+18	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+19	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-3417
 # text = Önlerde bir yere oturduk.
@@ -31683,14 +31641,13 @@
 
 # sent_id = mst-3539
 # text = Stas bir kapanı işaret ediyor.
-1	Stas	Stas	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
-2	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
-3-4	kapanı	_	_	_	_	_	_	_	_
-3	kapan	kap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	obj	_	_
-4	ı	_	ADP	Zero	Case=Acc|Number=Sing|Person=3	3	case	_	_
-5	işaret	işaret	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-6	ediyor	et	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	5	compound:lvc	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	5	punct	_	_
+# Change 2.2/dev: fix 'kapanı' VERB -> NOUN
+1	Stas	Stas	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
+2	bir	bir	NUM	ANum	NumType=Card	3	det	_	_
+3	kapanı	kap	NOUN	Noun	Case=Acc|Number=Sing|Person=3	4	obj	_	_
+4	işaret	işaret	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
+5	ediyor	et	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	4	compound:lvc	_	SpaceAfter=No
+6	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-3540
 # text = Bunları söylerken iki adımda Ömür Uzatma Kıraathanesi'nin kapısına varmıştı.
@@ -33723,12 +33680,11 @@
 
 # sent_id = mst-3749
 # text = Kavrulmamışı da olmaz.
-1-2	Kavrulmamışı	_	_	_	_	_	_	_	_
-1	Kavrulmamış	kavrul	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Neg|Tense=Past|VerbForm=Part	4	obj	_	_
-2	ı	_	ADP	Zero	Case=Acc|Number=Sing|Person=3	1	case	_	_
-3	da	da	CCONJ	Conj	_	2	advmod:emph	_	_
-4	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	4	punct	_	_
+# Change 2.2/dev: merge Kavrulmamış + ı
+1	Kavrulmamışı	kavrul	VERB	Verb	Aspect=Perf|Case=Acc|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past|VerbForm=Part	3	ccomp	_	_
+2	da	da	CCONJ	Conj	_	1	advmod:emph	_	_
+3	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3750
 # text = Ama bakın; en büyük korkunuz, en sevdiğiniz varlığınız oğlunuzun ölümü değil.
@@ -34119,20 +34075,19 @@
 
 # sent_id = mst-3790
 # text = Yarının hayal edilmiş dünyasına göre vizyonları olanlar, yarına geçecek sınırdan...
+# Change 2.2/dev: merge -(y)An
 1	Yarının	yarın	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod	_	_
 2	hayal	hayal	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod	_	_
 3	edilmiş	et	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	2	compound:lvc	_	_
-4	dünyasına	dünya	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obl	_	_
+4	dünyasına	dünya	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obl	_	_
 5	göre	göre	ADP	PCDat	_	4	case	_	_
-6	vizyonları	vizyon	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	8	obl	_	_
-7-8	olanlar	_	_	_	_	_	_	_	SpaceAfter=No
-7	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	nsubj	_	_
-8	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	7	case	_	_
-9	,	,	PUNCT	Punc	_	7	punct	_	_
-10	yarına	yarın	NOUN	Noun	Case=Dat|Number=Sing|Person=3	11	obl	_	_
-11	geçecek	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
-12	sınırdan	sınır	NOUN	Noun	Case=Abl|Number=Sing|Person=3	11	obl	_	SpaceAfter=No
-13	...	...	PUNCT	Punc	_	11	punct	_	_
+6	vizyonları	vizyon	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	7	obj	_	_
+7	olanlar	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	10	nsubj	_	SpaceAfter=No
+8	,	,	PUNCT	Punc	_	7	punct	_	_
+9	yarına	yarın	NOUN	Noun	Case=Dat|Number=Sing|Person=3	10	obl	_	_
+10	geçecek	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
+11	sınırdan	sınır	NOUN	Noun	Case=Abl|Number=Sing|Person=3	10	obl	_	SpaceAfter=No
+12	...	...	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-3791
 # text = Ufaklık için de bir açıklamaya ihtiyacım olacaktı belli ki Köpek de nöbetçimiz olacak.
@@ -34423,15 +34378,14 @@
 
 # sent_id = mst-3824
 # text = Dönüp baktı, Ramiz ile Katana.
+# Change 2.2/dev: fix proper name Katana.
 1	Dönüp	dön	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	0	root	_	_
 2	baktı	bak	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	2	punct	_	_
 4	Ramiz	Ramiz	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
 5	ile	ile	CCONJ	Conj	_	7	cc	_	_
-6-7	Katana	_	_	_	_	_	_	_	SpaceAfter=No
-6	Katan	kat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	2	conj	_	_
-7	a	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	6	case	_	_
-8	.	.	PUNCT	Punc	_	7	punct	_	_
+6	Katana	Katana	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	conj	_	SpaceAfter=No
+7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3825
 # text = Başka ne yapabilirim ki.
@@ -34853,19 +34807,17 @@
 
 # sent_id = mst-3869
 # text = Benim gibi yüksek tansiyonu olanlar tuzsuz da yer.
-1-2	Benim	_	_	_	_	_	_	_	_
-1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	obl	_	_
-2	im	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	1	cop	_	_
-3	gibi	gibi	ADP	PCNom	_	1	case	_	_
-4	yüksek	yüksek	ADJ	Adj	_	5	amod	_	_
-5	tansiyonu	tansiyon	NOUN	Noun	Case=Acc|Number=Sing|Person=3	7	nsubj	_	_
-6-7	olanlar	_	_	_	_	_	_	_	_
-6	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	nsubj	_	_
-7	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	6	case	_	_
-8	tuzsuz	tuzsuz	ADJ	Adj	_	10	obj	_	_
-9	da	da	CCONJ	Conj	_	8	advmod:emph	_	_
-10	yer	yer	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	10	punct	_	_
+# Change 2.2/dev: merge -(y)An
+# Change 2.2/dev: fix 'benim', -im is not copular here
+1	Benim	ben	PRON	Pers	Case=Gen|Number=Sing|Person=1|PronType=Prs	5	obl	_	_
+2	gibi	gibi	ADP	PCNom	_	1	case	_	_
+3	yüksek	yüksek	ADJ	Adj	_	4	amod	_	_
+4	tansiyonu	tansiyon	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	nsubj	_	_
+5	olanlar	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	8	csubj	_	_
+6	tuzsuz	tuzsuz	ADJ	Adj	_	8	obj	_	_
+7	da	da	CCONJ	Conj	_	6	advmod:emph	_	_
+8	yer	yer	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-3871
 # text = Ben de sakız çiğnemekle ayıp arasında bir bağlantı kuramıyorum.
@@ -36498,6 +36450,7 @@
 
 # sent_id = mst-4063
 # text = Başka siyasetçiler, başka toplumlar, başka uluslar için anlayana...
+# Change 2.2/dev: merge -(y)An
 1	Başka	başka	ADJ	Adj	_	2	amod	_	_
 2	siyasetçiler	siyasetçi	NOUN	Noun	Case=Nom|Number=Plur|Person=3	10	case	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	5	punct	_	_
@@ -36507,10 +36460,8 @@
 7	başka	başka	ADJ	Adj	_	8	amod	_	_
 8	uluslar	ulus	NOUN	Noun	Case=Nom|Number=Plur|Person=3	2	conj	_	_
 9	için	için	ADP	PCNom	_	2	case	_	_
-10-11	anlayana	_	_	_	_	_	_	_	SpaceAfter=No
-10	anlayan	anla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	0	root	_	_
-11	a	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	2	conj	_	_
-12	...	...	PUNCT	Punc	_	10	punct	_	_
+10	anlayana	anla	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	0	root	_	SpaceAfter=No
+11	...	...	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-4064
 # text = Kopenhag'da otellerin önünde bekleyen kızlar, Hamburg'un, Berlin'in... buluşma yerleri...
@@ -36599,12 +36550,12 @@
 
 # sent_id = mst-4074
 # text = Mersedes'liden kazandım...
-1-3	Mersedes'liden	_	_	_	_	_	_	_	_
-1	Mersedes	Mersedes	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	obj	_	_
-2	'li	li	ADP	With	_	1	case	_	_
-3	den	_	ADP	Zero	Case=Abl|Number=Sing|Person=3	1	case	_	_
-4	kazandım	kazan	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-5	...	...	PUNCT	Punc	_	4	punct	_	_
+# Change 2.2/dev: merge  -li + den
+1-2	Mersedes'liden	_	_	_	_	_	_	_	_
+1	Mersedes	Mersedes	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	obj	_	_
+2	'liden	li	ADP	With	Case=Abl|Number=Sing|Person=3	1	case	_	_
+3	kazandım	kazan	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+4	...	...	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-4076
 # text = Şehvet ve arzu yaşanırken, eski bir kadının düşüncelere girmesi çok zordur.
@@ -38463,23 +38414,22 @@
 
 # sent_id = mst-4285
 # text = Böyle bir saldırıyla karşılaşan bir geyik çobanı sabah, heyecanla olanları anlatmıştı yola çıkarlarken.
+# Change 2.2/dev: merge -(y)An
 1	Böyle	böyle	ADJ	Adj	_	3	amod	_	_
 2	bir	bir	NUM	ANum	NumType=Card	3	det	_	_
 3	saldırıyla	saldırı	NOUN	Noun	Case=Ins|Number=Sing|Person=3	4	obl	_	_
 4	karşılaşan	karşılaş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	acl	_	_
 5	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
 6	geyik	geyik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod:poss	_	_
-7	çobanı	çoban	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	nsubj	_	_
-8	sabah	sabah	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	SpaceAfter=No
+7	çobanı	çoban	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	nsubj	_	_
+8	sabah	sabah	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	10	punct	_	_
 10	heyecanla	heyecan	NOUN	Noun	Case=Ins|Number=Sing|Person=3	8	conj	_	_
-11-12	olanları	_	_	_	_	_	_	_	_
-11	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	13	obj	_	_
-12	ları	_	ADP	Zero	Case=Acc|Number=Plur|Person=3	11	case	_	_
-13	anlatmıştı	anla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp|Voice=Cau	0	root	_	_
-14	yola	yol	NOUN	Noun	Case=Dat|Number=Sing|Person=3	15	obl	_	_
-15	çıkarlarken	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	13	nmod	_	SpaceAfter=No
-16	.	.	PUNCT	Punc	_	15	punct	_	_
+11	olanları	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	12	obj	_	_
+12	anlatmıştı	anla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp|Voice=Cau	0	root	_	_
+13	yola	yol	NOUN	Noun	Case=Dat|Number=Sing|Person=3	14	obl	_	_
+14	çıkarlarken	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	12	nmod	_	SpaceAfter=No
+15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-4286
 # text = Nasıl bir viski vereyim sana.
@@ -39834,26 +39784,25 @@
 
 # sent_id = mst-4436
 # text = Sonunda elde kalanın doyum mu, doyumsuzluk mu olduğuna karar veremediğin, tütsülerin savrulduğu anıt-mezarlar...
+# Change 2.2/dev: merge -(y)An
 1	Sonunda	sonunda	ADV	Adverb	_	2	advmod	_	_
-2	elde	el	NOUN	Noun	Case=Loc|Number=Sing|Person=3	10	nmod:poss	_	_
-3-4	kalanın	_	_	_	_	_	_	_	_
-3	kalan	kal	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	2	compound	_	_
-4	ın	_	ADP	Zero	Case=Gen|Number=Sing|Person=3	2	case	_	_
-5	doyum	doyum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obj	_	_
-6	mu	mu	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	5	aux:q	_	SpaceAfter=No
-7	,	,	PUNCT	Punc	_	8	punct	_	_
-8	doyumsuzluk	doyumsuzluk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	conj	_	_
-9	mu	mu	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	8	aux:q	_	_
-10	olduğuna	ol	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	11	acl	_	_
-11	karar	karar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nmod	_	_
-12	veremediğin	ver	VERB	Verb	Aspect=Perf|Mood=Pot|Number[psor]=Sing|Person[psor]=2|Polarity=Neg|Tense=Past|VerbForm=Part	11	compound	_	SpaceAfter=No
-13	,	,	PUNCT	Punc	_	18	punct	_	_
-14	tütsülerin	tütsü	NOUN	Noun	Case=Gen|Number=Plur|Person=3	15	nmod:poss	_	_
-15	savrulduğu	savrul	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	18	acl	_	_
-16	anıt	anıt	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nmod	_	SpaceAfter=No
-17	-	-	PUNCT	Punc	_	18	punct	_	SpaceAfter=No
-18	mezarlar	mezar	NOUN	Noun	Case=Nom|Number=Plur|Person=3	0	root	_	SpaceAfter=No
-19	...	...	PUNCT	Punc	_	18	punct	_	_
+2	elde	el	NOUN	Noun	Case=Loc|Number=Sing|Person=3	9	nmod:poss	_	_
+3	kalanın	kal	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	2	compound	_	_
+4	doyum	doyum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
+5	mu	mu	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	4	aux:q	_	SpaceAfter=No
+6	,	,	PUNCT	Punc	_	7	punct	_	_
+7	doyumsuzluk	doyumsuzluk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	conj	_	_
+8	mu	mu	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	7	aux:q	_	_
+9	olduğuna	ol	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	10	acl	_	_
+10	karar	karar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nmod	_	_
+11	veremediğin	ver	VERB	Verb	Aspect=Perf|Mood=Pot|Number[psor]=Sing|Person[psor]=2|Polarity=Neg|Tense=Past|VerbForm=Part	10	compound	_	SpaceAfter=No
+12	,	,	PUNCT	Punc	_	17	punct	_	_
+13	tütsülerin	tütsü	NOUN	Noun	Case=Gen|Number=Plur|Person=3	14	nmod:poss	_	_
+14	savrulduğu	savrul	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	17	acl	_	_
+15	anıt	anıt	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nmod	_	SpaceAfter=No
+16	-	-	PUNCT	Punc	_	17	punct	_	SpaceAfter=No
+17	mezarlar	mezar	NOUN	Noun	Case=Nom|Number=Plur|Person=3	0	root	_	SpaceAfter=No
+18	...	...	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-4438
 # text = Eski kocası havuzun başında durur her zaman.
@@ -40119,6 +40068,7 @@
 
 # sent_id = mst-4466
 # text = Ta ki delikanlı kendisine para için şantaj yapana kadar.
+# Change 2.2/dev: merge -(y)An
 1	Ta	ta	ADV	Adverb	_	7	advmod	_	_
 2	ki	ki	CCONJ	Conj	_	1	compound	_	_
 3	delikanlı	delikanlı	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
@@ -40126,11 +40076,9 @@
 5	para	para	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
 6	için	için	ADP	PCNom	_	5	case	_	_
 7	şantaj	şantaj	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-8-9	yapana	_	_	_	_	_	_	_	_
-8	yapan	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	compound:lvc	_	_
-9	a	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	7	case	_	_
-10	kadar	kadar	ADP	PCDat	_	7	case	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	7	punct	_	_
+8	yapana	yap	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	7	compound:lvc	_	_
+9	kadar	kadar	ADP	PCDat	_	7	case	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-4467
 # text = Size iyi tatiller.
@@ -40443,18 +40391,17 @@
 
 # sent_id = mst-4503
 # text = Tamamen yaşayanları korumaya yönelik bir rapor hazırlandı, dedi.
-1	Tamamen	tamamen	ADV	Adverb	_	4	advmod	_	_
-2-3	yaşayanları	_	_	_	_	_	_	_	_
-2	yaşayan	yaşa	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	obj	_	_
-3	ları	_	ADP	Zero	Case=Acc|Number=Plur|Person=3	2	case	_	_
-4	korumaya	koru	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	nmod	_	_
-5	yönelik	yönelik	ADP	PCDat	_	4	case	_	_
-6	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
-7	rapor	rapor	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8	hazırlandı	hazırla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	10	obj	_	SpaceAfter=No
-9	,	,	PUNCT	Punc	_	8	punct	_	_
-10	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	10	punct	_	_
+# Change 2.2/dev: merge -(y)An
+1	Tamamen	tamamen	ADV	Adverb	_	3	advmod	_	_
+2	yaşayanları	yaşa	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	3	obj	_	_
+3	korumaya	koru	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	nmod	_	_
+4	yönelik	yönelik	ADP	PCDat	_	3	case	_	_
+5	bir	bir	NUM	ANum	NumType=Card	6	det	_	_
+6	rapor	rapor	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
+7	hazırlandı	hazırla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	9	obj	_	SpaceAfter=No
+8	,	,	PUNCT	Punc	_	7	punct	_	_
+9	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-4505
 # text = kirk yaşındayım.
@@ -41892,14 +41839,13 @@
 
 # sent_id = mst-4680
 # text = O parktan kurtulana pek rastlamadım.
+# Change 2.2/dev: merge -(y)An
 1	O	o	DET	Det	_	2	det	_	_
 2	parktan	park	NOUN	Noun	Case=Abl|Number=Sing|Person=3	3	obl	_	_
-3-4	kurtulana	_	_	_	_	_	_	_	_
-3	kurtulan	kurtul	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	acl	_	_
-4	a	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	3	case	_	_
-5	pek	pek	ADV	Adverb	_	6	advmod	_	_
-6	rastlamadım	rastla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	6	punct	_	_
+3	kurtulana	kurtul	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	5	acl	_	_
+4	pek	pek	ADV	Adverb	_	5	advmod	_	_
+5	rastlamadım	rastla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
+6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4682
 # text = Potaya girerken arkadan gelen bir diğeri onları vurabilir.
@@ -42104,13 +42050,12 @@
 
 # sent_id = mst-4707
 # text = Önüne gelenle yatıp kalkıyormuşum.
+# Change 2.2/dev: merge -(y)An
 1	Önüne	ön	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	case	_	_
-2-3	gelenle	_	_	_	_	_	_	_	_
-2	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	acl	_	_
-3	le	_	ADP	Zero	Case=Ins|Number=Sing|Person=3	1	compound	_	_
-4	yatıp	yat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	0	root	_	_
-5	kalkıyormuşum	kalk	VERB	Verb	Aspect=Prog|Evident=Nfh|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Past	4	compound	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	4	punct	_	_
+2	gelenle	gel	VERB	Verb	Aspect=Perf|Case=Ins|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	3	acl	_	_
+3	yatıp	yat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	0	root	_	_
+4	kalkıyormuşum	kalk	VERB	Verb	Aspect=Prog|Evident=Nfh|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Past	3	compound	_	SpaceAfter=No
+5	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-4708
 # text = Herkes onun peşinde.
@@ -42764,25 +42709,24 @@
 
 # sent_id = mst-4796
 # text = Melek her gün yüz bin lira kazansam, kış gelene kadar bir kondu alabilir miyiz?.
-1	Melek	Melek	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	_
+# Change 2.2/dev: merge -(y)An
+1	Melek	Melek	PROPN	Prop	Case=Nom|Number=Sing|Person=3	14	vocative	_	_
 2	her	her	DET	Det	_	7	det	_	_
 3	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound	_	_
 4	yüz	yüz	NUM	ANum	NumType=Card	7	obj	_	_
 5	bin	bin	NUM	ANum	NumType=Card	4	flat	_	_
 6	lira	lira	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	flat	_	_
-7	kazansam	kazan	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	15	nmod	_	SpaceAfter=No
+7	kazansam	kazan	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	14	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	kış	kış	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obj	_	_
-10-11	gelene	_	_	_	_	_	_	_	_
-10	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	15	acl	_	_
-11	e	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	10	case	_	_
-12	kadar	kadar	ADP	PCDat	_	10	case	_	_
-13	bir	bir	NUM	ANum	NumType=Card	14	det	_	_
-14	kondu	kon	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	15	obj	_	_
-15	alabilir	al	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	_
-16	miyiz	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Tense=Pres	15	aux:q	_	SpaceAfter=No
-17	?	?	PUNCT	Punc	_	15	punct	_	SpaceAfter=No
-18	.	.	PUNCT	Punc	_	15	punct	_	_
+10	gelene	gel	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	14	acl	_	_
+11	kadar	kadar	ADP	PCDat	_	10	case	_	_
+12	bir	bir	NUM	ANum	NumType=Card	13	det	_	_
+13	kondu	kon	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	14	obj	_	_
+14	alabilir	al	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+15	miyiz	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Tense=Pres	14	aux:q	_	SpaceAfter=No
+16	?	?	PUNCT	Punc	_	14	punct	_	SpaceAfter=No
+17	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-4797
 # text = Ben Erbakan'ın yanında onun yanlışlarına ortak olsaydım kırk defa bakan olurdum, elli defa genel başkan olurdum.
@@ -42829,27 +42773,26 @@
 
 # sent_id = mst-4800
 # text = Drugstore'da alışveriş yapanların yüzde 91'i ambalajın önyüzünü, yüzde 42'si arkasını, yüzde 8'i de yan yüzlerini okuyor.
+# Change 2.2/dev: merge -(y)An
 1	Drugstore'da	Drugstore	PROPN	Prop	Case=Loc|Number=Sing|Person=3	2	nmod	_	_
-2	alışveriş	alışveriş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	compound	_	_
-3-4	yapanların	_	_	_	_	_	_	_	_
-3	yapan	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	2	compound:lvc	_	_
-4	ların	_	ADP	Zero	Case=Gen|Number=Plur|Person=3	2	case	_	_
-5	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	19	nsubj	_	_
-6	91'i	91	NUM	NNum	Case=Acc|Number=Sing|NumType=Card|Person=3	5	flat	_	_
-7	ambalajın	ambalaj	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	8	nmod:poss	_	_
-8	önyüzünü	önyüz	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	obj	_	SpaceAfter=No
-9	,	,	PUNCT	Punc	_	19	punct	_	_
-10	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	19	nsubj	_	_
-11	42'si	42	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=3	10	flat	_	_
-12	arkasını	arka	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	obj	_	SpaceAfter=No
-13	,	,	PUNCT	Punc	_	19	punct	_	_
-14	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	19	nsubj	_	_
-15	8'i	8	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=3	14	flat	_	_
-16	de	de	CCONJ	Conj	_	14	advmod:emph	_	_
-17	yan	yan	ADJ	Adj	_	18	amod	_	_
-18	yüzlerini	yüz	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	19	obj	_	_
-19	okuyor	oku	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
-20	.	.	PUNCT	Punc	_	19	punct	_	_
+2	alışveriş	alışveriş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	compound	_	_
+3	yapanların	yap	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	2	compound:lvc	_	_
+4	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	18	nsubj	_	_
+5	91'i	91	NUM	NNum	Case=Acc|Number=Sing|NumType=Card|Person=3	4	flat	_	_
+6	ambalajın	ambalaj	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	7	nmod:poss	_	_
+7	önyüzünü	önyüz	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	obj	_	SpaceAfter=No
+8	,	,	PUNCT	Punc	_	18	punct	_	_
+9	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	18	nsubj	_	_
+10	42'si	42	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=3	9	flat	_	_
+11	arkasını	arka	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	obj	_	SpaceAfter=No
+12	,	,	PUNCT	Punc	_	18	punct	_	_
+13	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	18	nsubj	_	_
+14	8'i	8	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=3	13	flat	_	_
+15	de	de	CCONJ	Conj	_	13	advmod:emph	_	_
+16	yan	yan	ADJ	Adj	_	17	amod	_	_
+17	yüzlerini	yüz	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	18	obj	_	_
+18	okuyor	oku	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
+19	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-4801
 # text = Bir kuramın yanlışlanabilirliği o kuramın olumsuzluğuna, işe yaramazlığına değil, tam tersine verimliliğine, doğurganlığına işaret eder.
@@ -43811,20 +43754,19 @@
 
 # sent_id = mst-4898
 # text = Sahnede dans edenler sanki insan değil de tüy gibi geldi bana.
+# Change 2.2/dev: merge -(y)An
 1	Sahnede	sahne	NOUN	Noun	Case=Loc|Number=Sing|Person=3	2	nmod	_	_
-2	dans	dans	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
-3-4	edenler	_	_	_	_	_	_	_	_
-3	eden	et	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	2	compound:lvc	_	_
-4	ler	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	2	case	_	_
-5	sanki	sanki	ADV	Adverb	_	7	advmod	_	_
-6	insan	insan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
-7	değil	değil	CCONJ	Conj	_	11	nmod	_	_
-8	de	de	CCONJ	Conj	_	9	cc	_	_
-9	tüy	tüy	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	7	conj	_	_
-10	gibi	gibi	ADP	PCNom	_	7	case	_	_
-11	geldi	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
-12	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	11	obl	_	SpaceAfter=No
-13	.	.	PUNCT	Punc	_	11	punct	_	_
+2	dans	dans	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
+3	edenler	et	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	2	compound:lvc	_	_
+4	sanki	sanki	ADV	Adverb	_	6	advmod	_	_
+5	insan	insan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
+6	değil	değil	CCONJ	Conj	_	10	nmod	_	_
+7	de	de	CCONJ	Conj	_	8	cc	_	_
+8	tüy	tüy	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	6	conj	_	_
+9	gibi	gibi	ADP	PCNom	_	6	case	_	_
+10	geldi	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+11	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	10	obl	_	SpaceAfter=No
+12	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-4899
 # text = Ayrıca oyunculuğu da çok iyi " dedi.
@@ -44068,20 +44010,19 @@
 
 # sent_id = mst-4926
 # text = O arada geri dönüp olanları anlatmaya çalışan Ramiz'in kafasına indirdi cetvelini.
-1	O	o	DET	Det	_	10	nsubj	_	_
+# Change 2.2/dev: merge -(y)An
+1	O	o	DET	Det	_	9	nsubj	_	_
 2	arada	ara	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	3	amod	_	_
-3	geri	geri	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	7	amod	_	_
+3	geri	geri	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	6	amod	_	_
 4	dönüp	dön	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	3	compound	_	_
-5-6	olanları	_	_	_	_	_	_	_	_
-5	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	obj	_	_
-6	ları	_	ADP	Zero	Case=Acc|Number=Plur|Person=3	5	case	_	_
-7	anlatmaya	anlat	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nmod	_	_
-8	çalışan	çalış	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	acl	_	_
-9	Ramiz'in	Ramiz	PROPN	Prop	Case=Gen|Number=Sing|Person=3	10	nmod:poss	_	_
-10	kafasına	kafa	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
-11	indirdi	in	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	10	compound	_	_
-12	cetvelini	cetvel	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obj	_	SpaceAfter=No
-13	.	.	PUNCT	Punc	_	10	punct	_	_
+5	olanları	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	6	obj	_	_
+6	anlatmaya	anlat	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	nmod	_	_
+7	çalışan	çalış	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	8	acl	_	_
+8	Ramiz'in	Ramiz	PROPN	Prop	Case=Gen|Number=Sing|Person=3	9	nmod:poss	_	_
+9	kafasına	kafa	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
+10	indirdi	in	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	9	compound	_	_
+11	cetvelini	cetvel	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obj	_	SpaceAfter=No
+12	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-4927
 # text = altı yıl önce Aysun Hanım'la evlenen Ulusu, kaderinin bu denli tesadüfi çizilebileceğini bilemezdi belki.
@@ -45188,45 +45129,42 @@
 
 # sent_id = mst-5057
 # text = İşte o zaman, bu turistik yörenin olağanüstü tarihine merak duyanlar, buradaki insanların birkaç bin yıl önceki bir uygarlığın torunları olduğunu bilenler, tarihten bir sahnenin canlanmakta olduğunu sezerlerdi.
+# Change 2.2/dev: merge -(y)An
 1	İşte	işte	ADV	Adverb	_	2	advmod:emph	_	_
-2	o	o	DET	Det	_	34	det	_	_
+2	o	o	DET	Det	_	32	det	_	_
 3	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound	_	SpaceAfter=No
-4	,	,	PUNCT	Punc	_	34	punct	_	_
+4	,	,	PUNCT	Punc	_	32	punct	_	_
 5	bu	bu	DET	Det	_	7	det	_	_
 6	turistik	turistik	ADJ	Adj	_	7	amod	_	_
 7	yörenin	yöre	NOUN	Noun	Case=Gen|Number=Sing|Person=3	9	nmod:poss	_	_
 8	olağanüstü	olağanüstü	ADJ	Adj	_	9	amod	_	_
 9	tarihine	tarih	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nmod	_	_
-10	merak	merak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	34	nsubj	_	_
-11-12	duyanlar	_	_	_	_	_	_	_	SpaceAfter=No
-11	duyan	duy	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	compound	_	_
-12	lar	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	10	case	_	_
-13	,	,	PUNCT	Punc	_	27	punct	_	_
-14-15	buradaki	_	_	_	_	_	_	_	_
-14	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	16	nmod	_	_
-15	ki	ki	ADP	Rel	_	14	case	_	_
-16	insanların	insan	NOUN	Noun	Case=Gen|Number=Plur|Person=3	25	nmod:poss	_	_
-17	birkaç	birkaç	DET	Det	_	18	det	_	_
-18	bin	bin	NUM	ANum	NumType=Card	19	nummod	_	_
-19	yıl	yıl	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nmod	_	_
-20-21	önceki	_	_	_	_	_	_	_	_
-20	önce	önce	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	nmod	_	_
-21	ki	ki	ADP	Rel	_	20	case	_	_
-22	bir	bir	NUM	ANum	NumType=Card	23	det	_	_
-23	uygarlığın	uygarlık	NOUN	Noun	Case=Gen|Number=Sing|Person=3	24	nmod	_	_
-24	torunları	torun	NOUN	Noun	Case=Acc|Number=Plur|Person=3	25	obl	_	_
-25	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	26	obj	_	_
-26-27	bilenler	_	_	_	_	_	_	_	SpaceAfter=No
-26	bilen	bil	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	12	conj	_	_
-27	ler	_	ADP	Zero	Case=Nom|Number=Plur|Person=3	26	case	_	_
-28	,	,	PUNCT	Punc	_	27	punct	_	_
-29	tarihten	tarih	NOUN	Noun	Case=Abl|Number=Sing|Person=3	31	nmod	_	_
-30	bir	bir	NUM	ANum	NumType=Card	31	det	_	_
-31	sahnenin	sahne	NOUN	Noun	Case=Gen|Number=Sing|Person=3	33	nmod:poss	_	_
-32	canlanmakta	canlan	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Form|Tense=Pres	33	nmod	_	_
-33	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	34	obj	_	_
-34	sezerlerdi	sez	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
-35	.	.	PUNCT	Punc	_	34	punct	_	_
+10	merak	merak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	32	nsubj	_	_
+11	duyanlar	duy	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	10	compound	_	SpaceAfter=No
+12	,	,	PUNCT	Punc	_	25	punct	_	_
+13-14	buradaki	_	_	_	_	_	_	_	_
+13	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	15	nmod	_	_
+14	ki	ki	ADP	Rel	_	13	case	_	_
+15	insanların	insan	NOUN	Noun	Case=Gen|Number=Plur|Person=3	24	nmod:poss	_	_
+16	birkaç	birkaç	DET	Det	_	17	det	_	_
+17	bin	bin	NUM	ANum	NumType=Card	18	nummod	_	_
+18	yıl	yıl	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	nmod	_	_
+19-20	önceki	_	_	_	_	_	_	_	_
+19	önce	önce	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	nmod	_	_
+20	ki	ki	ADP	Rel	_	20	case	_	_
+21	bir	bir	NUM	ANum	NumType=Card	22	det	_	_
+22	uygarlığın	uygarlık	NOUN	Noun	Case=Gen|Number=Sing|Person=3	23	nmod	_	_
+23	torunları	torun	NOUN	Noun	Case=Acc|Number=Plur|Person=3	24	obl	_	_
+24	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	25	obj	_	_
+25	bilenler	bil	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	11	conj	_	SpaceAfter=No
+26	,	,	PUNCT	Punc	_	25	punct	_	_
+27	tarihten	tarih	NOUN	Noun	Case=Abl|Number=Sing|Person=3	29	nmod	_	_
+28	bir	bir	NUM	ANum	NumType=Card	29	det	_	_
+29	sahnenin	sahne	NOUN	Noun	Case=Gen|Number=Sing|Person=3	31	nmod:poss	_	_
+30	canlanmakta	canlan	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Form|Tense=Pres	31	nmod	_	_
+31	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	32	obj	_	_
+32	sezerlerdi	sez	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+33	.	.	PUNCT	Punc	_	32	punct	_	_
 
 # sent_id = mst-5060
 # text = Erkekler Parkı'ndan geliyorum.
@@ -46219,18 +46157,17 @@
 
 # sent_id = mst-5196
 # text = Bu işlem, bardak ağzına ulaşana dek özenle sürerdi.
+# Change 2.2/dev: merge -(y)An
 1	Bu	bu	DET	Det	_	2	det	_	_
-2	işlem	işlem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	SpaceAfter=No
-3	,	,	PUNCT	Punc	_	10	punct	_	_
+2	işlem	işlem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	Punc	_	9	punct	_	_
 4	bardak	bardak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
 5	ağzına	ağız	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	_
-6-7	ulaşana	_	_	_	_	_	_	_	_
-6	ulaşan	ulaş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	acl	_	_
-7	a	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	6	case	_	_
-8	dek	dek	ADP	PCDat	_	6	case	_	_
-9	özenle	özen	NOUN	Noun	Case=Ins|Number=Sing|Person=3	10	obl	_	_
-10	sürerdi	sür	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	10	punct	_	_
+6	ulaşana	ulaş	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	8	acl	_	_
+7	dek	dek	ADP	PCDat	_	6	case	_	_
+8	özenle	özen	NOUN	Noun	Case=Ins|Number=Sing|Person=3	9	obl	_	_
+9	sürerdi	sür	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-5197
 # text = İnşaat konsorsiyumu, okullara kitap yardımı yapacak.
@@ -47599,17 +47536,16 @@
 
 # sent_id = mst-5367
 # text = Senaryo, çünkü bileşenleri tamamen metafizik öğelerden oluşmaktadır.
-1	Senaryo	senaryo	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	Punc	_	9	punct	_	_
+# Change 2.2/dev: fix 'bileşen' VERB -> NOUN
+1	Senaryo	senaryo	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nsubj	_	SpaceAfter=No
+2	,	,	PUNCT	Punc	_	8	punct	_	_
 3	çünkü	çünkü	CCONJ	Conj	_	1	cc	_	_
-4-5	bileşenleri	_	_	_	_	_	_	_	_
-4	bileşen	bileş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	8	acl	_	_
-5	leri	_	ADP	Zero	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	4	case	_	_
-6	tamamen	tamamen	ADV	Adverb	_	8	advmod	_	_
-7	metafizik	metafizik	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	8	amod	_	_
-8	öğelerden	öğe	NOUN	Noun	Case=Abl|Number=Plur|Person=3	9	obl	_	_
-9	oluşmaktadır	oluş	VERB	Verb	Aspect=Prog|Mood=Gen|Number=Sing|Person=3|Polarity=Pos|Polite=Form|Tense=Pres	0	root	_	SpaceAfter=No
-10	.	.	PUNCT	Punc	_	9	punct	_	_
+4	bileşenleri	bileşen	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
+5	tamamen	tamamen	ADV	Adverb	_	7	advmod	_	_
+6	metafizik	metafizik	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	7	amod	_	_
+7	öğelerden	öğe	NOUN	Noun	Case=Abl|Number=Plur|Person=3	8	obl	_	_
+8	oluşmaktadır	oluş	VERB	Verb	Aspect=Prog|Mood=Gen|Number=Sing|Person=3|Polarity=Pos|Polite=Form|Tense=Pres	0	root	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-5368
 # text = İşte, dünyanın her yanında insanlar vardı; burada, yabancısı olduğum bu kanallar kentinde de.
@@ -47826,6 +47762,7 @@
 
 # sent_id = mst-5383
 # text = Başkalarının en iyi gizlenen sırlarına bile ulaşmanın daima bir yolu bulunurdu, ama insanın kendi sırlarına erişmesi neredeyse imkansızdı ve yazarlık bu imkansızı yaşamaktı sürekli.
+# Change 2.2/dev: merge imkan + sız + ı
 1	Başkalarının	başka	ADJ	NAdj	Case=Gen|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	5	nmod:poss	_	_
 2	en	en	ADV	Adverb	_	3	advmod	_	_
 3	iyi	iyi	ADJ	Adj	_	4	amod	_	_
@@ -47848,17 +47785,14 @@
 19	imkansız	imkânsız	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	9	conj	_	_
 20	dı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	19	cop	_	_
 21	ve	ve	CCONJ	Conj	_	27	cc	_	_
-22	yazarlık	yazarlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	27	nsubj	_	_
-23	bu	bu	DET	Det	_	26	det	_	_
-24-26	imkansızı	_	_	_	_	_	_	_	_
-24	imkan	imkan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	27	obj	_	_
-25	sız	siz	ADP	Without	_	24	case	_	_
-26	ı	_	ADP	Zero	Case=Acc|Number=Sing|Person=3	24	case	_	_
-27-28	yaşamaktı	_	_	_	_	_	_	_	_
-27	yaşamak	yaşa	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	conj	_	_
-28	tı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	27	cop	_	_
-29	sürekli	sürekli	ADV	Adverb	_	27	advmod	_	SpaceAfter=No
-30	.	.	PUNCT	Punc	_	27	punct	_	_
+22	yazarlık	yazarlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	25	nsubj	_	_
+23	bu	bu	DET	Det	_	24	det	_	_
+24	imkansızı	imkânsız	ADJ	NAdj	Case=Acc|Number=Sing|Person=3	25	obj	_	_
+25-26	yaşamaktı	_	_	_	_	_	_	_	_
+25	yaşamak	yaşa	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	conj	_	_
+26	tı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	25	cop	_	_
+27	sürekli	sürekli	ADV	Adverb	_	25	advmod	_	SpaceAfter=No
+28	.	.	PUNCT	Punc	_	25	punct	_	_
 
 # sent_id = mst-5384
 # text = paralel bağlanabiliyor; ama bir trafik kazasında insanların paralel bağlanabileceğini ilk kez duyuyorum.
@@ -48785,33 +48719,32 @@
 
 # sent_id = mst-5480
 # text = Ben de o gece kardeşlerimin yatma saati gelene kadar uzun uzun köpeğimizi anlattım onlara, ne de olsa o artık evimizin köpeğiydi.
-1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	_	_
+# Change 2.2/dev: merge -(y)An
+1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	_	_
 2	de	de	CCONJ	Conj	_	1	mark	_	_
 3	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	4	nmod	_	_
-4	gece	gece	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	obl	_	_
+4	gece	gece	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
 5	kardeşlerimin	kardeş	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=1	7	nmod:poss	_	_
 6	yatma	yat	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	nmod:poss	_	_
-7	saati	saat	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obj	_	_
-8-9	gelene	_	_	_	_	_	_	_	_
-8	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	14	acl	_	_
-9	e	_	ADP	Zero	Case=Dat|Number=Sing|Person=3	8	case	_	_
-10	kadar	kadar	ADP	PCDat	_	8	case	_	_
-11	uzun	uzun	ADJ	Adj	_	14	amod	_	_
-12	uzun	uzun	ADJ	Adj	_	11	compound:redup	_	_
-13	köpeğimizi	köpek	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	14	obj	_	_
-14	anlattım	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
-15	onlara	o	PRON	Pers	Case=Dat|Number=Plur|Person=3|PronType=Prs	14	obl	_	SpaceAfter=No
-16	,	,	PUNCT	Punc	_	14	punct	_	_
-17	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	19	advmod:emph	_	_
-18	de	de	CCONJ	Conj	_	17	advmod:emph	_	_
-19	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	14	conj	_	_
-20	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	23	nsubj	_	_
-21	artık	artık	ADV	Adverb	_	23	advmod	_	_
-22	evimizin	ev	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	23	nmod:poss	_	_
-23-24	köpeğiydi	_	_	_	_	_	_	_	SpaceAfter=No
-23	köpeği	köpek	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	conj	_	_
-24	ydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	23	cop	_	_
-25	.	.	PUNCT	Punc	_	23	punct	_	_
+7	saati	saat	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
+8	gelene	gel	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	13	acl	_	_
+9	kadar	kadar	ADP	PCDat	_	8	case	_	_
+10	uzun	uzun	ADJ	Adj	_	13	amod	_	_
+11	uzun	uzun	ADJ	Adj	_	10	compound:redup	_	_
+12	köpeğimizi	köpek	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	13	obj	_	_
+13	anlattım	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
+14	onlara	o	PRON	Pers	Case=Dat|Number=Plur|Person=3|PronType=Prs	13	obl	_	SpaceAfter=No
+15	,	,	PUNCT	Punc	_	13	punct	_	_
+16	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	18	advmod:emph	_	_
+17	de	de	CCONJ	Conj	_	16	advmod:emph	_	_
+18	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	13	conj	_	_
+19	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	22	nsubj	_	_
+20	artık	artık	ADV	Adverb	_	22	advmod	_	_
+21	evimizin	ev	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	22	nmod:poss	_	_
+22-23	köpeğiydi	_	_	_	_	_	_	_	SpaceAfter=No
+22	köpeği	köpek	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	conj	_	_
+23	ydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	22	cop	_	_
+24	.	.	PUNCT	Punc	_	22	punct	_	_
 
 # sent_id = mst-5481
 # text = Sevinmez mi?
@@ -49453,27 +49386,26 @@
 
 # sent_id = mst-5560
 # text = O sırada, iş dönüşü yorgun ve dalgın adımlarla geçip gidenlerden bir ikisinin gözleri takılır kenardakilere.
+# Change 2.2/dev: merge -(y)An
 1	O	o	DET	Det	_	2	det	_	_
-2	sırada	sıra	NOUN	Noun	Case=Loc|Number=Sing|Person=3	15	nmod	_	SpaceAfter=No
-3	,	,	PUNCT	Punc	_	15	punct	_	_
+2	sırada	sıra	NOUN	Noun	Case=Loc|Number=Sing|Person=3	14	nmod	_	SpaceAfter=No
+3	,	,	PUNCT	Punc	_	14	punct	_	_
 4	iş	iş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
-5	dönüşü	dönüş	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	nmod	_	_
+5	dönüşü	dönüş	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	nmod	_	_
 6	yorgun	yorgun	ADJ	Adj	_	9	amod	_	_
 7	ve	ve	CCONJ	Conj	_	8	cc	_	_
 8	dalgın	dalgın	ADJ	Adj	_	6	conj	_	_
 9	adımlarla	adım	NOUN	Noun	Case=Ins|Number=Plur|Person=3	10	obl	_	_
-10	geçip	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	12	nmod	_	_
-11-12	gidenlerden	_	_	_	_	_	_	_	_
-11	giden	git	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	13	nmod	_	_
-12	lerden	_	ADP	Zero	Case=Abl|Number=Plur|Person=3	11	case	_	_
-13	bir	bir	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	15	nmod:poss	_	_
-14	ikisinin	iki	NUM	NNum	Case=Gen|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=3	13	compound	_	_
-15	gözleri	göz	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
-16	takılır	takıl	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	15	compound	_	_
-17-18	kenardakilere	_	_	_	_	_	_	_	SpaceAfter=No
-17	kenarda	kenar	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	15	amod	_	_
-18	kilere	ki	ADP	Rel	Case=Dat|Number=Plur|Person=3	17	case	_	_
-19	.	.	PUNCT	Punc	_	15	punct	_	_
+10	geçip	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	11	nmod	_	_
+11	gidenlerden	git	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	12	nmod	_	_
+12	bir	bir	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	14	nmod:poss	_	_
+13	ikisinin	iki	NUM	NNum	Case=Gen|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=3	12	compound	_	_
+14	gözleri	göz	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
+15	takılır	takıl	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	14	compound	_	_
+16-17	kenardakilere	_	_	_	_	_	_	_	SpaceAfter=No
+16	kenarda	kenar	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	14	amod	_	_
+17	kilere	ki	ADP	Rel	Case=Dat|Number=Plur|Person=3	16	case	_	_
+18	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-5561
 # text = Şirketin patronu olan okul arkadaşım her zaman giydiği birbirinin aynı siyah takım elbiseleri, inanılmaz derecede parlak kravatlarıyla öğlen yemeğine giderken kapıdan kafasını uzatıp Kaç? diye soruyordu, ona o ana kadar okuyup kaydettiğim cinayetlerin sayısını söylüyordum.

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -1193,12 +1193,13 @@
 9	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-0152
-# text = Kadının adı ?eymiş.
+# text = Kadının adı neymiş.
+# Fixed 2.2/dev: original sentence ID: 00099161374/1
 1	Kadının	kadın	ADJ	NAdj	Case=Gen|Number=Sing|Person=3	2	nmod:poss	_	_
 2	adı	ad	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	nsubj	_	_
-3-4	?eymiş	_	_	_	_	_	_	_	SpaceAfter=No
-3	?	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
-4	eymiş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	3	cop	_	_
+3-4	neymiş	_	_	_	_	_	_	_	SpaceAfter=No
+3	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
+4	ymiş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	3	cop	_	_
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-0153
@@ -4851,7 +4852,8 @@
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-0537
-# text = Anayasalar en büyük toplumsal uzlaşma ile düzenlenmesi gereken ?etinlerdir.
+# text = Anayasalar en büyük toplumsal uzlaşma ile düzenlenmesi gereken metinlerdir.
+# Fixed 2.2/dev: original sentence ID: 20580000-4/1
 1	Anayasalar	anayasa	NOUN	Noun	Case=Nom|Number=Plur|Person=3	9	nsubj	_	_
 2	en	en	ADV	Adverb	_	3	advmod	_	_
 3	büyük	büyük	ADJ	Adj	_	5	amod	_	_
@@ -4860,9 +4862,9 @@
 6	ile	ile	CCONJ	Conj	_	7	nmod	_	_
 7	düzenlenmesi	düzenle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	8	obj	_	_
 8	gereken	gerek	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	acl	_	_
-9-10	?etinlerdir	_	_	_	_	_	_	_	SpaceAfter=No
-9	?	metin	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
-10	etinlerdir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Plur|Person=3|Tense=Pres	9	cop	_	_
+9-10	metinlerdir	_	_	_	_	_	_	_	SpaceAfter=No
+9	metinler	metin	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	0	root	_	_
+10	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	9	cop	_	_
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-0538
@@ -5358,11 +5360,12 @@
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-0605
-# text = Aklın ?eredeydi.
+# text = Aklın neredeydi.
+# Fixed 2.2/dev: original sentence ID: 001961701367/5
 1	Aklın	akıl	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	2	nsubj	_	_
-2-3	?eredeydi	_	_	_	_	_	_	_	SpaceAfter=No
-2	?	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	0	root	_	_
-3	eredeydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	2	cop	_	_
+2-3	neredeydi	_	_	_	_	_	_	_	SpaceAfter=No
+2	nerede	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	0	root	_	_
+3	ydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	2	cop	_	_
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0606
@@ -8756,10 +8759,11 @@
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-0975
-# text = ?imsiniz? dedi bir erkek sesi.
-1-2	?imsiniz	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	4	ccomp	_	_
-2	imsiniz	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	1	cop	_	_
+# text = Kimsiniz? dedi bir erkek sesi.
+# Fixed 2.2/dev: original sentence ID:00099161431/1
+1-2	Kimsiniz	_	_	_	_	_	_	_	SpaceAfter=No
+1	Kim	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	4	ccomp	_	_
+2	siniz	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	1	cop	_	_
 3	?	?	PUNCT	Punc	_	4	punct	_	_
 4	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 5	bir	bir	NUM	ANum	NumType=Card	6	det	_	_
@@ -13945,10 +13949,11 @@
 12	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-1553
-# text = ?eydiaranızdaki ilişki.
-1-2	?eydi	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	eydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	1	cop	_	_
+# text = Neydi aranızdaki ilişki.
+# Fixed 2.2/dev: original sentence ID: 00099161328/1
+1-2	Neydi	_	_	_	_	_	_	_	_
+1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
+2	ydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	1	cop	_	_
 3-4	aranızdaki	_	_	_	_	_	_	_	_
 3	aranızda	ara	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	5	amod	_	_
 4	ki	ki	ADP	Rel	_	3	case	_	_
@@ -17102,30 +17107,29 @@
 8	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-1914
-# text = Casino Venüs'e ?irerkeno kilitli camlı dönen kapıdan geçerken içim bir an heyecandan cızlar.
+# text = Casino Venüs'e girerken o kilitli camlı dönen kapıdan geçerken içim bir an heyecandan cızlar.
+# Fixed 2.2/dev: original sentence ID: 00099161401/2
 1	Casino	casino	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obl	_	_
 2	Venüs'e	Venüs	PROPN	Prop	Case=Dat|Number=Sing|Person=3	1	flat	_	_
-3-4	?irerken	_	_	_	_	_	_	_	SpaceAfter=No
-3	?	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	18	nmod	_	_
-4	irerken	i	AUX	Zero	Aspect=Perf|Mood=Ind|Tense=Pres|VerbForm=Conv	3	cop	_	_
-5	o	o	DET	Det	_	6	det	_	_
-6-7	kilitli	_	_	_	_	_	_	_	_
-6	kilit	kilit	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
-7	li	li	ADP	With	_	6	case	_	_
-8-9	camlı	_	_	_	_	_	_	_	_
-8	cam	cam	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	10	obj	_	_
-9	lı	li	ADP	With	_	8	case	_	_
-10	dönen	dön	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	nmod	_	_
-11	kapıdan	kapı	NOUN	Noun	Case=Abl|Number=Sing|Person=3	12	obl	_	_
-12-13	geçerken	_	_	_	_	_	_	_	_
-12	geçer	geçer	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	18	amod	_	_
-13	ken	i	AUX	Zero	Aspect=Perf|Mood=Ind|Tense=Pres|VerbForm=Conv	12	cop	_	_
-14	içim	içim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nsubj	_	_
-15	bir	bir	NUM	ANum	NumType=Card	16	det	_	_
-16	an	an	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nmod	_	_
-17	heyecandan	heyecan	NOUN	Noun	Case=Abl|Number=Sing|Person=3	18	nmod	_	_
-18	cızlar	cız	NOUN	Noun	Case=Nom|Number=Plur|Person=3	0	root	_	SpaceAfter=No
-19	.	.	PUNCT	Punc	_	18	punct	_	_
+3	girerken	i	AUX	Zero	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	17	advcl	_	_
+4	o	o	DET	Det	_	5	det	_	_
+5-6	kilitli	_	_	_	_	_	_	_	_
+5	kilit	kilit	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
+6	li	li	ADP	With	_	5	case	_	_
+7-8	camlı	_	_	_	_	_	_	_	_
+7	cam	cam	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	9	obj	_	_
+8	lı	li	ADP	With	_	7	case	_	_
+9	dönen	dön	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	nmod	_	_
+10	kapıdan	kapı	NOUN	Noun	Case=Abl|Number=Sing|Person=3	11	obl	_	_
+11-12	geçerken	_	_	_	_	_	_	_	_
+11	geçer	geçer	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	17	amod	_	_
+12	ken	i	AUX	Zero	Aspect=Perf|Mood=Ind|Tense=Pres|VerbForm=Conv	11	cop	_	_
+13	içim	içim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nsubj	_	_
+14	bir	bir	NUM	ANum	NumType=Card	15	det	_	_
+15	an	an	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nmod	_	_
+16	heyecandan	heyecan	NOUN	Noun	Case=Abl|Number=Sing|Person=3	17	nmod	_	_
+17	cızlar	cızla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-1915
 # text = -Nereden biliyorsun.
@@ -21118,11 +21122,12 @@
 30	...	...	PUNCT	Punc	_	29	punct	_	_
 
 # sent_id = mst-2338
-# text = Sen ?eredesindiye sordum.
+# text = Sen neredesin diye sordum.
+# Fixed 2.2/dev: original sentence ID: 00002213160/3
 1	Sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	2	nmod	_	_
-2-3	?eredesin	_	_	_	_	_	_	_	SpaceAfter=No
-2	?	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	5	obl	_	_
-3	eredesin	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Pres	2	cop	_	_
+2-3	neredesin	_	_	_	_	_	_	_	_
+2	nerede	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	5	obl	_	_
+3	sin	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Pres	2	cop	_	_
 4	diye	diye	ADP	PCNom	_	2	case	_	_
 5	sordum	sor	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	conj	_	_
@@ -21871,7 +21876,8 @@
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-2429
-# text = Yani senin zamanın, saatin, süren ?edir?
+# text = Yani senin zamanın, saatin, süren nedir?
+# Fixed 2.2/dev: original sentence ID: 00002213160/2
 1	Yani	yani	CCONJ	Conj	_	0	root	_	_
 2	senin	sen	PRON	Pers	Case=Gen|Number=Sing|Person=2|PronType=Prs	3	nmod:poss	_	_
 3	zamanın	zaman	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	8	nsubj	_	SpaceAfter=No
@@ -21879,9 +21885,9 @@
 5	saatin	saat	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	3	conj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	7	punct	_	_
 7	süren	süre	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	3	conj	_	_
-8-9	?edir	_	_	_	_	_	_	_	SpaceAfter=No
-8	?	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	1	conj	_	_
-9	edir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	8	cop	_	_
+8-9	nedir	_	_	_	_	_	_	_	SpaceAfter=No
+8	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	1	conj	_	_
+9	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	8	cop	_	_
 10	?	?	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-2431
@@ -25313,10 +25319,11 @@
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-2795
-# text = ?erdeydin? diye bağırdı.
-1-2	?erdeydin	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	4	nmod	_	_
-2	erdeydin	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Past	1	cop	_	_
+# text = Nerdeydin? diye bağırdı.
+# Fixed 2.2/dev: original sentence ID: 00032161392/1
+1-2	Nerdeydin	_	_	_	_	_	_	_	SpaceAfter=No
+1	Nerde	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	4	nmod	_	_
+2	ydin	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Past	1	cop	_	_
 3	?	?	PUNCT	Punc	_	4	punct	_	_
 4	diye	de	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	nmod	_	_
 5	bağırdı	bağır	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -25579,12 +25586,13 @@
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-2828
-# text = İstediğiniz ücret ?edir.
+# text = İstediğiniz ücret nedir.
+# Fixed 2.2/dev: original sentence ID: 00058111785/1
 1	İstediğiniz	iste	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	2	acl	_	_
 2	ücret	ücret	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
-3-4	?edir	_	_	_	_	_	_	_	SpaceAfter=No
-3	?	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
-4	edir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	3	cop	_	_
+3-4	nedir	_	_	_	_	_	_	_	SpaceAfter=No
+3	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
+4	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	3	cop	_	_
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-2830
@@ -28350,11 +28358,12 @@
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-3149
-# text = Sorumluluk ?edirhiç öğrenmemişti ki.
+# text = Sorumluluk nedir hiç öğrenmemişti ki.
+# Fixed 2.2/dev: original sentence ID: 00095233-10/10
 1	Sorumluluk	sorumluluk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
-2-3	?edir	_	_	_	_	_	_	_	SpaceAfter=No
-2	?	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
-3	edir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	2	cop	_	_
+2-3	nedir	_	_	_	_	_	_	_	_
+2	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
+3	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	2	cop	_	_
 4	hiç	hiç	ADV	Adverb	_	5	advmod	_	_
 5	öğrenmemişti	öğren	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pqp	2	conj	_	_
 6	ki	ki	CCONJ	Conj	_	5	cc	_	SpaceAfter=No
@@ -29152,10 +29161,11 @@
 22	.	.	PUNCT	Punc	_	21	punct	_	_
 
 # sent_id = mst-3240
-# text = ?eydiki onlar?
-1-2	?eydi	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	eydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	1	cop	_	_
+# text = Neydi ki onlar?
+# Fixed 2.2/dev: original sentence ID: 0000221379/5
+1-2	Neydi	_	_	_	_	_	_	_	_
+1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
+2	ydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	1	cop	_	_
 3	ki	ki	CCONJ	Conj	_	1	advmod:emph	_	_
 4	onlar	o	PRON	Demons	Case=Nom|Number=Plur|Person=3|PronType=Dem	1	nsubj	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	1	punct	_	_
@@ -29819,10 +29829,11 @@
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-3306
-# text = ?eredesinizoğlum? dedi bağırarak.
-1-2	?eredesiniz	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	5	ccomp	_	_
-2	eredesiniz	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	1	cop	_	_
+# text = Neredesiniz oğlum? dedi bağırarak.
+# Fixed 2.2/dev: original sentence ID: 00084111-46/1
+1-2	Neredesiniz	_	_	_	_	_	_	_	_
+1	Nerede	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	5	ccomp	_	_
+2	siniz	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	1	cop	_	_
 3	oğlum	oğul	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	0	root	_	SpaceAfter=No
 4	?	?	PUNCT	Punc	_	5	punct	_	_
 5	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	conj	_	_
@@ -33029,7 +33040,8 @@
 18	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-3681
-# text = Adını önce İngiltere ve Amerika'da duyuran Çağlayan, Paris'te yükselen yıldızını, başkentin gözde konser salonlarından ' Salla ?aveau'dakiçılgın defilesiyle ' en iyiler ' arasına yazdırdı.
+# text = Adını önce İngiltere ve Amerika'da duyuran Çağlayan, Paris'te yükselen yıldızını, başkentin gözde konser salonlarından 'Salla Gaveau'daki çılgın defilesiyle 'en iyiler' arasına yazdırdı.
+# Fixed 2.2/dev: original sentence ID: 20210000-30/1
 1	Adını	ad	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obj	_	_
 2	önce	önce	ADP	PCAbl	_	6	case	_	_
 3	İngiltere	İngiltere	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	obl	_	_
@@ -33046,16 +33058,16 @@
 14	gözde	gözde	ADJ	Adj	_	16	amod	_	_
 15	konser	konser	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nmod:poss	_	_
 16	salonlarından	salon	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	18	nmod	_	_
-17	'	'	PUNCT	Punc	_	22	punct	_	_
+17	'	'	PUNCT	Punc	_	22	punct	_	SpaceAfter=No
 18	Salla	sal	NOUN	Noun	Case=Ins|Number=Sing|Person=3	22	nmod	_	_
-19-20	?aveau'daki	_	_	_	_	_	_	_	SpaceAfter=No
-19	?	Gaveau	PROPN	Prop	Case=Loc|Number=Sing|Person=3	18	flat	_	_
-20	aveau'daki	ki	ADP	Rel	_	18	case	_	_
+19-20	Gaveau'daki	_	_	_	_	_	_	_	_
+19	Gaveau'da	Gaveau	PROPN	Prop	Case=Loc|Number=Sing|Person=3	18	flat	_	_
+20	ki	ki	ADP	Rel	_	18	case	_	_
 21	çılgın	çılgın	ADJ	Adj	_	22	amod	_	_
 22	defilesiyle	defile	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	28	obl	_	_
-23	'	'	PUNCT	Punc	_	22	punct	_	_
+23	'	'	PUNCT	Punc	_	22	punct	_	SpaceAfter=No
 24	en	en	ADV	Adverb	_	25	advmod	_	_
-25	iyiler	iyi	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	27	nmod:poss	_	_
+25	iyiler	iyi	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	27	nmod:poss	_	SpaceAfter=No
 26	'	'	PUNCT	Punc	_	25	punct	_	_
 27	arasına	ara	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	28	advmod:emph	_	_
 28	yazdırdı	yaz	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
@@ -33874,10 +33886,11 @@
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-3761
-# text = ?eymişbu makine... diyordu Gül Abla.
-1-2	?eymiş	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	6	ccomp	_	_
-2	eymiş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	1	cop	_	_
+# text = Neymiş bu makine... diyordu Gül Abla.
+# Fixed 2.2/dev: original sentence ID: 00099161392/1
+1-2	Neymiş	_	_	_	_	_	_	_	_
+1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	6	ccomp	_	_
+2	ymiş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	1	cop	_	_
 3	bu	bu	DET	Det	_	4	det	_	_
 4	makine	makine	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	obj	_	SpaceAfter=No
 5	...	...	PUNCT	Punc	_	6	punct	_	_
@@ -35004,10 +35017,11 @@
 29	.	.	PUNCT	Punc	_	28	punct	_	_
 
 # sent_id = mst-3878
-# text = ?edirbu MCB.
-1-2	?edir	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	edir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	1	cop	_	_
+# text = Nedir bu MCB.
+# Fixed 2.2/dev: original sentence ID: 00131260896/1
+1-2	Nedir	_	_	_	_	_	_	_	_
+1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
+2	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	1	cop	_	_
 3	bu	bu	DET	Det	_	4	det	_	_
 4	MCB	MCB	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	1	nsubj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	1	punct	_	_
@@ -35929,14 +35943,15 @@
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-3989
-# text = Karl Popper'ın geliştirmiş olduğu ?anlışlanabilirlikilkesi materyalist felsefenin yadsımanın yadsıması ilkesini andırmaktadır.
+# text = Karl Popper'ın geliştirmiş olduğu yanlışlanabilirlik ilkesi materyalist felsefenin yadsımanın yadsıması ilkesini andırmaktadır.
+# Fixed 2.2/dev: original sentence ID: 00044121454/7
 1	Karl	Karl	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	Popper'ın	Popper	PROPN	Prop	Case=Gen|Number=Sing|Person=3	1	flat	_	_
 3	geliştirmiş	geliş	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Cau	4	obj	_	_
 4	olduğu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	7	acl	_	_
-5-6	?anlışlanabilirlik	_	_	_	_	_	_	_	SpaceAfter=No
-5	?	yanlışla	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	7	acl	_	_
-6	anlışlanabilirlik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	5	case	_	_
+5-6	yanlışlanabilirlik	_	_	_	_	_	_	_	_
+5	yanlışlanabilir	yanlışla	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	7	acl	_	_
+6	lik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	5	case	_	_
 7	ilkesi	ilke	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	nsubj	_	_
 8	materyalist	materyalist	ADJ	Adj	_	9	amod	_	_
 9	felsefenin	felsefe	NOUN	Noun	Case=Gen|Number=Sing|Person=3	11	nmod:poss	_	_
@@ -38364,10 +38379,11 @@
 28	...	...	PUNCT	Punc	_	26	punct	_	_
 
 # sent_id = mst-4271
-# text = ?anlışlanabilirlikilkesi ne yazık ki çoğu zaman yanlış yorumlanmaktadır.
-1-2	?anlışlanabilirlik	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	yanlışla	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	3	nmod:poss	_	_
-2	anlışlanabilirlik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	1	case	_	_
+# text = Yanlışlanabilirlik ilkesi ne yazık ki çoğu zaman yanlış yorumlanmaktadır.
+# Fixed 2.2/dev: original sentence ID: 00044121454/1
+1-2	Yanlışlanabilirlik	_	_	_	_	_	_	_	_
+1	Yanlışlanabilir	yanlışla	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	3	nmod:poss	_	_
+2	lik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	1	case	_	_
 3	ilkesi	ilke	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nsubj	_	_
 4	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	5	nmod	_	_
 5	yazık	yazık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obl	_	_
@@ -38626,10 +38642,11 @@
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-4299
-# text = ?immişbu kadın.
-1-2	?immiş	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	immiş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	1	cop	_	_
+# text = Kimmiş bu kadın.
+# Fixed 2.2/dev: original sentence ID: 00099161364/1
+1-2	Kimmiş	_	_	_	_	_	_	_	_
+1	Kim	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
+2	miş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	1	cop	_	_
 3	bu	bu	DET	Det	_	4	det	_	_
 4	kadın	kadın	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	1	nsubj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	1	punct	_	_
@@ -39909,10 +39926,11 @@
 8	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4439
-# text = ?ostakoviç'miş! Tövbe yarabbi.
-1-2	?ostakoviç'miş	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	Şostakoviç	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	ostakoviç'miş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	1	cop	_	_
+# text = Şostakoviç'miş! Tövbe yarabbi.
+# Fixed 2.2/dev: original sentence ID: 001961701348/7
+1-2	Şostakoviç'miş	_	_	_	_	_	_	_	SpaceAfter=No
+1	Şostakoviç	Şostakoviç	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	_
+2	'miş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	1	cop	_	_
 3	!	!	PUNCT	Punc	_	1	punct	_	_
 4	Tövbe	tövbe	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
 5	yarabbi	Yarabbi	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	conj	_	SpaceAfter=No
@@ -40655,13 +40673,14 @@
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-4522
-# text = Alışverişlerde çocukların etkisi ?edir?.
+# text = Alışverişlerde çocukların etkisi nedir?.
+# Fixed 2.2/dev: original sentence ID: 20210000-3/1
 1	Alışverişlerde	alışveriş	NOUN	Noun	Case=Loc|Number=Plur|Person=3	4	nmod	_	_
 2	çocukların	çocuk	NOUN	Noun	Case=Gen|Number=Plur|Person=3	3	nmod:poss	_	_
 3	etkisi	etki	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
-4-5	?edir	_	_	_	_	_	_	_	SpaceAfter=No
-4	?	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
-5	edir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	4	cop	_	_
+4-5	nedir	_	_	_	_	_	_	_	SpaceAfter=No
+4	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
+5	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	4	cop	_	_
 6	?	?	PUNCT	Punc	_	4	punct	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -41946,18 +41965,17 @@
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-4682
-# text = Potaya ?irerkenarkadan gelen bir diğeri onları vurabilir.
+# text = Potaya girerken arkadan gelen bir diğeri onları vurabilir.
+# Fixed 2.2/dev: original sentence ID: 001422111080/2
 1	Potaya	pota	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
-2-3	?irerken	_	_	_	_	_	_	_	SpaceAfter=No
-2	?	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	9	nmod	_	_
-3	irerken	i	AUX	Zero	Aspect=Perf|Mood=Ind|Tense=Pres|VerbForm=Conv	2	cop	_	_
-4	arkadan	arkadan	ADV	Adverb	_	5	advmod	_	_
-5	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	acl	_	_
-6	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
-7	diğeri	diğer	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	nsubj	_	_
-8	onları	o	PRON	Demons	Case=Acc|Number=Plur|Person=3|PronType=Dem	9	obj	_	_
-9	vurabilir	vur	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
-10	.	.	PUNCT	Punc	_	9	punct	_	_
+2	girerken	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	8	advcl	_	_
+3	arkadan	arkadan	ADV	Adverb	_	4	advmod	_	_
+4	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	acl	_	_
+5	bir	bir	NUM	ANum	NumType=Card	6	det	_	_
+6	diğeri	diğer	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nsubj	_	_
+7	onları	o	PRON	Demons	Case=Acc|Number=Plur|Person=3|PronType=Dem	8	obj	_	_
+8	vurabilir	vur	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-4683
 # text = Ancak kapsamı genişletiliyor.
@@ -42682,10 +42700,11 @@
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-4778
-# text = ?erdeydin.
-1-2	?erdeydin	_	_	_	_	_	_	_	SpaceAfter=No
-1	?	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	0	root	_	_
-2	erdeydin	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Past	1	cop	_	_
+# text = Nerdeydin.
+# Fixed 2.2/dev: original sentence ID: 00032161375/1
+1-2	Nerdeydin	_	_	_	_	_	_	_	SpaceAfter=No
+1	Nerde	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	0	root	_	_
+2	ydin	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Past	1	cop	_	_
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-4780
@@ -42896,12 +42915,13 @@
 20	.	.	PUNCT	Punc	_	19	punct	_	_
 
 # sent_id = mst-4801
-# text = Bir kuramın ?anlışlanabilirliğio kuramın olumsuzluğuna, işe yaramazlığına değil, tam tersine verimliliğine, doğurganlığına işaret eder.
+# text = Bir kuramın yanlışlanabilirliği o kuramın olumsuzluğuna, işe yaramazlığına değil, tam tersine verimliliğine, doğurganlığına işaret eder.
+# Fixed 2.2/dev: original sentence ID: 00044121454/2
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	kuramın	kuram	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
-3-4	?anlışlanabilirliği	_	_	_	_	_	_	_	SpaceAfter=No
-3	?	yanlışla	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	11	nsubj	_	_
-4	anlışlanabilirliği	lik	ADP	Ness	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	case	_	_
+3-4	yanlışlanabilirliği	_	_	_	_	_	_	_	_
+3	yanlışlanabilir	yanlışla	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	11	nsubj	_	_
+4	liği	lik	ADP	Ness	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	case	_	_
 5	o	o	DET	Det	_	6	det	_	_
 6	kuramın	kuram	NOUN	Noun	Case=Gen|Number=Sing|Person=3	15	nmod:poss	_	_
 7	olumsuzluğuna	olumsuzluk	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	nmod	_	SpaceAfter=No
@@ -43930,12 +43950,13 @@
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-4906
-# text = Aman, ?eymişbu makine... diye söylendi Gül Abla.
+# text = Aman, neymiş bu makine... diye söylendi Gül Abla.
+# Fixed 2.2/dev: original sentence ID: 00099161381/1
 1	Aman	aman	INTJ	Interj	_	9	discourse	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	3	punct	_	_
-3-4	?eymiş	_	_	_	_	_	_	_	SpaceAfter=No
-3	?	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	1	conj	_	_
-4	eymiş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	3	cop	_	_
+3-4	neymiş	_	_	_	_	_	_	_	_
+3	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	1	conj	_	_
+4	ymiş	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	3	cop	_	_
 5	bu	bu	DET	Det	_	6	det	_	_
 6	makine	makine	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	SpaceAfter=No
 7	...	...	PUNCT	Punc	_	9	punct	_	_
@@ -48932,7 +48953,8 @@
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-5489
-# text = Yağma yok diye diklendi Memo, hepiniz havanızı ?lırsınız.
+# text = Yağma yok diye diklendi Memo, hepiniz havanızı alırsınız.
+# Fixed 2.2/dev: original sentence ID: 001701601196/1
 1	Yağma	yağma	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
 2	yok	yok	ADJ	Adj	_	4	amod	_	_
 3	diye	diye	ADP	PCNom	_	2	case	_	_
@@ -48941,10 +48963,8 @@
 6	,	,	PUNCT	Punc	_	4	punct	_	_
 7	hepiniz	hep	PRON	Quant	Case=Nom|Number=Plur|Number[psor]=Plur|Person=2|Person[psor]=2|PronType=Ind	8	nsubj	_	_
 8	havanızı	hava	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	4	cop	_	_
-9-10	?lırsınız	_	_	_	_	_	_	_	SpaceAfter=No
-9	?	al	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	4	conj	_	_
-10	lırsınız	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	8	conj	_	_
-11	.	.	PUNCT	Punc	_	9	punct	_	_
+9	alırsınız	al	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	4	conj	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-5490
 # text = Öyle sanıyorum, dedi Jul.

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -1698,11 +1698,12 @@
 
 # sent_id = mst-0223
 # text = Şahin, TSMF Avrupa Birinci Bölge Direktörü BDDK ' ile yarın başlayacak görüşmelerin en önemli gündeminin memur ve işçilere yapılacak zam ile atıl istihdam olduğunu belirtti.
+# Change 2.2/dev: fix ordinal number
 1	Şahin	Şahin	PROPN	Prop	Case=Nom|Number=Sing|Person=3	27	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	27	punct	_	_
 3	TSMF	TSMF	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	7	compound	_	_
 4	Avrupa	Avrupa	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
-5	Birinci	birinci	ADJ	Adj	_	6	amod	_	_
+5	Birinci	bir	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	6	amod	_	_
 6	Bölge	bölge	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	compound	_	_
 7	Direktörü	direktör	NOUN	Noun	Case=Acc|Number=Sing|Person=3	10	nmod	_	_
 8	BDDK	Bddk	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
@@ -2471,8 +2472,9 @@
 
 # sent_id = mst-0305
 # text = Tahvilin ikinci kuponu ve bu kupona ilişkin yapılacak olan referans bono ihalesi ise doksan gün vadeli olacak.
+# Change 2.2/dev: fix ordinal number
 1	Tahvilin	tahvil	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
-2	ikinci	ikinci	ADJ	Adj	_	3	amod	_	_
+2	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	3	amod	_	_
 3	kuponu	kupon	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	nsubj	_	_
 4	ve	ve	CCONJ	Conj	_	12	cc	_	_
 5	bu	bu	DET	Det	_	6	det	_	_
@@ -3353,6 +3355,7 @@
 # sent_id = mst-0381
 # text = İnsanları ikiye ayırıyor annem (sayacağı iki kalem de olsa mutlaka parmaklarını avucuna kapatarak sayacak; birincisi yaşayanlar (bunlar başkalarını da yaşatıyor), ikincisi yaşayanları seyredenler (bunlar da başkalarının sırtına yük oluyorlar).
 # Change 2.2/dev: merge -(y)An
+# Change 2.2/dev: fix ordinal number
 1	İnsanları	insan	NOUN	Noun	Case=Acc|Number=Plur|Person=3	3	obj	_	_
 2	ikiye	iki	NUM	NNum	Case=Dat|Number=Sing|NumType=Card|Person=3	3	nummod	_	_
 3	ayırıyor	ayır	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	_
@@ -3369,7 +3372,7 @@
 14	kapatarak	kapa	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	15	nmod	_	_
 15	sayacak	say	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	3	conj	_	SpaceAfter=No
 16	;	;	PUNCT	Punc	_	15	punct	_	_
-17	birincisi	birinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	18	amod	_	_
+17	birincisi	bir	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	18	amod	_	_
 18	yaşayanlar	yaşa	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	28	nmod	_	_
 19	(	(	PUNCT	Punc	_	23	punct	_	SpaceAfter=No
 20	bunlar	bu	PRON	Demons	Case=Nom|Number=Plur|Person=3|PronType=Dem	23	nsubj	_	_
@@ -3378,7 +3381,7 @@
 23	yaşatıyor	yaşa	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Cau	18	parataxis	_	SpaceAfter=No
 24	)	)	PUNCT	Punc	_	23	punct	_	SpaceAfter=No
 25	,	,	PUNCT	Punc	_	23	punct	_	_
-26	ikincisi	ikinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	28	amod	_	_
+26	ikincisi	iki	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	28	amod	_	_
 27	yaşayanları	yaşa	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	28	ccomp	_	_
 28	seyredenler	seyret	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	3	nsubj	_	_
 29	(	(	PUNCT	Punc	_	28	punct	_	SpaceAfter=No
@@ -3457,7 +3460,8 @@
 
 # sent_id = mst-0391
 # text = Birincisi, eski Mısır, Çin, Hindistan ve Mezopotamya'da başlayarak eski Yunan'da zirvesine ulaşan ve matematik alanında gerçekleşen atılımdır.
-1	Birincisi	birinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	20	nsubj	_	SpaceAfter=No
+# Change 2.2/dev: fix ordinal number
+1	Birincisi	bir	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	20	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	20	punct	_	_
 3	eski	eski	ADJ	Adj	_	11	amod	_	_
 4	Mısır	Mısır	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	compound	_	SpaceAfter=No
@@ -6734,7 +6738,8 @@
 
 # sent_id = mst-0769
 # text = Birincisi pervane buzlanmasından bahsediyordu.
-1	Birincisi	birinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	4	nsubj	_	_
+# Change 2.2/dev: fix ordinal number
+1	Birincisi	bir	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	4	nsubj	_	_
 2	pervane	pervane	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 3	buzlanmasından	buzlan	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	nmod	_	_
 4	bahsediyordu	bahset	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
@@ -8253,7 +8258,8 @@
 
 # sent_id = mst-0924
 # text = İkincisi, big bang bilim dünyasında yaygın olarak onanan değil yaygın olarak propagandası yapılan bir senaryodur.
-1	İkincisi	ikinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	10	amod	_	SpaceAfter=No
+# Change 2.2/dev: fix ordinal number
+1	İkincisi	iki	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	10	amod	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	10	punct	_	_
 3	big	big	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	nsubj	_	_
 4	bang	bang	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	compound	_	_
@@ -9544,7 +9550,8 @@
 
 # sent_id = mst-1061
 # text = İkinci dubleden sonra kravat düzeneğine gerek kalmazdı artık.
-1	İkinci	ikinci	ADJ	Adj	_	2	amod	_	_
+# Change 2.2/dev: fix ordinal number
+1	İkinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	2	amod	_	_
 2	dubleden	duble	NOUN	Noun	Case=Abl|Number=Sing|Person=3	6	nmod	_	_
 3	sonra	sonra	ADP	PCAbl	_	2	case	_	_
 4	kravat	kravat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
@@ -11046,6 +11053,7 @@
 
 # sent_id = mst-1237
 # text = Hazine, ikibinüç yılı dış borçlanma programı çerçevesinde ikinci ihracını gerçekleştirerek, beşyüz milyon Finnur tutarında beş yıl vadeli ve yüzde on kupon faizli ' cinsi tahvil ihracı yaptı.
+# Change 2.2/dev: fix ordinal number
 1	Hazine	hazine	NOUN	Noun	Case=Nom|Number=Sing|Person=3	30	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	30	punct	_	_
 3	ikibinüç	ikibinüç	NUM	ANum	NumType=Card	4	nummod	_	_
@@ -11054,7 +11062,7 @@
 6	borçlanma	borçlan	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	compound	_	_
 7	programı	program	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nmod:poss	_	_
 8	çerçevesinde	çerçeve	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obl	_	_
-9	ikinci	ikinci	ADJ	Adj	_	10	amod	_	_
+9	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	10	amod	_	_
 10	ihracını	ihraç	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obj	_	_
 11	gerçekleştirerek	gerçekleş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	30	nmod	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	11	punct	_	_
@@ -11805,11 +11813,12 @@
 
 # sent_id = mst-1326
 # text = Mazeret bildirip uçuşa gitmeyen ikinci pilotun yerine göreve çağrıldı, böylece o gece eşiyle yemeğe gitmek yerine ölüme kanat açtı.
+# Change 2.2/dev: fix ordinal number
 1	Mazeret	mazeret	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	obj	_	_
 2	bildirip	bil	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	4	nmod	_	_
 3	uçuşa	uçuş	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
 4	gitmeyen	git	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	6	acl	_	_
-5	ikinci	ikinci	ADJ	Adj	_	6	amod	_	_
+5	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	6	amod	_	_
 6	pilotun	pilot	NOUN	Noun	Case=Gen|Number=Sing|Person=3	7	nmod:poss	_	_
 7	yerine	yer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
 8	göreve	görev	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
@@ -12145,6 +12154,7 @@
 
 # sent_id = mst-1367
 # text = yüzyılda bilimin gelişimini genel hatlarıyla betimlemek istersek, şu iki görüngüyü temel almamız gerekir: Birincisi, bu yüzyıl Bilimsel Devrim'in son atılımlarının gerçekleştiği yüzyıl olmuştur.
+# Change 2.2/dev: fix ordinal number
 1	yüzyılda	yüzyıl	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
 2	bilimin	bilim	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
 3	gelişimini	gelişim	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obj	_	_
@@ -12160,7 +12170,7 @@
 13	almamız	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	14	nsubj	_	_
 14	gerekir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
 15	:	:	PUNCT	Punc	_	16	punct	_	_
-16	Birincisi	birinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	14	conj	_	SpaceAfter=No
+16	Birincisi	bir	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	14	conj	_	SpaceAfter=No
 17	,	,	PUNCT	Punc	_	26	punct	_	_
 18	bu	bu	DET	Det	_	19	det	_	_
 19	yüzyıl	yüzyıl	NOUN	Noun	Case=Nom|Number=Sing|Person=3	26	nsubj	_	_
@@ -14195,11 +14205,12 @@
 
 # sent_id = mst-1589
 # text = Dosyamızın esas unsuru olan ikinci bölümde ise sona eren bin yılın en büyük bilim ve düşün devrimlerini yansıtmaya çalıştık.
+# Change 2.2/dev: fix ordinal number
 1	Dosyamızın	dosya	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	3	nmod:poss	_	_
 2	esas	esas	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	3	amod	_	_
 3	unsuru	unsur	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
 4	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	acl	_	_
-5	ikinci	ikinci	ADJ	Adj	_	6	amod	_	_
+5	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	6	amod	_	_
 6	bölümde	bölüm	NOUN	Noun	Case=Loc|Number=Sing|Person=3	7	nmod	_	_
 7	ise	ise	CCONJ	Conj	_	18	nmod	_	_
 8	sona	son	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	9	amod	_	_
@@ -21515,9 +21526,10 @@
 
 # sent_id = mst-2394
 # text = yazarları Termodinamiğin İkinci Yasası'nın tanımını ve yorumunu yanlış yapıyorlar! Yanlış! Entropinin sürekli arttığını savunan Boltzmann yorumu, dizgedeki entropi üretiminin ısı akısı ve bu akıya neden olan sıcaklık gradyentinden hesaplandığını söyler.
+# Change 2.2/dev: fix ordinal number
 1	yazarları	yazar	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	9	nsubj	_	_
 2	Termodinamiğin	termodinamik	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod	_	_
-3	İkinci	ikinci	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	4	amod	_	_
+3	İkinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	4	amod	_	_
 4	Yasası'nın	yasa	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nmod:poss	_	_
 5	tanımını	tanım	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obj	_	_
 6	ve	ve	CCONJ	Conj	_	7	cc	_	_
@@ -22060,10 +22072,11 @@
 
 # sent_id = mst-2463
 # text = Çağdaş bilim kavramının ikinci ayağı, bilgilerin soyutlama yoluyla sistemleştirilmesi diye tanımladığımız teoridir.
+# Change 2.2/dev: fix ordinal number
 1	Çağdaş	çağdaş	ADJ	Adj	_	2	amod	_	_
 2	bilim	bilim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 3	kavramının	kavram	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nmod:poss	_	_
-4	ikinci	ikinci	ADJ	Adj	_	5	amod	_	_
+4	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	5	amod	_	_
 5	ayağı	ayak	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	nsubj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	13	punct	_	_
 7	bilgilerin	bilgi	NOUN	Noun	Case=Gen|Number=Plur|Person=3	10	nmod:poss	_	_
@@ -22117,7 +22130,8 @@
 
 # sent_id = mst-2469
 # text = İkinci büyük teorik atılım dönemi, işe yüzyıllar sonra Arşimed'in bıraktığı noktadan başlayarak devam eden Bilimsel Devrim dönemidir.
-1	İkinci	ikinci	ADJ	Adj	_	4	amod	_	_
+# Change 2.2/dev: fix ordinal number
+1	İkinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	4	amod	_	_
 2	büyük	büyük	ADJ	Adj	_	4	amod	_	_
 3	teorik	teorik	ADJ	Adj	_	4	amod	_	_
 4	atılım	atılım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
@@ -22314,8 +22328,9 @@
 
 # sent_id = mst-2492
 # text = Rapor'un üçüncü sayfasında ise Takriben saat on.
+# Change 2.2/dev: fix ordinal number
 1	Rapor'un	Rapor	PROPN	Prop	Case=Gen|Number=Sing|Person=3	2	nmod	_	_
-2	üçüncü	üçüncü	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	3	nmod:poss	_	_
+2	üçüncü	üç	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	3	nmod:poss	_	_
 3	sayfasında	sayfa	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nmod	_	_
 4	ise	ise	CCONJ	Conj	_	7	nmod	_	_
 5	Takriben	takriben	ADV	Adverb	_	7	advmod	_	_
@@ -24550,7 +24565,8 @@
 
 # sent_id = mst-2720
 # text = Birinci günkü başlıkta farklı olarak şeyler yazıldı orada.
-1	Birinci	birinci	ADJ	Adj	_	2	amod	_	_
+# Change 2.2/dev: fix ordinal number
+1	Birinci	bir	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	2	amod	_	_
 2-3	günkü	_	_	_	_	_	_	_	_
 2	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod	_	_
 3	kü	ki	ADP	Rel	_	2	case	_	_
@@ -28407,9 +28423,10 @@
 
 # sent_id = mst-3163
 # text = Ayrıca bunlardan birincisi, daha çok yüzyılın ilk yarısında gerçekleşmiş, ikincisi ise, yüzyılın ikinci yarısında zirvesine ulaşmıştır.
+# Change 2.2/dev: fix ordinal number
 1	Ayrıca	ayrıca	ADV	Adverb	_	0	root	_	_
 2	bunlardan	bu	PRON	Demons	Case=Abl|Number=Plur|Person=3|PronType=Dem	3	nmod:poss	_	_
-3	birincisi	birinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	10	nsubj	_	SpaceAfter=No
+3	birincisi	bir	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	10	nsubj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	10	punct	_	_
 5	daha	daha	ADV	Adverb	_	6	advmod	_	_
 6	çok	çok	ADV	Adverb	_	10	advmod	_	_
@@ -28418,11 +28435,11 @@
 9	yarısında	yarı	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	amod	_	_
 10	gerçekleşmiş	gerçekleş	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
 11	,	,	PUNCT	Punc	_	19	punct	_	_
-12	ikincisi	ikinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	19	nsubj	_	_
+12	ikincisi	iki	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	19	nsubj	_	_
 13	ise	ise	CCONJ	Conj	_	12	cc	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	19	punct	_	_
 15	yüzyılın	yüzyıl	NOUN	Noun	Case=Gen|Number=Sing|Person=3	17	nmod:poss	_	_
-16	ikinci	ikinci	ADJ	Adj	_	17	amod	_	_
+16	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	17	amod	_	_
 17	yarısında	yarı	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	amod	_	_
 18	zirvesine	zirve	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	obj	_	_
 19	ulaşmıştır	ulaş	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Gen|Number=Sing|Person=3|Polarity=Pos|Tense=Past	10	conj	_	SpaceAfter=No
@@ -28603,6 +28620,7 @@
 
 # sent_id = mst-3186
 # text = Sigarama davrandım, saygılıyım, ikincisine.
+# Change 2.2/dev: fix ordinal number
 1	Sigarama	sigara	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	obl	_	_
 2	davrandım	davran	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	4	punct	_	_
@@ -28611,7 +28629,7 @@
 5	lı	li	ADP	With	_	4	case	_	_
 6	yım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	4	cop	_	_
 7	,	,	PUNCT	Punc	_	2	punct	_	_
-8	ikincisine	ikinci	NUM	NNum	Case=Dat|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	7	amod	_	SpaceAfter=No
+8	ikincisine	iki	NUM	NNum	Case=Dat|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	7	amod	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-3187
@@ -30578,6 +30596,7 @@
 
 # sent_id = mst-3408
 # text = ÇALIŞTIĞI şirketi suçlayan Ciguli şunları söyledi: " İkinci kaset için çağırdılar.
+# Change 2.2/dev: fix ordinal number
 1	ÇALIŞTIĞI	çalış	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	2	acl	_	_
 2	şirketi	şirket	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
 3	suçlayan	suçla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	acl	_	_
@@ -30586,7 +30605,7 @@
 6	söyledi	söyle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 7	:	:	PUNCT	Punc	_	6	punct	_	_
 8	"	"	PUNCT	Punc	_	6	punct	_	_
-9	İkinci	ikinci	ADJ	Adj	_	10	amod	_	_
+9	İkinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	10	amod	_	_
 10	kaset	kaset	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
 11	için	için	ADP	PCNom	_	10	case	_	_
 12	çağırdılar	çağır	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	6	obj	_	SpaceAfter=No
@@ -30770,6 +30789,7 @@
 
 # sent_id = mst-3438
 # text = Futbol Federasyonu eski Başkanı Kemal Ulusu'nun oğlu Altuğ Ulusu, düşen uçağın ikinci pilotuydu.
+# Change 2.2/dev: fix ordinal number
 1	Futbol	futbol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod:poss	_	_
 2	Federasyonu	federasyon	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	compound	_	_
 3	eski	eski	ADJ	Adj	_	1	amod	_	_
@@ -30782,7 +30802,7 @@
 10	,	,	PUNCT	Punc	_	14	punct	_	_
 11	düşen	düş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	12	acl	_	_
 12	uçağın	uçak	NOUN	Noun	Case=Gen|Number=Sing|Person=3	14	nmod:poss	_	_
-13	ikinci	ikinci	ADJ	Adj	_	14	amod	_	_
+13	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	14	amod	_	_
 14-15	pilotuydu	_	_	_	_	_	_	_	SpaceAfter=No
 14	pilotu	pilot	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 15	ydu	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	14	cop	_	_
@@ -32769,12 +32789,13 @@
 
 # sent_id = mst-3664
 # text = Kopenhag Zirvesi'ne kadar yetiştirilmeye çalışılan ikinci uyum paketinde son dakika değişikliği yapıldı.
+# Change 2.2/dev: fix ordinal number
 1	Kopenhag	Kopenhag	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	obl	_	_
 2	Zirvesi'ne	zirve	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	compound	_	_
 3	kadar	kadar	ADP	PCDat	_	1	case	_	_
 4	yetiştirilmeye	yetiş	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=CauPass	5	obj	_	_
 5	çalışılan	çalış	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	8	acl	_	_
-6	ikinci	ikinci	ADJ	Adj	_	8	amod	_	_
+6	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	8	amod	_	_
 7	uyum	uyum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
 8	paketinde	paket	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	obl	_	_
 9	son	son	ADJ	Adj	_	10	amod	_	_
@@ -33052,10 +33073,11 @@
 
 # sent_id = mst-3687
 # text = ) Fen kolu birincisi.
+# Change 2.2/dev: fix ordinal number
 1	)	)	PUNCT	Punc	_	0	root	_	_
 2	Fen	fen	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
 3	kolu	kol	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	compound	_	_
-4	birincisi	birinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	1	conj	_	SpaceAfter=No
+4	birincisi	bir	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	1	conj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-3688
@@ -34855,6 +34877,7 @@
 
 # sent_id = mst-3874
 # text = Ağbim de çok iyi bir öğrenci, hep sınıf ikincisi.
+# Change 2.2/dev: fix ordinal number
 1	Ağbim	ağbi	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	6	nsubj	_	_
 2	de	de	CCONJ	Conj	_	1	advmod:emph	_	_
 3	çok	çok	ADV	Adverb	_	5	advmod	_	_
@@ -34864,7 +34887,7 @@
 7	,	,	PUNCT	Punc	_	10	punct	_	_
 8	hep	hep	ADV	Adverb	_	10	advmod	_	_
 9	sınıf	sınıf	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod:poss	_	_
-10	ikincisi	ikinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	6	conj	_	SpaceAfter=No
+10	ikincisi	iki	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	6	conj	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-3875
@@ -38323,7 +38346,8 @@
 
 # sent_id = mst-4277
 # text = İkincisi de teknik raporun, Kara Havacılık Okulu'ndan bir albayın ve uçak şirketinden iki yetkilinin düzenlediği rapordaki bilgilerin aslında sadece enkazla ilgili olduğunu, uçağın düşüş nedeniyle ilgili olmadığını söylüyor.
-1	İkincisi	ikinci	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	31	nsubj	_	_
+# Change 2.2/dev: fix ordinal number
+1	İkincisi	iki	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	31	nsubj	_	_
 2	de	de	CCONJ	Conj	_	1	advmod:emph	_	_
 3	teknik	teknik	ADJ	Adj	_	4	amod	_	_
 4	raporun	rapor	NOUN	Noun	Case=Gen|Number=Sing|Person=3	24	nmod:poss	_	SpaceAfter=No
@@ -39861,7 +39885,8 @@
 
 # sent_id = mst-4443
 # text = Birinci Erim Hükümetiydi bu.
-1	Birinci	birinci	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	2	amod	_	_
+# Change 2.2/dev: fix ordinal number
+1	Birinci	bir	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	2	amod	_	_
 2	Erim	Erim	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	_
 3-4	Hükümetiydi	_	_	_	_	_	_	_	_
 3	Hükümeti	hükümet	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	compound	_	_
@@ -40430,8 +40455,9 @@
 
 # sent_id = mst-4509
 # text = Dünyanın üçüncü büyük otomobil üreticisi Toyota'nın küçük sınıftaki temsilcisi Yaris'in Avrupa'daki üretim sayısı ikiyuz bini buldu.
+# Change 2.2/dev: fix ordinal number
 1	Dünyanın	dünya	NOUN	Noun	Case=Gen|Number=Sing|Person=3	5	nmod:poss	_	_
-2	üçüncü	üçüncü	ADJ	Adj	_	3	amod	_	_
+2	üçüncü	üç	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	3	amod	_	_
 3	büyük	büyük	ADJ	Adj	_	5	amod	_	_
 4	otomobil	otomobil	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
 5	üreticisi	üretici	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nmod:poss	_	_
@@ -43070,6 +43096,7 @@
 
 # sent_id = mst-4825
 # text = Ailenin yakınlarından alınan bilgiye göre Altuğ Ulusu, aslında Diyarbakır'a gidecek olan uçağın ikinci pilotu değildi.
+# Change 2.2/dev: fix ordinal number
 1	Ailenin	aile	NOUN	Noun	Case=Gen|Number=Sing|Person=3	2	nmod:poss	_	_
 2	yakınlarından	yakın	ADJ	NAdj	Case=Abl|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	3	amod	_	_
 3	alınan	al	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	4	acl	_	_
@@ -43083,7 +43110,7 @@
 11	gidecek	git	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	12	nmod	_	_
 12	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	13	acl	_	_
 13	uçağın	uçak	NOUN	Noun	Case=Gen|Number=Sing|Person=3	15	nmod:poss	_	_
-14	ikinci	ikinci	ADJ	Adj	_	15	amod	_	_
+14	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	15	amod	_	_
 15	pilotu	pilot	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 16	değildi	değil	VERB	Neg	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	15	cop	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	15	punct	_	_
@@ -44546,9 +44573,10 @@
 
 # sent_id = mst-4988
 # text = Neyse ki üçüncü kez sorduğunda iyi bir cevap hazırlamıştım: Esinciğim evde tek kız olmasının daha iyi olduğuna karar verdik.
+# Change 2.2/dev: fix ordinal number
 1	Neyse	neyse	ADV	Adverb	_	8	advmod	_	_
 2	ki	ki	CCONJ	Conj	_	1	compound	_	_
-3	üçüncü	üçüncü	ADJ	Adj	_	4	amod	_	_
+3	üçüncü	üç	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	4	amod	_	_
 4	kez	kez	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
 5	sorduğunda	sor	VERB	Verb	Aspect=Perf|Case=Loc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	8	acl	_	_
 6	iyi	iyi	ADJ	Adj	_	8	amod	_	_
@@ -45833,7 +45861,8 @@
 
 # sent_id = mst-5147
 # text = Birinci, Ayhan'dı.
-1	Birinci	birinci	ADJ	Adj	_	3	amod	_	SpaceAfter=No
+# Change 2.2/dev: fix ordinal number
+1	Birinci	bir	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	3	amod	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	3	punct	_	_
 3-4	Ayhan'dı	_	_	_	_	_	_	_	SpaceAfter=No
 3	Ayhan	Ayhan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	_

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -720,10 +720,11 @@
 8	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-0094
-# text = üç) İMKB endekslerine paralel seyir göstermeyi hedefleyen A tipi endeks fonlar: Bu kategorideki fonlar yılı İmkb'deki kayba paralel kapattılar.
+# text = üç) İMKB endekslerine paralel seyir göstermeyi hedefleyen A tipi endeks fonlar: Bu kategorideki fonlar yılı İMKB'deki kayba paralel kapattılar.
+# Change 2.2/dev: fix 'lowercasing' of İMKB
 1	üç	üç	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	0	root	_	SpaceAfter=No
 2	)	)	PUNCT	Punc	_	9	punct	_	_
-3	İMKB	İmkb	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
+3	İMKB	İMKB	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 4	endekslerine	endeks	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	5	nmod	_	_
 5	paralel	paralel	ADJ	Adj	_	6	amod	_	_
 6	seyir	seyir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
@@ -740,8 +741,8 @@
 16	ki	ki	ADP	Rel	_	15	case	_	_
 17	fonlar	fon	NOUN	Noun	Case=Nom|Number=Plur|Person=3	23	nsubj	_	_
 18	yılı	yıl	NOUN	Noun	Case=Acc|Number=Sing|Person=3	23	obj	_	_
-19-20	İmkb'deki	_	_	_	_	_	_	_	_
-19	İmkb'de	İmkb	PROPN	Prop	Case=Loc|Number=Sing|Person=3	21	obl	_	_
+19-20	İMKB'deki	_	_	_	_	_	_	_	_
+19	İMKB'de	İMKB	PROPN	Prop	Case=Loc|Number=Sing|Person=3	21	obl	_	_
 20	ki	ki	ADP	Rel	_	19	case	_	_
 21	kayba	kayıp	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	22	amod	_	_
 22	paralel	paralel	ADJ	Adj	_	23	amod	_	_
@@ -2130,7 +2131,7 @@
 12	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-0276
-# text = Ecevit partisinin bakanlarıyla protokolün bir tarafında otururken, diğer tarafta Chp'liler yer aldı.
+# text = Ecevit partisinin bakanlarıyla protokolün bir tarafında otururken, diğer tarafta CHP'liler yer aldı.
 1	Ecevit	Ecevit	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	partisinin	parti	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	nmod:poss	_	_
 3	bakanlarıyla	bakan	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	7	obl	_	_
@@ -2141,8 +2142,8 @@
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	diğer	diğer	ADJ	Adj	_	10	amod	_	_
 10	tarafta	taraf	NOUN	Noun	Case=Loc|Number=Sing|Person=3	14	nmod	_	_
-11-13	Chp'liler	_	_	_	_	_	_	_	_
-11	Chp	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	14	csubj	_	_
+11-13	CHP'liler	_	_	_	_	_	_	_	_
+11	CHP	CHP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	14	csubj	_	_
 12	'li	li	ADP	With	_	11	case	_	_
 13	ler	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Tense=Pres	11	cop	_	_
 14	yer	yer	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
@@ -5412,7 +5413,7 @@
 7	Eyüp	Eyüp	PROPN	Prop	Case=Nom|Number=Sing|Person=3	27	nmod	_	_
 8	Fatsa	Fatsa	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	flat	_	_
 9	ve	ve	CCONJ	Conj	_	26	cc	_	_
-10	CHP	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
+10	CHP	CHP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
 11	Grup	grup	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nmod:poss	_	_
 12	Başkanvekili	başkanvekili	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	nmod	_	_
 13	Haluk	Haluk	PROPN	Prop	Case=Nom|Number=Sing|Person=3	15	nmod	_	_
@@ -5670,7 +5671,7 @@
 # text = Ağabeyim hep CHP'den yana.
 1	Ağabeyim	ağabey	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	3	nsubj	_	_
 2	hep	hep	ADV	Adverb	_	3	advmod	_	_
-3	CHP'den	Chp	NOUN	Abr	Abbr=Yes|Case=Abl|Number=Sing|Person=3	0	root	_	_
+3	CHP'den	CHP	PROPN	Abr	Abbr=Yes|Case=Abl|Number=Sing|Person=3	0	root	_	_
 4	yana	yana	ADP	PCAbl	_	3	case	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -7055,7 +7056,7 @@
 9	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-0805
-# text = Rumların, Kıbrıs Türklerine yönelik uygulayacağı tedbirler ve AB'nin KKTC'yi IMF'nin-Akp'lilerin ederek Türk tarafındaki bazı çevrelere yapacağı yardım, halkta bölünmeye yol açabilir.
+# text = Rumların, Kıbrıs Türklerine yönelik uygulayacağı tedbirler ve AB'nin KKTC'yi IMF'nin-AKP'lilerin ederek Türk tarafındaki bazı çevrelere yapacağı yardım, halkta bölünmeye yol açabilir.
 # Change 2.2/dev: merge li + lerin
 1	Rumların	Rum	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	6	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	6	punct	_	_
@@ -7069,8 +7070,8 @@
 10	KKTC'yi	Kktc	NOUN	Abr	Abbr=Yes|Case=Acc|Number=Sing|Person=3	15	obj	_	_
 11	IMF'nin	Imf	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	9	conj	_	SpaceAfter=No
 12	-	-	PUNCT	Punc	_	14	punct	_	SpaceAfter=No
-13-14	Akp'lilerin	_	_	_	_	_	_	_	_
-13	Akp	Akp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	9	conj	_	_
+13-14	AKP'lilerin	_	_	_	_	_	_	_	_
+13	AKP	AKP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	9	conj	_	_
 14	'lilerin	li	ADP	With	Case=Gen|Number=Plur|Person=3	13	case	_	_
 15	ederek	et	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	21	nmod	_	_
 16	Türk	Türk	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	17	nmod:poss	_	_
@@ -9829,7 +9830,7 @@
 
 # sent_id = mst-1089
 # text = CHP desteğini sürdürdü, vetolu yasa yine Köşk'e gitti.
-1	CHP	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
+1	CHP	CHP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	desteğini	destek	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
 3	sürdürdü	sür	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	3	punct	_	_
@@ -10233,7 +10234,7 @@
 3-4	arasındaki	_	_	_	_	_	_	_	_
 3	arasında	ara	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	amod	_	_
 4	ki	ki	ADP	Rel	_	3	case	_	_
-5	DYP'de	Dyp	NOUN	Abr	Abbr=Yes|Case=Loc|Number=Sing|Person=3	11	obl	_	_
+5	DYP'de	DYP	PROPN	Abr	Abbr=Yes|Case=Loc|Number=Sing|Person=3	11	obl	_	_
 6	ise	i	AUX	Conj	_	5	discourse	_	_
 7	gözle	göz	NOUN	Noun	Case=Ins|Number=Sing|Person=3	10	nmod	_	_
 8	görülür	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	7	compound	_	_
@@ -10549,16 +10550,16 @@
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-1177
-# text = " Bu arada Şelaleevleri'ne kaçırdığını sandığı yedideeki İstanbul-Diyarbakır seferi, iki saat kırkbeş dakika gecikmeyle dokuzkırkbeş'te kalkmıştı.
+# text = " Bu arada Şelaleevleri'ne kaçırdığını sandığı yedideki İstanbul-Diyarbakır seferi, iki saat kırkbeş dakika gecikmeyle dokuzkırkbeş'te kalkmıştı.
 1	"	"	PUNCT	Punc	_	0	root	_	_
 2	Bu	bu	DET	Det	_	1	conj	_	_
 3	arada	ara	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	2	compound	_	_
 4	Şelaleevleri'ne	Şelaleevleri	PROPN	Prop	Case=Dat|Number=Sing|Person=3	20	obl	_	_
 5	kaçırdığını	kaçır	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	6	obj	_	_
 6	sandığı	san	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	12	acl	_	_
-7-8	yedideeki	_	_	_	_	_	_	_	_
+7-8	yedideki	_	_	_	_	_	_	_	_
 7	yedide	yedi	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	12	nummod	_	_
-8	eki	ki	ADP	Rel	_	7	case	_	_
+8	ki	ki	ADP	Rel	_	7	case	_	_
 9	İstanbul	İstanbul	PROPN	Prop	Case=Nom|Number=Sing|Person=3	12	nmod:poss	_	SpaceAfter=No
 10	-	-	PUNCT	Punc	_	20	punct	_	SpaceAfter=No
 11	Diyarbakır	Diyarbakır	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	compound	_	_
@@ -10977,12 +10978,12 @@
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-1227
-# text = O tekke, binikiyuz'lü yıllardan kalmadır.
+# text = O tekke, binikiyüz'lü yıllardan kalmadır.
 1	O	o	DET	Det	_	2	det	_	_
 2	tekke	tekke	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	7	punct	_	_
-4-5	binikiyuz'lü	_	_	_	_	_	_	_	_
-4	binikiyuz	binikiyuz	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	7	obl	_	_
+4-5	binikiyüz'lü	_	_	_	_	_	_	_	_
+4	binikiyüz	binikiyüz	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	7	obl	_	_
 5	'lü	li	ADP	With	_	4	case	_	_
 6	yıllardan	yıl	NOUN	Noun	Case=Abl|Number=Plur|Person=3	4	flat	_	_
 7-8	kalmadır	_	_	_	_	_	_	_	SpaceAfter=No
@@ -12085,8 +12086,8 @@
 9	hükümet	hükümet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod:poss	_	_
 10	formülü	formül	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obj	_	_
 11	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	15	acl	_	_
-12	DYP	Dyp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	15	nmod:poss	_	_
-13	CHP	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	12	conj	_	SpaceAfter=No
+12	DYP	DYP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	15	nmod:poss	_	_
+13	CHP	CHP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	12	conj	_	SpaceAfter=No
 14	-	-	PUNCT	Punc	_	13	punct	_	SpaceAfter=No
 15	koalisyonunun	koalisyon	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	nmod:poss	_	_
 16	gerçekleşmesi	gerçekleş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	17	nmod:poss	_	_
@@ -16555,7 +16556,7 @@
 # sent_id = mst-1851
 # text = Kokteyle CHP Genel Başkanı Deniz Baykal ile çok sayıda partili katıldı.
 1	Kokteyle	kokteyl	NOUN	Noun	Case=Dat|Number=Sing|Person=3	11	obl	_	_
-2	CHP	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
+2	CHP	CHP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 3	Genel	genel	ADJ	Adj	_	4	amod	_	_
 4	Başkanı	başkan	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nmod	_	_
 5	Deniz	Deniz	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
@@ -19497,11 +19498,11 @@
 14	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-2159
-# text = Chp'lilerin tarım ve sağlık sektörüne destek amacıyla verdiği önergeler ise " gider Başesgioğlu " olduğu gerekçesiyle kabul edilmedi.
+# text = CHP'lilerin tarım ve sağlık sektörüne destek amacıyla verdiği önergeler ise " gider Başesgioğlu " olduğu gerekçesiyle kabul edilmedi.
 # Change 2.2/dev: merge li + lerin
 # Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
-1-2	Chp'lilerin	_	_	_	_	_	_	_	_
-1	Chp	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	9	nmod:poss	_	_
+1-2	CHP'lilerin	_	_	_	_	_	_	_	_
+1	CHP	CHP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	9	nmod:poss	_	_
 2	'lilerin	li	ADP	With	Case=Gen|Number=Plur|Person=3	1	case	_	_
 3	tarım	tarım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 4	ve	ve	CCONJ	Conj	_	5	cc	_	_
@@ -20013,7 +20014,7 @@
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2209
-# text = Bunun üzerine askeri savcılıktan bir defa daha talepte bulunup Ankara Asliye Hukuk mahkemesindeeki davanın selahiyeti açısından raporları eksiksiz görmek istediklerini belirttiler.
+# text = Bunun üzerine askeri savcılıktan bir defa daha talepte bulunup Ankara Asliye Hukuk mahkemesindeki davanın selahiyeti açısından raporları eksiksiz görmek istediklerini belirttiler.
 1	Bunun	bu	PRON	Demons	Case=Gen|Number=Sing|Person=3|PronType=Dem	2	nmod:poss	_	_
 2	üzerine	üzer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 3	askeri	askeri	ADJ	Adj	_	4	amod	_	_
@@ -20026,7 +20027,7 @@
 10	Ankara	Ankara	PROPN	Prop	Case=Nom|Number=Sing|Person=3	15	nmod	_	_
 11	Asliye	asliye	ADJ	Adj	_	10	flat	_	_
 12	Hukuk	hukuk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	flat	_	_
-13-14	mahkemesindeeki	_	_	_	_	_	_	_	_
+13-14	mahkemesindeki	_	_	_	_	_	_	_	_
 13	mahkemesinde	mahkeme	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	flat	_	_
 14	eki	ki	ADP	Rel	_	10	case	_	_
 15	davanın	dava	NOUN	Noun	Case=Gen|Number=Sing|Person=3	16	nmod:poss	_	_
@@ -22622,8 +22623,8 @@
 6	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2522
-# text = Dışardaaki çadırda Şura ekmek hazırlıyor.
-1-2	Dışardaaki	_	_	_	_	_	_	_	_
+# text = Dışardaki çadırda Şura ekmek hazırlıyor.
+1-2	Dışardaki	_	_	_	_	_	_	_	_
 1	Dışarda	dışarı	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
 2	aki	ki	ADP	Rel	_	1	case	_	_
 3	çadırda	çadır	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
@@ -24077,7 +24078,7 @@
 1	Geçen	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	2	acl	_	_
 2	süre	süre	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod	_	_
 3	zarfında	zarf	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	_
-4	İMKB'nin	İmkb	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
+4	İMKB'nin	İMKB	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
 5	kısa	kısa	ADJ	Adj	_	6	amod	_	_
 6	tarihinde	tarih	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	_
 7	de	de	CCONJ	Conj	_	6	advmod:emph	_	_
@@ -25456,7 +25457,7 @@
 6	1.Şub	1.Şub	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	14	nsubj	_	_
 7	yıl	yıl	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
 8	içinde	iç	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	amod	_	_
-9	İMKB	İmkb	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	nmod:poss	_	_
+9	İMKB	İMKB	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	nmod:poss	_	_
 10	yuz	yuz	NUM	ANum	NumType=Card	11	nummod	_	_
 11	Endeksi'nin	endeks	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	nmod:poss	_	_
 12	yuzon	yuzon	NUM	ANum	NumType=Card	14	nummod	_	_
@@ -25854,7 +25855,7 @@
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2863
-# text = Toplantıyı evinde yapacak olan kişi, Sakarya caddesindeeki iki büyük bakkaldan, ya da Bulvar üzerindeki Trakya Şarküterisi'nden peynir, salam, tarama, Rus salatası, dolma gibi şeyler alırdı.
+# text = Toplantıyı evinde yapacak olan kişi, Sakarya caddesindeki iki büyük bakkaldan, ya da Bulvar üzerindeki Trakya Şarküterisi'nden peynir, salam, tarama, Rus salatası, dolma gibi şeyler alırdı.
 1	Toplantıyı	toplantı	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	obj	_	_
 2	evinde	ev	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obl	_	_
 3	yapacak	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	5	acl	_	_
@@ -25862,7 +25863,7 @@
 5	kişi	kişi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	33	nsubj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	33	punct	_	_
 7	Sakarya	Sakarya	PROPN	Prop	Case=Nom|Number=Sing|Person=3	12	nmod	_	_
-8-9	caddesindeeki	_	_	_	_	_	_	_	_
+8-9	caddesindeki	_	_	_	_	_	_	_	_
 8	caddesinde	cadde	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	flat	_	_
 9	eki	ki	ADP	Rel	_	7	case	_	_
 10	iki	iki	NUM	ANum	NumType=Card	11	nummod	_	_
@@ -26165,7 +26166,7 @@
 
 # sent_id = mst-2903
 # text = CHP Genel Sekreter Yardımcısı Algan Hacaloğlu'nun hazırladığı pakette, " Kürt sorunu " ve " Güneydoğu sorunu " ifadeleri yerine " etnik duyarlılıklara demokratik çözüm " ve " kültürel çoğulculuk " kavramları tercih edildi.
-1	CHP	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
+1	CHP	CHP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 2	Genel	genel	ADJ	Adj	_	3	advmod:emph	_	_
 3	Sekreter	sekreter	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 4	Yardımcısı	yardımcı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nmod	_	_
@@ -26317,7 +26318,7 @@
 
 # sent_id = mst-2924
 # text = DYP Genel Başkanlığı için Türkiye turuna çıkan Elazığ Milletvekili Mehmet Ağar, hakkında çıkarılan şaibe söylentilerinin arkasında başka hesaplar olduğunu savunarak, " Benim için şu anda hukuki problem yok.
-1	DYP	Dyp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
+1	DYP	DYP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 2	Genel	genel	ADJ	Adj	_	3	nmod:poss	_	_
 3	Başkanlığı	başkanlık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nmod	_	_
 4	için	için	ADP	PCNom	_	3	case	_	_
@@ -29048,7 +29049,7 @@
 
 # sent_id = mst-3230
 # text = CHP de sıcak bakıyor.
-1	CHP	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
+1	CHP	CHP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 2	de	de	CCONJ	Conj	_	1	advmod:emph	_	_
 3	sıcak	sıcak	ADJ	Adj	_	4	amod	_	_
 4	bakıyor	bak	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
@@ -29283,11 +29284,11 @@
 
 # sent_id = mst-3257
 # text = DYP Trabzon İl AKP'li partililere seslenen Ağar, Tansu Çiller'i üstü kapalı şekilde eleştirmeyi sürdürdü.
-1	DYP	Dyp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	2	compound	_	_
+1	DYP	DYP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	2	compound	_	_
 2	Trabzon	Trabzon	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	compound	_	_
 3	İl	il	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	compound	_	_
 4-5	AKP'li	_	_	_	_	_	_	_	_
-4	AKP	Akp	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obl	_	_
+4	AKP	AKP	PROPN	Noun	Case=Nom|Number=Sing|Person=3	6	obl	_	_
 5	'li	li	ADP	With	_	4	case	_	_
 6	partililere	partili	ADJ	NAdj	Case=Dat|Number=Plur|Person=3	7	amod	_	_
 7	seslenen	seslen	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	8	acl	_	_
@@ -37326,7 +37327,7 @@
 7	sistem	sistem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod	_	_
 8	üzerinde	üzer	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	obl	_	_
 9	adeta	adeta	ADV	Adverb	_	10	advmod	_	_
-10	AKP	Akp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	12	obl	_	_
+10	AKP	AKP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	12	obl	_	_
 11	gibi	gibi	ADP	PCNom	_	10	case	_	_
 12	oturan	otur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	14	acl	_	_
 13	birkaç	birkaç	DET	Det	_	14	det	_	_
@@ -37350,7 +37351,7 @@
 
 # sent_id = mst-4169
 # text = AKP milletvekillerinin Erbakan'ın iddiasıyla ilgili görüşleri şöyle:.
-1	AKP	Akp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
+1	AKP	AKP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	milletvekillerinin	milletvekili	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	6	nmod	_	_
 3	Erbakan'ın	Erbakan	PROPN	Prop	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
 4	iddiasıyla	iddia	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nmod	_	_
@@ -37781,10 +37782,10 @@
 13	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-4225
-# text = otuz'dan itibaren dışardaaki hava sıcaklığının artmasından dolayı karlar erimeye başlamıştır.
+# text = otuz'dan itibaren dışardaki hava sıcaklığının artmasından dolayı karlar erimeye başlamıştır.
 1	otuz'dan	otuz	NUM	NNum	Case=Abl|Number=Sing|NumType=Card|Person=3	7	nummod	_	_
 2	itibaren	itibaren	ADP	PCAbl	_	1	case	_	_
-3-4	dışardaaki	_	_	_	_	_	_	_	_
+3-4	dışardaki	_	_	_	_	_	_	_	_
 3	dışarda	dışarı	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	nmod	_	_
 4	aki	ki	ADP	Rel	_	3	case	_	_
 5	hava	hava	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
@@ -38713,14 +38714,14 @@
 27	.	.	PUNCT	Punc	_	26	punct	_	_
 
 # sent_id = mst-4311
-# text = En yüksek memur maaşı Başbakanlık müsteşarınınnki kabul edildiğinde ise yapılacak zam yüzsekiz milyon üçyüzseksendört bin beşyüz lira olacak.
+# text = En yüksek memur maaşı Başbakanlık müsteşarınınki kabul edildiğinde ise yapılacak zam yüzsekiz milyon üçyüzseksendört bin beşyüz lira olacak.
 # Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	En	en	ADV	Adverb	_	2	advmod	_	_
 2	yüksek	yüksek	ADJ	Adj	_	4	amod	_	_
 3	memur	memur	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 4	maaşı	maaş	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nsubj	_	_
 5	Başbakanlık	başbakanlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
-6-7	müsteşarınınnki	_	_	_	_	_	_	_	_
+6-7	müsteşarınınki	_	_	_	_	_	_	_	_
 6	müsteşarının	müsteşar	ADJ	NAdj	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
 7	nki	ki	ADP	Rel	Case=Nom|Number=Sing|Person=3	6	case	_	_
 8	kabul	kabul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	obl	_	_
@@ -38914,7 +38915,7 @@
 
 # sent_id = mst-4333
 # text = CHP Genel Başkanı Deniz Baykal da, Kıbrıs yaklaşımı nedeniyle " derin devletin son temsilcisi " diye tanımlanarak protesto edildi.
-1	CHP	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	2	compound	_	_
+1	CHP	CHP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	2	compound	_	_
 2	Genel	genel	ADJ	Adj	_	3	amod	_	_
 3	Başkanı	başkan	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	compound	_	_
 4	Deniz	Deniz	PROPN	Prop	Case=Nom|Number=Sing|Person=3	19	nsubj	_	_
@@ -40711,7 +40712,7 @@
 
 # sent_id = mst-4530
 # text = CHP milletvekilleri dün akşam Devlet Konukevi'nde düzenlenen kokteylle tanıştı.
-1	CHP	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
+1	CHP	CHP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	milletvekilleri	milletvekili	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	9	nsubj	_	_
 3	dün	dün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod	_	_
 4	akşam	akşam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
@@ -40792,7 +40793,7 @@
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4538
-# text = Çağdaş Sanatlar Merkezi önünde toplanan grup, Atatürk bulvarındaaki trafiği bir süre durdurarak, elçilik önüne kadar sloganlarla yürüdü.
+# text = Çağdaş Sanatlar Merkezi önünde toplanan grup, Atatürk bulvarındaki trafiği bir süre durdurarak, elçilik önüne kadar sloganlarla yürüdü.
 1	Çağdaş	çağdaş	ADJ	Adj	_	4	amod	_	_
 2	Sanatlar	sanat	NOUN	Noun	Case=Nom|Number=Plur|Person=3	1	flat	_	_
 3	Merkezi	merkez	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	flat	_	_
@@ -40801,7 +40802,7 @@
 6	grup	grup	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	nsubj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	14	punct	_	_
 8	Atatürk	Atatürk	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	nmod	_	_
-9-10	bulvarındaaki	_	_	_	_	_	_	_	_
+9-10	bulvarındaki	_	_	_	_	_	_	_	_
 9	bulvarında	bulvar	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	flat	_	_
 10	aki	ki	ADP	Rel	_	8	case	_	_
 11	trafiği	trafik	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	obj	_	_
@@ -42990,35 +42991,33 @@
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-4812
-# text = Hitler'in Almanya için kimi iyi şeyler yaptığına, Karl marks'ın dört ayak üstünde çocukları sırtında gezdiren, büyümeyen bir çocuk olarak kaldığına hayretle muttali oluyorsunuz.
+# text = Hitler'in Almanya için kimi iyi şeyler yaptığına, Karl Marks'ın dört ayak üstünde çocukları sırtında gezdiren, büyümeyen bir çocuk olarak kaldığına hayretle muttali oluyorsunuz.
 1	Hitler'in	Hitler	PROPN	Prop	Case=Gen|Number=Sing|Person=3	7	nmod:poss	_	_
 2	Almanya	Almanya	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	obl	_	_
 3	için	için	ADP	PCNom	_	2	case	_	_
 4	kimi	kimi	DET	Det	_	6	det	_	_
 5	iyi	iyi	ADJ	Adj	_	6	amod	_	_
 6	şeyler	şey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	7	obj	_	_
-7	yaptığına	yap	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	26	acl	_	SpaceAfter=No
+7	yaptığına	yap	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	25	acl	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	23	punct	_	_
-9	Karl	Karl	PROPN	Prop	Case=Nom|Number=Sing|Person=3	23	nmod:poss	_	_
-10-11	marks'ın	_	_	_	_	_	_	_	_
-10	mark	mark	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	flat	_	_
-11	s'ın	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Tense=Pres	9	cop	_	_
-12	dört	dört	NUM	ANum	NumType=Card	13	nummod	_	_
-13	ayak	ayak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	nmod:poss	_	_
-14	üstünde	üst	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	amod	_	_
-15	çocukları	çocuk	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	17	obj	_	_
-16	sırtında	sırt	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	obl	_	_
-17	gezdiren	gez	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	21	acl	_	SpaceAfter=No
-18	,	,	PUNCT	Punc	_	19	punct	_	_
-19	büyümeyen	büyü	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	17	conj	_	_
-20	bir	bir	NUM	ANum	NumType=Card	21	det	_	_
-21	çocuk	çocuk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	obl	_	_
-22	olarak	olarak	ADP	PCNom	_	21	case	_	_
-23	kaldığına	kal	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	7	conj	_	_
-24	hayretle	hayret	NOUN	Noun	Case=Ins|Number=Sing|Person=3	26	obl	_	_
-25	muttali	muttali	ADJ	Adj	_	26	obj	_	_
-26	oluyorsunuz	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
-27	.	.	PUNCT	Punc	_	26	punct	_	_
+9	Karl	Karl	PROPN	Prop	Case=Nom|Number=Sing|Person=3	22	nmod:poss	_	_
+10	Marks'ın	Marks	PROPN	Noun	Case=Gen|Number=Sing|Person=3	9	flat	_	_
+11	dört	dört	NUM	ANum	NumType=Card	12	nummod	_	_
+12	ayak	ayak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nmod:poss	_	_
+13	üstünde	üst	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	amod	_	_
+14	çocukları	çocuk	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	16	obj	_	_
+15	sırtında	sırt	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obl	_	_
+16	gezdiren	gez	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	20	acl	_	SpaceAfter=No
+17	,	,	PUNCT	Punc	_	18	punct	_	_
+18	büyümeyen	büyü	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	16	conj	_	_
+19	bir	bir	NUM	ANum	NumType=Card	20	det	_	_
+20	çocuk	çocuk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	obl	_	_
+21	olarak	olarak	ADP	PCNom	_	20	case	_	_
+22	kaldığına	kal	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	7	conj	_	_
+23	hayretle	hayret	NOUN	Noun	Case=Ins|Number=Sing|Person=3	25	obl	_	_
+24	muttali	muttali	ADJ	Adj	_	25	obj	_	_
+25	oluyorsunuz	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
+26	.	.	PUNCT	Punc	_	25	punct	_	_
 
 # sent_id = mst-4816
 # text = Irak'ta savaş tehdidi yanısıra, Amerika'nın baskısına rağmen AB için Türkiye'ye müzakere tarihi verilmeyeceği yönündeki sinyaller piyasada moral bozdu.
@@ -45039,7 +45038,7 @@
 2	hisse	hisse	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 3	oranları	oran	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
 4	arttıkça	art	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	10	nmod	_	_
-5	İMKB	İmkb	PROPN	Prop	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
+5	İMKB	İMKB	PROPN	Prop	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
 6	ve	ve	CCONJ	Conj	_	7	cc	_	_
 7	fon	fon	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	conj	_	_
 8	getirisi	getiri	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nsubj	_	_
@@ -46819,7 +46818,7 @@
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-5272
-# text = Sanayi ve Ticaret Bakanı Ali Coşkun Tüketici yasasındaaki değişikliğin iki hafta içinde TBMM'ye sunulacağını bildirdi.
+# text = Sanayi ve Ticaret Bakanı Ali Coşkun Tüketici yasasındaki değişikliğin iki hafta içinde TBMM'ye sunulacağını bildirdi.
 1	Sanayi	sanayi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nsubj	_	_
 2	ve	ve	CCONJ	Conj	_	1	compound	_	_
 3	Ticaret	ticaret	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
@@ -46827,7 +46826,7 @@
 5	Ali	Ali	PROPN	Prop	Case=Nom|Number=Sing|Person=3	1	flat	_	_
 6	Coşkun	Coşkun	PROPN	Prop	Case=Nom|Number=Sing|Person=3	1	compound	_	_
 7	Tüketici	tüketici	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod	_	_
-8-9	yasasındaaki	_	_	_	_	_	_	_	_
+8-9	yasasındaki	_	_	_	_	_	_	_	_
 8	yasasında	yasa	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	compound	_	_
 9	aki	ki	ADP	Rel	_	7	case	_	_
 10	değişikliğin	değişiklik	NOUN	Noun	Case=Gen|Number=Sing|Person=3	15	nmod:poss	_	_
@@ -47692,7 +47691,7 @@
 24	,	,	PUNCT	Punc	_	35	punct	_	_
 25	aynı	aynı	ADJ	Adj	_	35	amod	_	_
 26	zamanda	zaman	NOUN	Noun	Case=Loc|Number=Sing|Person=3	25	compound	_	_
-27	AKP'nin	Akp	NOUN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	29	nmod:poss	_	_
+27	AKP'nin	AKP	PROPN	Abr	Abbr=Yes|Case=Gen|Number=Sing|Person=3	29	nmod:poss	_	_
 28	istihdamın	istihdam	NOUN	Noun	Case=Gen|Number=Sing|Person=3	27	conj	_	_
 29	önünde	ön	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	30	amod	_	_
 30	yükselen	yüksel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	31	acl	_	_
@@ -48328,7 +48327,7 @@
 
 # sent_id = mst-5423
 # text = CHP de sıcak.
-1	CHP	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
+1	CHP	CHP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	de	de	CCONJ	Conj	_	1	advmod:emph	_	_
 3	sıcak	sıcak	ADJ	Adj	_	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -49426,7 +49425,7 @@
 1	Heyette	heyet	NOUN	Noun	Case=Loc|Number=Sing|Person=3	2	nmod	_	_
 2	yer	yer	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
 3	alan	al	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	2	compound	_	_
-4	CHP	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
+4	CHP	CHP	PROPN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 5	İzmir	İzmir	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 6	Milletvekili	milletvekili	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nmod	_	_
 7	Erdal	Erdal	PROPN	Prop	Case=Nom|Number=Sing|Person=3	24	nsubj	_	_

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -343,23 +343,22 @@
 
 # sent_id = mst-0048
 # text = Serin havayla hafifçe ürpermekten, hayatın gerçekliğine dokunmaktan ve sırlarını hissetmekten hoşnuttum.
+# Change 2.2/dev: merge -CA
 1	Serin	serin	ADJ	Adj	_	2	amod	_	_
-2	havayla	hava	NOUN	Noun	Case=Ins|Number=Sing|Person=3	5	obl	_	_
-3-4	hafifçe	_	_	_	_	_	_	_	_
-3	hafif	hafif	ADJ	Adj	_	5	amod	_	_
-4	çe	ce	ADP	Ly	_	3	case	_	_
-5	ürpermekten	ürper	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	13	nmod	_	SpaceAfter=No
-6	,	,	PUNCT	Punc	_	9	punct	_	_
-7	hayatın	hayat	NOUN	Noun	Case=Gen|Number=Sing|Person=3	8	nmod:poss	_	_
-8	gerçekliğine	gerçeklik	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
-9	dokunmaktan	dokun	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	conj	_	_
-10	ve	ve	CCONJ	Conj	_	12	cc	_	_
-11	sırlarını	sır	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	12	obj	_	_
-12	hissetmekten	hisset	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	conj	_	_
-13-14	hoşnuttum	_	_	_	_	_	_	_	SpaceAfter=No
-13	hoşnut	hoşnut	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
-14	tum	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Past	13	cop	_	_
-15	.	.	PUNCT	Punc	_	13	punct	_	_
+2	havayla	hava	NOUN	Noun	Case=Ins|Number=Sing|Person=3	4	obl	_	_
+3	hafifçe	hafifçe	ADV	Adverb	_	4	advmod	_	_
+4	ürpermekten	ürper	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	12	nmod	_	SpaceAfter=No
+5	,	,	PUNCT	Punc	_	8	punct	_	_
+6	hayatın	hayat	NOUN	Noun	Case=Gen|Number=Sing|Person=3	7	nmod:poss	_	_
+7	gerçekliğine	gerçeklik	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	_
+8	dokunmaktan	dokun	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	conj	_	_
+9	ve	ve	CCONJ	Conj	_	11	cc	_	_
+10	sırlarını	sır	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	11	obj	_	_
+11	hissetmekten	hisset	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	conj	_	_
+12-13	hoşnuttum	_	_	_	_	_	_	_	SpaceAfter=No
+12	hoşnut	hoşnut	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
+13	tum	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Past	12	cop	_	_
+14	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-0050
 # text = Aydınlık gazetesinde konuştuğu muhabirler, Biz size yardımcı olalım, dediler.
@@ -522,26 +521,25 @@
 
 # sent_id = mst-0067
 # text = Yerde araç izinin olmaması ve kamyonun ilerleyecek yol bulamaması, ormanın bu bölümüne kasabadan sıkça gelinmediğini gösteriyordu.
+# Change 2.2/dev: merge -CA
 1	Yerde	yer	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 2	araç	araç	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 3	izinin	iz	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
-4	olmaması	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	18	obj	_	_
+4	olmaması	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	17	obj	_	_
 5	ve	ve	CCONJ	Conj	_	9	cc	_	_
 6	kamyonun	kamyon	NOUN	Noun	Case=Gen|Number=Sing|Person=3	9	nsubj	_	_
 7	ilerleyecek	ilerle	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	8	acl	_	_
 8	yol	yol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
 9	bulamaması	bul	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	4	conj	_	SpaceAfter=No
-10	,	,	PUNCT	Punc	_	17	punct	_	_
+10	,	,	PUNCT	Punc	_	16	punct	_	_
 11	ormanın	orman	NOUN	Noun	Case=Gen|Number=Sing|Person=3	13	nmod:poss	_	_
 12	bu	bu	DET	Det	_	13	det	_	_
-13	bölümüne	bölüm	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	obl	_	_
-14	kasabadan	kasaba	NOUN	Noun	Case=Abl|Number=Sing|Person=3	17	obl	_	_
-15-16	sıkça	_	_	_	_	_	_	_	_
-15	sık	sık	ADJ	Adj	_	17	amod	_	_
-16	ça	ce	ADP	Ly	_	15	case	_	_
-17	gelinmediğini	gel	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part|Voice=Pass	4	conj	_	_
-18	gösteriyordu	göster	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
-19	.	.	PUNCT	Punc	_	18	punct	_	_
+13	bölümüne	bölüm	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obl	_	_
+14	kasabadan	kasaba	NOUN	Noun	Case=Abl|Number=Sing|Person=3	16	obl	_	_
+15	sıkça	sıkça	ADV	Adverb	_	16	advmod	_	_
+16	gelinmediğini	gel	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part|Voice=Pass	4	conj	_	_
+17	gösteriyordu	göster	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
+18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-0068
 # text = Patlıcan mideye muzır.
@@ -986,12 +984,11 @@
 
 # sent_id = mst-0122
 # text = Yanakları hafifçe pembeleşmişti.
-1	Yanakları	yanak	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
-2-3	hafifçe	_	_	_	_	_	_	_	_
-2	hafif	hafif	ADJ	Adj	_	4	amod	_	_
-3	çe	ce	ADP	Ly	_	2	case	_	_
-4	pembeleşmişti	pembeleş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	4	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Yanakları	yanak	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	3	nsubj	_	_
+2	hafifçe	hafifçe	ADV	Adverb	_	3	advmod	_	_
+3	pembeleşmişti	pembeleş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-0123
 # text = Siyah rugan.
@@ -2100,20 +2097,19 @@
 
 # sent_id = mst-0273
 # text = Bugün iyice kalabalıklaşan kervan altı saatlik yolculukla kasabaya ulaşacak.
-1	Bugün	bugün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obl	_	_
-2-3	iyice	_	_	_	_	_	_	_	_
-2	iyi	iyi	ADJ	Adj	_	4	amod	_	_
-3	ce	ce	ADP	Ly	_	2	case	_	_
-4	kalabalıklaşan	kalabalıklaş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	acl	_	_
-5	kervan	kervan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
-6	altı	altı	NUM	ANum	NumType=Card	7	nummod	_	_
-7-8	saatlik	_	_	_	_	_	_	_	_
-7	saat	saat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nmod	_	_
-8	lik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	7	case	_	_
-9	yolculukla	yolculuk	NOUN	Noun	Case=Ins|Number=Sing|Person=3	11	obl	_	_
-10	kasabaya	kasaba	NOUN	Noun	Case=Dat|Number=Sing|Person=3	11	obl	_	_
-11	ulaşacak	ulaş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	SpaceAfter=No
-12	.	.	PUNCT	Punc	_	11	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Bugün	bugün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obl	_	_
+2	iyice	iyice	ADV	Adverb	_	3	advmod	_	_
+3	kalabalıklaşan	kalabalıklaş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	acl	_	_
+4	kervan	kervan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
+5	altı	altı	NUM	ANum	NumType=Card	6	nummod	_	_
+6-7	saatlik	_	_	_	_	_	_	_	_
+6	saat	saat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod	_	_
+7	lik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	6	case	_	_
+8	yolculukla	yolculuk	NOUN	Noun	Case=Ins|Number=Sing|Person=3	10	obl	_	_
+9	kasabaya	kasaba	NOUN	Noun	Case=Dat|Number=Sing|Person=3	10	obl	_	_
+10	ulaşacak	ulaş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	SpaceAfter=No
+11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-0274
 # text = Anlatırım.
@@ -4287,6 +4283,7 @@
 
 # sent_id = mst-0479
 # text = Bir köpeğin bütün kokuları birbirinden ayırdedip insanların duygularını kokularından anlamaları gibi kadınların sesini tanırdım, her tonunu bilirdim, yalnızca kulaklarımla değil bütün vücudumla duyardım onların sesini.
+# Change 2.2/dev: merge -CA
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	köpeğin	köpek	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod	_	_
 3	bütün	bütün	ADJ	Adj	_	4	det	_	_
@@ -4305,18 +4302,16 @@
 16	her	her	DET	Det	_	18	obj	_	_
 17	tonunu	ton	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	obj	_	_
 18	bilirdim	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	14	conj	_	SpaceAfter=No
-19	,	,	PUNCT	Punc	_	26	punct	_	_
-20-21	yalnızca	_	_	_	_	_	_	_	_
-20	yalnız	yalnız	ADJ	Adj	_	22	amod	_	_
-21	ca	ce	ADP	Ly	_	20	case	_	_
-22	kulaklarımla	kulak	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=1	23	nmod	_	_
-23	değil	değil	CCONJ	Conj	_	26	nmod	_	_
-24	bütün	bütün	ADJ	Adj	_	25	det	_	_
-25	vücudumla	vücut	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	23	conj	_	_
-26	duyardım	duy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	14	conj	_	_
-27	onların	o	PRON	Pers	Case=Gen|Number=Plur|Person=3|PronType=Prs	28	nmod:poss	_	_
-28	sesini	ses	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	26	obj	_	SpaceAfter=No
-29	.	.	PUNCT	Punc	_	26	punct	_	_
+19	,	,	PUNCT	Punc	_	25	punct	_	_
+20	yalnızca	yalnızca	ADV	Adverb	_	21	advmod	_	_
+21	kulaklarımla	kulak	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=1	22	nmod	_	_
+22	değil	değil	CCONJ	Conj	_	25	nmod	_	_
+23	bütün	bütün	ADJ	Adj	_	24	det	_	_
+24	vücudumla	vücut	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	22	conj	_	_
+25	duyardım	duy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	14	conj	_	_
+26	onların	o	PRON	Pers	Case=Gen|Number=Plur|Person=3|PronType=Prs	27	nmod:poss	_	_
+27	sesini	ses	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	25	obj	_	SpaceAfter=No
+28	.	.	PUNCT	Punc	_	25	punct	_	_
 
 # sent_id = mst-0480
 # text = Kara sevda...
@@ -4768,26 +4763,25 @@
 
 # sent_id = mst-0528
 # text = Oğlunuza sarıldığınızda, aklınızdan, Ya bu ona son sarılışımsa gibi aptalca bir düşünce geçiyor.
+# Change 2.2/dev: merge -CA
 1	Oğlunuza	oğul	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	2	obl	_	_
 2	sarıldığınızda	sar	VERB	Verb	Aspect=Perf|Case=Loc|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	17	acl	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	2	punct	_	_
-4	aklınızdan	akıl	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	17	obl	_	SpaceAfter=No
-5	,	,	PUNCT	Punc	_	17	punct	_	_
+4	aklınızdan	akıl	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	16	obl	_	SpaceAfter=No
+5	,	,	PUNCT	Punc	_	16	punct	_	_
 6	Ya	ya	CCONJ	Conj	_	0	root	_	_
 7	bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	10	nsubj	_	_
 8	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	10	nmod	_	_
 9	son	son	ADJ	Adj	_	10	amod	_	_
 10-11	sarılışımsa	_	_	_	_	_	_	_	_
-10	sarılışım	sarılış	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	16	nmod	_	_
+10	sarılışım	sarılış	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	15	nmod	_	_
 11	sa	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	10	cop	_	_
 12	gibi	gibi	ADP	PCNom	_	10	case	_	_
-13-14	aptalca	_	_	_	_	_	_	_	_
-13	aptal	aptal	ADJ	Adj	_	16	amod	_	_
-14	ca	ce	ADP	Ly	_	13	case	_	_
-15	bir	bir	NUM	ANum	NumType=Card	16	det	_	_
-16	düşünce	düşünce	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nsubj	_	_
-17	geçiyor	geç	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	6	conj	_	SpaceAfter=No
-18	.	.	PUNCT	Punc	_	17	punct	_	_
+13	aptalca	aptalca	ADV	Adverb	_	15	advmod	_	_
+14	bir	bir	NUM	ANum	NumType=Card	15	det	_	_
+15	düşünce	düşünce	NOUN	Noun	Case=Nom|Number=Sing|Person=2	17	nsubj	_	_
+16	geçiyor	geç	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	6	conj	_	SpaceAfter=No
+17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-0529
 # text = Ya orayı bir daha bulamazsam?
@@ -5395,12 +5389,10 @@
 
 # sent_id = mst-0610
 # text = Sessizce onayladık.
-1-3	Sessizce	_	_	_	_	_	_	_	_
-1	Ses	ses	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obl	_	_
-2	siz	siz	ADP	Without	_	1	case	_	_
-3	ce	ce	ADP	Ly	_	1	case	_	_
-4	onayladık	onayla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	4	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Sessizce	sessizce	ADV	Adverb	_	2	obl	_	_
+2	onayladık	onayla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0613
 # text = Naci Bey hala sınıfa bakıyordu.
@@ -7962,25 +7954,24 @@
 
 # sent_id = mst-0894
 # text = Kolayca eşelenen kuru karın altındaki otlar, kış ayları boyunca yeterli gıdayı sağlıyordu onlara.
-1-2	Kolayca	_	_	_	_	_	_	_	_
-1	Kolay	kolay	ADJ	Adj	_	3	amod	_	_
-2	ca	ce	ADP	Ly	_	1	case	_	_
-3	eşelenen	eşele	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	5	acl	_	_
-4	kuru	kuru	ADJ	Adj	_	5	amod	_	_
-5	karın	kar	NOUN	Noun	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
-6-7	altındaki	_	_	_	_	_	_	_	_
-6	altında	altı	NUM	NNum	Case=Loc|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=2	8	nummod	_	_
-7	ki	ki	ADP	Rel	_	6	case	_	_
-8	otlar	ot	NOUN	Noun	Case=Nom|Number=Plur|Person=3	15	nsubj	_	SpaceAfter=No
-9	,	,	PUNCT	Punc	_	15	punct	_	_
-10	kış	kış	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nmod:poss	_	_
-11	ayları	ay	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	15	obl	_	_
-12	boyunca	boyunca	ADP	PCNom	_	11	case	_	_
-13	yeterli	yeterli	ADJ	Adj	_	14	amod	_	_
-14	gıdayı	gıda	NOUN	Noun	Case=Acc|Number=Sing|Person=3	15	obj	_	_
-15	sağlıyordu	sağla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	_
-16	onlara	o	PRON	Pers	Case=Dat|Number=Plur|Person=3|PronType=Prs	15	obl	_	SpaceAfter=No
-17	.	.	PUNCT	Punc	_	15	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Kolayca	Kolayca	ADV	Adverb	_	2	advmod	_	_
+2	eşelenen	eşele	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	4	acl	_	_
+3	kuru	kuru	ADJ	Adj	_	4	amod	_	_
+4	karın	kar	NOUN	Noun	Case=Gen|Number=Sing|Person=3	5	nmod:poss	_	_
+5-6	altındaki	_	_	_	_	_	_	_	_
+5	altında	altı	NUM	NNum	Case=Loc|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=2	7	nummod	_	_
+6	ki	ki	ADP	Rel	_	5	case	_	_
+7	otlar	ot	NOUN	Noun	Case=Nom|Number=Plur|Person=3	14	nsubj	_	SpaceAfter=No
+8	,	,	PUNCT	Punc	_	14	punct	_	_
+9	kış	kış	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod:poss	_	_
+10	ayları	ay	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	14	obl	_	_
+11	boyunca	boyunca	ADP	PCNom	_	10	case	_	_
+12	yeterli	yeterli	ADJ	Adj	_	13	amod	_	_
+13	gıdayı	gıda	NOUN	Noun	Case=Acc|Number=Sing|Person=3	14	obj	_	_
+14	sağlıyordu	sağla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	_
+15	onlara	o	PRON	Pers	Case=Dat|Number=Plur|Person=3|PronType=Prs	14	obl	_	SpaceAfter=No
+16	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-0895
 # text = Ama asıl avuçları iyi tanıyordu o cetveli.
@@ -11540,32 +11531,31 @@
 
 # sent_id = mst-1286
 # text = Kadınlar rahatça mağazada dolaşmaya, satış elemanlarıyla konuşmaya, ürünleri incelemeye, sorular sormaya, ürünleri denemeye ve sonunda satın almaya daha yatkın.
-1	Kadınlar	kadın	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	24	nsubj	_	_
-2-3	rahatça	_	_	_	_	_	_	_	_
-2	rahat	rahat	ADJ	Adj	_	5	amod	_	_
-3	ça	ce	ADP	Ly	_	2	case	_	_
-4	mağazada	mağaza	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
-5	dolaşmaya	dolaş	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	24	nmod	_	SpaceAfter=No
-6	,	,	PUNCT	Punc	_	9	punct	_	_
-7	satış	satış	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
-8	elemanlarıyla	eleman	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	7	compound	_	_
-9	konuşmaya	konuş	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	conj	_	SpaceAfter=No
-10	,	,	PUNCT	Punc	_	12	punct	_	_
-11	ürünleri	ürün	NOUN	Noun	Case=Acc|Number=Plur|Person=3	12	obj	_	_
-12	incelemeye	incele	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	conj	_	SpaceAfter=No
-13	,	,	PUNCT	Punc	_	15	punct	_	_
-14	sorular	soru	NOUN	Noun	Case=Nom|Number=Plur|Person=3	15	obj	_	_
-15	sormaya	sor	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	conj	_	SpaceAfter=No
-16	,	,	PUNCT	Punc	_	18	punct	_	_
-17	ürünleri	ürün	NOUN	Noun	Case=Acc|Number=Plur|Person=3	18	obj	_	_
-18	denemeye	dene	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	conj	_	_
-19	ve	ve	CCONJ	Conj	_	21	cc	_	_
-20	sonunda	son	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	amod	_	_
-21	satın	satın	ADV	Adverb	_	5	advmod	_	_
-22	almaya	al	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	21	compound	_	_
-23	daha	daha	ADV	Adverb	_	24	advmod	_	_
-24	yatkın	yatkın	ADJ	Adj	_	0	root	_	SpaceAfter=No
-25	.	.	PUNCT	Punc	_	24	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Kadınlar	kadın	ADJ	NAdj	Case=Nom|Number=Plur|Person=2	23	nsubj	_	_
+2	rahatça	rahatça	ADV	Adverb	_	4	advmod	_	_
+3	mağazada	mağaza	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
+4	dolaşmaya	dolaş	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	23	nmod	_	SpaceAfter=No
+5	,	,	PUNCT	Punc	_	8	punct	_	_
+6	satış	satış	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
+7	elemanlarıyla	eleman	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	6	compound	_	_
+8	konuşmaya	konuş	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	conj	_	SpaceAfter=No
+9	,	,	PUNCT	Punc	_	11	punct	_	_
+10	ürünleri	ürün	NOUN	Noun	Case=Acc|Number=Plur|Person=3	11	obj	_	_
+11	incelemeye	incele	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	conj	_	SpaceAfter=No
+12	,	,	PUNCT	Punc	_	14	punct	_	_
+13	sorular	soru	NOUN	Noun	Case=Nom|Number=Plur|Person=3	14	obj	_	_
+14	sormaya	sor	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	conj	_	SpaceAfter=No
+15	,	,	PUNCT	Punc	_	17	punct	_	_
+16	ürünleri	ürün	NOUN	Noun	Case=Acc|Number=Plur|Person=3	17	obj	_	_
+17	denemeye	dene	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	conj	_	_
+18	ve	ve	CCONJ	Conj	_	20	cc	_	_
+19	sonunda	son	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	amod	_	_
+20	satın	satın	ADV	Adverb	_	4	advmod	_	_
+21	almaya	al	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	20	compound	_	_
+22	daha	daha	ADV	Adverb	_	23	advmod	_	_
+23	yatkın	yatkın	ADJ	Adj	_	0	root	_	SpaceAfter=No
+24	.	.	PUNCT	Punc	_	23	punct	_	_
 
 # sent_id = mst-1289
 # text = Yaşlı bir dostun armağanı.
@@ -13496,6 +13486,7 @@
 
 # sent_id = mst-1506
 # text = Bazen şarkı söylerken de olur bu, arkadaşlar bilir (arkadaşlar, yani bıyıklarına ak düşmüş emekli sarhoşlar gözlerini yumup başlarını hafifçe eğerek onaylıyorlar) okursa hüzzam okur, herkesi kahırlandırır.
+# Change 2.2/dev: merge -CA
 1	Bazen	bazen	ADV	Adverb	_	5	advmod	_	_
 2	şarkı	şarkı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
 3	söylerken	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	2	compound	_	_
@@ -13517,19 +13508,17 @@
 19	gözlerini	göz	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	21	nmod	_	_
 20	yumup	yum	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	19	compound	_	_
 21	başlarını	baş	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	25	obl	_	_
-22-23	hafifçe	_	_	_	_	_	_	_	_
-22	hafif	hafif	ADJ	Adj	_	21	amod	_	_
-23	çe	ce	ADP	Ly	_	22	case	_	_
-24	eğerek	eğ	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	21	compound	_	_
-25	onaylıyorlar	onayla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	9	parataxis	_	SpaceAfter=No
-26	)	)	PUNCT	Punc	_	25	punct	_	_
-27	okursa	oku	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	29	nmod	_	_
-28	hüzzam	hüzzam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	29	obj	_	_
-29	okur	oku	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	SpaceAfter=No
-30	,	,	PUNCT	Punc	_	32	punct	_	_
-31	herkesi	herkes	NOUN	Noun	Case=Acc|Number=Sing|Person=3	32	obj	_	_
-32	kahırlandırır	kahırlan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	5	conj	_	SpaceAfter=No
-33	.	.	PUNCT	Punc	_	32	punct	_	_
+22	hafifçe	hafifçe	ADV	Adverb	_	21	advmod	_	_
+23	eğerek	eğ	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	21	compound	_	_
+24	onaylıyorlar	onayla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	9	parataxis	_	SpaceAfter=No
+25	)	)	PUNCT	Punc	_	24	punct	_	_
+26	okursa	oku	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	29	nmod	_	_
+27	hüzzam	hüzzam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	29	obj	_	_
+28	okur	oku	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	SpaceAfter=No
+29	,	,	PUNCT	Punc	_	32	punct	_	_
+30	herkesi	herkes	NOUN	Noun	Case=Acc|Number=Sing|Person=3	32	obj	_	_
+31	kahırlandırır	kahırlan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	5	conj	_	SpaceAfter=No
+32	.	.	PUNCT	Punc	_	31	punct	_	_
 
 # sent_id = mst-1509
 # text = Sosyal boyutu da ihmal edemeyiz " dedi.
@@ -15705,11 +15694,10 @@
 
 # sent_id = mst-1752
 # text = Soğukça yanıtladım.
-1-2	Soğukça	_	_	_	_	_	_	_	_
-1	Soğuk	soğuk	ADJ	Adj	_	3	amod	_	_
-2	ça	ce	ADP	Ly	_	1	case	_	_
-3	yanıtladım	yanıtla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-4	.	.	PUNCT	Punc	_	3	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Soğukça	Soğukça	ADV	Adverb	_	2	advmod	_	_
+2	yanıtladım	yanıtla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-1753
 # text = Börtü, böcek, tilki, sansar, kuş...
@@ -15768,12 +15756,10 @@
 
 # sent_id = mst-1760
 # text = Yavaşça yanına yaklaştım.
-1-2	Yavaşça	_	_	_	_	_	_	_	_
-1	Yavaş	yavaş	ADJ	Adj	_	4	amod	_	_
-2	ça	ce	ADP	Ly	_	1	case	_	_
-3	yanına	yan	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	amod	_	_
-4	yaklaştım	yaklaş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	4	punct	_	_
+1	Yavaşça	Yavaşça	ADV	Adverb	_	3	advmod	_	_
+2	yanına	yan	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	amod	_	_
+3	yaklaştım	yaklaş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1761
 # text = Hepsi bir sepetin içindeydi ve benim görevim, tabi eğer bu köpeği istiyorsam, bunların hepsinin yerli yerinde durmasını sağlamaktı.
@@ -16056,20 +16042,19 @@
 
 # sent_id = mst-1789
 # text = Kapı dışarıdan vuruluyor, hafifçe itiliyor, aralanıyor, yeniden kapanıyordu.
+# Change 2.2/dev: merge -CA
 1	Kapı	kapı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 2	dışarıdan	dışarı	NOUN	Noun	Case=Abl|Number=Sing|Person=3	3	obl	_	_
 3	vuruluyor	vurul	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
-4	,	,	PUNCT	Punc	_	7	punct	_	_
-5-6	hafifçe	_	_	_	_	_	_	_	_
-5	hafif	hafif	ADJ	Adj	_	7	amod	_	_
-6	çe	ce	ADP	Ly	_	5	case	_	_
-7	itiliyor	it	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Pass	3	conj	_	SpaceAfter=No
-8	,	,	PUNCT	Punc	_	9	punct	_	_
-9	aralanıyor	arala	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Pass	3	conj	_	SpaceAfter=No
-10	,	,	PUNCT	Punc	_	12	punct	_	_
-11	yeniden	yeniden	ADV	Adverb	_	12	advmod	_	_
-12	kapanıyordu	kapa	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Pass	3	conj	_	SpaceAfter=No
-13	.	.	PUNCT	Punc	_	12	punct	_	_
+4	,	,	PUNCT	Punc	_	6	punct	_	_
+5	hafifçe	hafifçe	ADV	Adverb	_	6	advmod	_	_
+6	itiliyor	it	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Pass	3	conj	_	SpaceAfter=No
+7	,	,	PUNCT	Punc	_	8	punct	_	_
+8	aralanıyor	arala	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Pass	3	conj	_	SpaceAfter=No
+9	,	,	PUNCT	Punc	_	11	punct	_	_
+10	yeniden	yeniden	ADV	Adverb	_	11	advmod	_	_
+11	kapanıyordu	kapa	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Pass	3	conj	_	SpaceAfter=No
+12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-1792
 # text = Tamam, geliyorum.
@@ -16523,20 +16508,19 @@
 
 # sent_id = mst-1845
 # text = İncecik bacaklarını birbirinin üzerine atmıştı, geniş koltuğun üzerinde rahatça oturuyordu.
+# Change 2.2/dev: merge -CA
 1	İncecik	incecik	ADJ	Adj	_	2	amod	_	_
 2	bacaklarını	bacak	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
 3	birbirinin	birbiri	PRON	Quant	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	4	nmod:poss	_	_
 4	üzerine	üzer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 5	atmıştı	at	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
-6	,	,	PUNCT	Punc	_	12	punct	_	_
+6	,	,	PUNCT	Punc	_	11	punct	_	_
 7	geniş	geniş	ADJ	Adj	_	8	amod	_	_
-8	koltuğun	koltuk	NOUN	Noun	Case=Gen|Number=Sing|Person=3	12	obl	_	_
+8	koltuğun	koltuk	NOUN	Noun	Case=Gen|Number=Sing|Person=3	11	obl	_	_
 9	üzerinde	üzer	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	appos	_	_
-10-11	rahatça	_	_	_	_	_	_	_	_
-10	rahat	rahat	ADJ	Adj	_	12	amod	_	_
-11	ça	ce	ADP	Ly	_	10	case	_	_
-12	oturuyordu	otur	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	5	conj	_	SpaceAfter=No
-13	.	.	PUNCT	Punc	_	12	punct	_	_
+10	rahatça	rahatça	ADV	Adverb	_	11	advmod	_	_
+11	oturuyordu	otur	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	5	conj	_	SpaceAfter=No
+12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-1847
 # text = Ulvi meslek öğretmenliğe sığındık.
@@ -18424,6 +18408,7 @@
 
 # sent_id = mst-2039
 # text = Biraz, çok değil, biraz soluklanmam gerek, kısacası.
+# Change 2.2/dev: merge -CA
 1	Biraz	biraz	ADV	Adverb	_	4	advmod:emph	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	6	punct	_	_
 3	çok	çok	ADV	Adverb	_	4	advmod:emph	_	_
@@ -19109,13 +19094,11 @@
 1	Peki	peki	ADV	Adverb	_	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	3	punct	_	_
 3	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	1	conj	_	_
-4-5	kısaca	_	_	_	_	_	_	_	_
-4	kısa	kısa	ADJ	Adj	_	6	amod	_	_
-5	ca	ce	ADP	Ly	_	4	case	_	_
-6	Gelin	gel	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	3	conj	_	_
-7	o	o	DET	Det	_	6	det	_	_
-8	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	compound	_	SpaceAfter=No
-9	.	.	PUNCT	Punc	_	6	punct	_	_
+4	kısaca	kısaca	ADV	Adverb	_	5	advmod	_	_
+5	Gelin	gel	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	3	conj	_	_
+6	o	o	DET	Det	_	5	det	_	_
+7	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	compound	_	SpaceAfter=No
+8	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-2118
 # text = Ne soracağımı anlamıştı, sor, dedi gönülsüzce.
@@ -19193,18 +19176,17 @@
 
 # sent_id = mst-2128
 # text = Kapı bir daha tıklayınca, sertçe açtı Naci Bey.
+# Change 2.2/dev: merge -CA
 1	Kapı	kapı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 2	bir	bir	ADV	Adverb	_	4	advmod	_	_
 3	daha	daha	ADV	Adverb	_	2	advmod	_	_
-4	tıklayınca	tıkla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	8	nmod	_	SpaceAfter=No
+4	tıklayınca	tıkla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	4	punct	_	_
-6-7	sertçe	_	_	_	_	_	_	_	_
-6	sert	sert	ADJ	Adj	_	8	amod	_	_
-7	çe	ce	ADP	Ly	_	6	case	_	_
-8	açtı	aç	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
-9	Naci	Naci	PROPN	Prop	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
-10	Bey	bey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	8	punct	_	_
+6	sertçe	sertçe	ADV	Adverb	_	7	advmod	_	_
+7	açtı	aç	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+8	Naci	Naci	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
+9	Bey	bey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-2129
 # text = Her gün kırmızı Mersedesi bekleyeceğim, dedi Memo heyecanla.
@@ -19816,23 +19798,22 @@
 
 # sent_id = mst-2187
 # text = Aptalca düşüncelerinizi, ruhunuzun hasta olduğunu sandığınız yanını başkalarının duymasından, bilmesinden korktunuz yıllarca.
-1-2	Aptalca	_	_	_	_	_	_	_	_
-1	Aptal	aptal	ADJ	Adj	_	3	amod	_	_
-2	ca	ce	ADP	Ly	_	1	case	_	_
-3	düşüncelerinizi	düşünce	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=2	11	obj	_	SpaceAfter=No
-4	,	,	PUNCT	Punc	_	11	punct	_	_
-5	ruhunuzun	ruh	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	7	nsubj	_	_
-6	hasta	hasta	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	7	obj	_	_
-7	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	8	obj	_	_
-8	sandığınız	san	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	9	acl	_	_
-9	yanını	yan	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obj	_	_
-10	başkalarının	başka	ADJ	NAdj	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=2	11	nmod:poss	_	_
-11	duymasından	duy	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	14	nmod	_	SpaceAfter=No
-12	,	,	PUNCT	Punc	_	13	punct	_	_
-13	bilmesinden	bil	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	11	conj	_	_
-14	korktunuz	kork	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Past	0	root	_	_
-15	yıllarca	yıllarca	ADV	Adverb	_	14	advmod	_	SpaceAfter=No
-16	.	.	PUNCT	Punc	_	14	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Aptalca	Aptalca	ADV	Adverb	_	2	advmod	_	_
+2	düşüncelerinizi	düşünce	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=2	10	obj	_	SpaceAfter=No
+3	,	,	PUNCT	Punc	_	10	punct	_	_
+4	ruhunuzun	ruh	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	6	nsubj	_	_
+5	hasta	hasta	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	6	obj	_	_
+6	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	7	obj	_	_
+7	sandığınız	san	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	8	acl	_	_
+8	yanını	yan	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obj	_	_
+9	başkalarının	başka	ADJ	NAdj	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=2	10	nmod:poss	_	_
+10	duymasından	duy	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	13	nmod	_	SpaceAfter=No
+11	,	,	PUNCT	Punc	_	12	punct	_	_
+12	bilmesinden	bil	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	10	conj	_	_
+13	korktunuz	kork	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Past	0	root	_	_
+14	yıllarca	yıllarca	ADV	Adverb	_	13	advmod	_	SpaceAfter=No
+15	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-2189
 # text = Öyle sevimli öyle sevimliydi ki.
@@ -23062,19 +23043,18 @@
 
 # sent_id = mst-2564
 # text = İyice kollarız, dedi Katana, yoksa dalarız.
-1-2	İyice	_	_	_	_	_	_	_	_
-1	İyi	iyi	ADJ	Adj	_	3	amod	_	_
-2	ce	ce	ADP	Ly	_	1	case	_	_
-3	kollarız	kolla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	5	obj	_	SpaceAfter=No
-4	,	,	PUNCT	Punc	_	10	punct	_	_
-5	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
-6	Katana	katana	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	SpaceAfter=No
-7	,	,	PUNCT	Punc	_	5	punct	_	_
-8-9	yoksa	_	_	_	_	_	_	_	_
-8	yok	yok	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	10	cc	_	_
-9	sa	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	8	cop	_	_
-10	dalarız	dala	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	10	punct	_	_
+# Change 2.2/dev: merge -CA
+1	İyice	İyice	ADV	Adverb	_	2	advmod	_	_
+2	kollarız	kolla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	4	obj	_	SpaceAfter=No
+3	,	,	PUNCT	Punc	_	9	punct	_	_
+4	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+5	Katana	katana	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	SpaceAfter=No
+6	,	,	PUNCT	Punc	_	4	punct	_	_
+7-8	yoksa	_	_	_	_	_	_	_	_
+7	yok	yok	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	9	cc	_	_
+8	sa	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	7	cop	_	_
+9	dalarız	dala	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	2	conj	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2565
 # text = Akçaalan Mahallesindeki ev iyiydi hoştu, ama hatta eş dost, hısım akraba hep oradaydı, ama devir değişiyordu.
@@ -24708,13 +24688,12 @@
 
 # sent_id = mst-2728
 # text = Kapının orda hafifçe sendeledi.
+# Change 2.2/dev: merge -CA
 1	Kapının	kapı	NOUN	Noun	Case=Gen|Number=Sing|Person=3	2	nmod	_	_
-2	orda	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
-3-4	hafifçe	_	_	_	_	_	_	_	_
-3	hafif	hafif	ADJ	Adj	_	5	amod	_	_
-4	çe	ce	ADP	Ly	_	3	case	_	_
-5	sendeledi	sendele	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	5	punct	_	_
+2	orda	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
+3	hafifçe	hafifçe	ADV	Adverb	_	4	advmod	_	_
+4	sendeledi	sendele	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2729
 # text = Ama bir ihtimal var, değil mi? Sırf sana olan kızgınlığımı birine anlatmam halinde üzerimden bir yük kalkar, gerilimim azalır, sana daha hoşgörülü yaklaşabilirim, daha bağışlayıcı olabilirim.
@@ -24983,12 +24962,11 @@
 
 # sent_id = mst-2757
 # text = Uysalca bıraktı ellerini.
-1-2	Uysalca	_	_	_	_	_	_	_	_
-1	Uysal	uysal	ADJ	Adj	_	3	amod	_	_
-2	ca	ce	ADP	Ly	_	1	case	_	_
-3	bıraktı	bırak	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
-4	ellerini	el	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	3	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Uysalca	Uysalca	ADV	Adverb	_	2	advmod	_	_
+2	bıraktı	bırak	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+3	ellerini	el	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	2	obj	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-2758
 # text = Kızakları geyiklere bağlayan deri kayışları gözden geçirdi Yura.
@@ -25747,17 +25725,16 @@
 
 # sent_id = mst-2848
 # text = Çocukluk yıllarınızı bu aptalca korku size zehir etti.
+# Change 2.2/dev: merge -CA
 1	Çocukluk	çocukluk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
-2	yıllarınızı	yıl	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=2	8	obj	_	_
-3	bu	bu	DET	Det	_	6	det	_	_
-4-5	aptalca	_	_	_	_	_	_	_	_
-4	aptal	aptal	ADJ	Adj	_	6	amod	_	_
-5	ca	ce	ADP	Ly	_	4	case	_	_
-6	korku	korku	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
-7	size	siz	PRON	Pers	Case=Dat|Number=Plur|Person=2|PronType=Prs	8	nmod	_	_
-8	zehir	zehir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-9	etti	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	8	compound:lvc	_	SpaceAfter=No
-10	.	.	PUNCT	Punc	_	8	punct	_	_
+2	yıllarınızı	yıl	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=2	7	obj	_	_
+3	bu	bu	DET	Det	_	5	det	_	_
+4	aptalca	aptalca	ADV	Adverb	_	5	advmod	_	_
+5	korku	korku	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
+6	size	siz	PRON	Pers	Case=Dat|Number=Plur|Person=2|PronType=Prs	7	nmod	_	_
+7	zehir	zehir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
+8	etti	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	7	compound:lvc	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-2849
 # text = Kardeşler zor günlerde birbirleriyle dayanışma içinde olurlar.
@@ -26584,15 +26561,14 @@
 
 # sent_id = mst-2949
 # text = Yüreğim delice çarpıyor, ellerim uyuştu.
-1	Yüreğim	yürek	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	4	nsubj	_	_
-2-3	delice	_	_	_	_	_	_	_	_
-2	deli	deli	ADJ	Adj	_	4	amod	_	_
-3	ce	ce	ADP	Ly	_	2	case	_	_
-4	çarpıyor	çarp	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
-5	,	,	PUNCT	Punc	_	7	punct	_	_
-6	ellerim	el	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=1	7	nsubj	_	_
-7	uyuştu	uyuş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	4	conj	_	SpaceAfter=No
-8	.	.	PUNCT	Punc	_	7	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Yüreğim	yürek	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	3	nsubj	_	_
+2	delice	delice	ADV	Adverb	_	3	advmod	_	_
+3	çarpıyor	çarp	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
+4	,	,	PUNCT	Punc	_	6	punct	_	_
+5	ellerim	el	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=1	6	nsubj	_	_
+6	uyuştu	uyuş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	conj	_	SpaceAfter=No
+7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-2951
 # text = İlhami büyük ama, biz iki kişi olunca onu döveriz.
@@ -26727,12 +26703,11 @@
 
 # sent_id = mst-2967
 # text = Delice bir arzu.
-1-2	Delice	_	_	_	_	_	_	_	_
-1	Deli	deli	ADJ	Adj	_	4	amod	_	_
-2	ce	ce	ADP	AsIf	_	1	case	_	_
-3	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
-4	arzu	arzu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	4	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Delice	Delice	ADV	Adverb	_	3	advmod	_	_
+2	bir	bir	NUM	ANum	NumType=Card	3	det	_	_
+3	arzu	arzu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-2968
 # text = Etrafı zaman zaman on metreye kadar yükselen ve bir sura dönüşen kayalarla çevrelenen bu ırmak, geyik sürülerinin dışarıdan gelebilecek saldırılara karşı kendilerini korudukları doğal bir sığınaktı.
@@ -27461,15 +27436,14 @@
 
 # sent_id = mst-3055
 # text = Arkamda oturan çocuk beni yavaşça dürttü.
+# Change 2.2/dev: merge -CA
 1	Arkamda	arka	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	amod	_	_
 2	oturan	otur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	acl	_	_
-3	çocuk	çocuk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
-4	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	7	obj	_	_
-5-6	yavaşça	_	_	_	_	_	_	_	_
-5	yavaş	yavaş	ADJ	Adj	_	7	amod	_	_
-6	ça	ce	ADP	Ly	_	5	case	_	_
-7	dürttü	dürt	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-8	.	.	PUNCT	Punc	_	7	punct	_	_
+3	çocuk	çocuk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
+4	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	6	obj	_	_
+5	yavaşça	yavaşça	ADV	Adverb	_	6	advmod	_	_
+6	dürttü	dürt	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3058
 # text = ..
@@ -27487,13 +27461,11 @@
 2	sır	sır	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
 3	verir	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	2	compound	_	_
 4	gibi	gibi	ADP	PCNom	_	2	case	_	_
-5-6	isteksizce	_	_	_	_	_	_	_	_
-5	isteksiz	isteksiz	ADJ	Adj	_	9	amod	_	_
-6	ce	ce	ADP	AsIf	_	5	case	_	_
-7	Üç	üç	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	9	obj	_	SpaceAfter=No
-8	,	,	PUNCT	Punc	_	9	punct	_	_
-9	demişti	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
-10	.	.	PUNCT	Punc	_	9	punct	_	_
+5	isteksizce	isteksizce	ADV	Adverb	_	8	advmod	_	_
+6	Üç	üç	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	8	obj	_	SpaceAfter=No
+7	,	,	PUNCT	Punc	_	8	punct	_	_
+8	demişti	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-3061
 # text = O, kendi açlığıyla oğlunu sevgiye boğduğunu bilmiyordu.
@@ -30159,37 +30131,36 @@
 
 # sent_id = mst-3344
 # text = Örneğin, annelerin bebek arabalarını rahatça sürecek genişlikte koridorlar olmaması 20'li 30'lu yaşlarındaki kadın müşteri kitlesinin bu mağazayı tercih etmemesine neden olacaktır.
+# Change 2.2/dev: merge -CA
 1	Örneğin	örneğin	CCONJ	Conj	_	0	root	_	SpaceAfter=No
-2	,	,	PUNCT	Punc	_	25	punct	_	_
-3	annelerin	anne	NOUN	Noun	Case=Gen|Number=Plur|Person=3	23	nsubj	_	_
+2	,	,	PUNCT	Punc	_	24	punct	_	_
+3	annelerin	anne	NOUN	Noun	Case=Gen|Number=Plur|Person=3	22	nsubj	_	_
 4	bebek	bebek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
-5	arabalarını	araba	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
-6-7	rahatça	_	_	_	_	_	_	_	_
-6	rahat	rahat	ADJ	Adj	_	8	amod	_	_
-7	ça	ce	ADP	Ly	_	6	case	_	_
-8	sürecek	sür	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	9	acl	_	_
-9	genişlikte	genişlik	NOUN	Noun	Case=Loc|Number=Sing|Person=3	10	nmod	_	_
-10	koridorlar	koridor	NOUN	Noun	Case=Nom|Number=Plur|Person=3	11	nsubj	_	_
-11	olmaması	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	25	nsubj	_	_
-12-13	20'li	_	_	_	_	_	_	_	_
-12	20	20	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	16	nummod	_	_
-13	'li	li	ADP	With	_	12	case	_	_
-14-15	30'lu	_	_	_	_	_	_	_	_
-14	30	30	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	12	flat	_	_
-15	'lu	li	ADP	With	_	14	case	_	_
-16-17	yaşlarındaki	_	_	_	_	_	_	_	_
-16	yaşlarında	yaş	ADJ	NAdj	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	18	amod	_	_
-17	ki	ki	ADP	Rel	_	16	case	_	_
-18	kadın	kadın	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	19	compound	_	_
-19	müşteri	müşteri	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nmod:poss	_	_
-20	kitlesinin	kitle	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	23	nmod	_	_
-21	bu	bu	DET	Det	_	22	det	_	_
-22	mağazayı	mağaza	NOUN	Noun	Case=Acc|Number=Sing|Person=3	23	nmod	_	_
-23	tercih	tercih	NOUN	Noun	Case=Nom|Number=Sing|Person=3	25	nmod	_	_
-24	etmemesine	et	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	23	compound:lvc	_	_
-25	neden	neden	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
-26	olacaktır	ol	VERB	Verb	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	25	compound:lvc	_	SpaceAfter=No
-27	.	.	PUNCT	Punc	_	25	punct	_	_
+5	arabalarını	araba	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	7	obj	_	_
+6	rahatça	rahatça	ADV	Adverb	_	7	advmod	_	_
+7	sürecek	sür	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	8	acl	_	_
+8	genişlikte	genişlik	NOUN	Noun	Case=Loc|Number=Sing|Person=3	9	nmod	_	_
+9	koridorlar	koridor	NOUN	Noun	Case=Nom|Number=Plur|Person=3	10	nsubj	_	_
+10	olmaması	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	24	nsubj	_	_
+11-12	20'li	_	_	_	_	_	_	_	_
+11	20	20	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	15	nummod	_	_
+12	'li	li	ADP	With	_	11	case	_	_
+13-14	30'lu	_	_	_	_	_	_	_	_
+13	30	30	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	11	flat	_	_
+14	'lu	li	ADP	With	_	13	case	_	_
+15-16	yaşlarındaki	_	_	_	_	_	_	_	_
+15	yaşlarında	yaş	ADJ	NAdj	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	17	amod	_	_
+16	ki	ki	ADP	Rel	_	15	case	_	_
+17	kadın	kadın	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	18	compound	_	_
+18	müşteri	müşteri	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	nmod:poss	_	_
+19	kitlesinin	kitle	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	22	nmod	_	_
+20	bu	bu	DET	Det	_	21	det	_	_
+21	mağazayı	mağaza	NOUN	Noun	Case=Acc|Number=Sing|Person=3	22	nmod	_	_
+22	tercih	tercih	NOUN	Noun	Case=Nom|Number=Sing|Person=3	24	nmod	_	_
+23	etmemesine	et	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	22	compound:lvc	_	_
+24	neden	neden	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
+25	olacaktır	ol	VERB	Verb	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	24	compound:lvc	_	SpaceAfter=No
+26	.	.	PUNCT	Punc	_	24	punct	_	_
 
 # sent_id = mst-3349
 # text = " Plan evlere dağıtılsın ".
@@ -31577,14 +31548,13 @@
 
 # sent_id = mst-3519
 # text = Fevzi yavaşça bana doğru eğildi.
-1	Fevzi	Fevzi	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
-2-3	yavaşça	_	_	_	_	_	_	_	_
-2	yavaş	yavaş	ADJ	Adj	_	6	amod	_	_
-3	ça	ce	ADP	Ly	_	2	case	_	_
-4	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	6	obl	_	_
-5	doğru	doğru	ADP	PCDat	_	4	case	_	_
-6	eğildi	eğ	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	6	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Fevzi	Fevzi	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
+2	yavaşça	yavaşça	ADV	Adverb	_	5	advmod	_	_
+3	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	5	obl	_	_
+4	doğru	doğru	ADP	PCDat	_	3	case	_	_
+5	eğildi	eğ	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
+6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-3521
 # text = Bu, dedikodu denen haz dünyasından ırak yaşayan bir püriten olsun, gidip zaman zaman ona içimizi dökelim.
@@ -35028,6 +34998,7 @@
 
 # sent_id = mst-3879
 # text = Orada, denizi gören yamaçlarda, ağaçların altına uzanıyor, piknik yapıyor, sonra da sonsuzca öpüşmelere başlıyorduk.
+# Change 2.2/dev: merge -CA
 1	Orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	9	obl	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	5	punct	_	_
 3	denizi	deniz	NOUN	Noun	Case=Acc|Number=Sing|Person=3	4	obj	_	_
@@ -35040,15 +35011,13 @@
 10	,	,	PUNCT	Punc	_	11	punct	_	_
 11	piknik	piknik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	conj	_	_
 12	yapıyor	yap	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	11	compound:lvc	_	SpaceAfter=No
-13	,	,	PUNCT	Punc	_	19	punct	_	_
-14	sonra	sonra	ADV	Adverb	_	19	advmod	_	_
+13	,	,	PUNCT	Punc	_	18	punct	_	_
+14	sonra	sonra	ADV	Adverb	_	18	advmod	_	_
 15	da	da	CCONJ	Conj	_	14	advmod:emph	_	_
-16-17	sonsuzca	_	_	_	_	_	_	_	_
-16	sonsuz	sonsuz	ADJ	Adj	_	18	amod	_	_
-17	ca	ce	ADP	AsIf	_	16	case	_	_
-18	öpüşmelere	öpüşme	NOUN	Noun	Case=Dat|Number=Plur|Person=3	19	obl	_	_
-19	başlıyorduk	başla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Polite=Infm|Tense=Past	9	conj	_	SpaceAfter=No
-20	.	.	PUNCT	Punc	_	19	punct	_	_
+16	sonsuzca	sonsuzca	ADV	Adverb	_	17	advmod	_	_
+17	öpüşmelere	öpüşme	NOUN	Noun	Case=Dat|Number=Plur|Person=3	18	obl	_	_
+18	başlıyorduk	başla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Polite=Infm|Tense=Past	9	conj	_	SpaceAfter=No
+19	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-3880
 # text = Dosya elimize geçtikten sonra ise olay aydınlanmaya başladı bizim açımızdan.
@@ -35652,16 +35621,15 @@
 
 # sent_id = mst-3949
 # text = Ceketinin kollarını hafifçe çekip ünlü cetvelini aldı.
+# Change 2.2/dev: merge -CA
 1	Ceketinin	ceket	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	nmod:poss	_	_
-2	kollarını	kol	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
-3-4	hafifçe	_	_	_	_	_	_	_	_
-3	hafif	hafif	ADJ	Adj	_	5	amod	_	_
-4	çe	ce	ADP	Ly	_	3	case	_	_
-5	çekip	çek	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	8	nmod	_	_
-6	ünlü	ünlü	ADJ	Adj	_	7	amod	_	_
-7	cetvelini	cetvel	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
-8	aldı	al	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-9	.	.	PUNCT	Punc	_	8	punct	_	_
+2	kollarını	kol	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
+3	hafifçe	hafifçe	ADV	Adverb	_	4	advmod	_	_
+4	çekip	çek	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	_
+5	ünlü	ünlü	ADJ	Adj	_	6	amod	_	_
+6	cetvelini	cetvel	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obj	_	_
+7	aldı	al	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-3950
 # text = Buralarda bekledim.
@@ -35742,13 +35710,12 @@
 
 # sent_id = mst-3960
 # text = Bütün gece rahatça izledim.
+# Change 2.2/dev: merge -CA
 1	Bütün	bütün	ADJ	Adj	_	2	amod	_	_
-2	gece	gece	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
-3-4	rahatça	_	_	_	_	_	_	_	_
-3	rahat	rahat	ADJ	Adj	_	5	amod	_	_
-4	ça	ce	ADP	Ly	_	3	case	_	_
-5	izledim	izle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	5	punct	_	_
+2	gece	gece	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obl	_	_
+3	rahatça	rahatça	ADV	Adverb	_	4	advmod	_	_
+4	izledim	izle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-3962
 # text = Sevgilinin ışıksız pencerelerine uzaktan bakarken kalbim böyle küt küt atmamıştı.
@@ -35989,32 +35956,31 @@
 
 # sent_id = mst-3996
 # text = Anne iyice sağlığına kavuşunca bir de ben gidip bu adamı göreyim diye düşünmüş ve kızın peşine takılıp şehrin ucundaki eve gitmiş.
-1	Anne	anne	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	nsubj	_	_
-2-3	iyice	_	_	_	_	_	_	_	_
-2	iyi	iyi	ADJ	Adj	_	5	amod	_	_
-3	ce	ce	ADP	Ly	_	2	case	_	_
-4	sağlığına	sağlık	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
-5	kavuşunca	kavuş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	14	nmod	_	_
-6	bir	bir	ADV	Adverb	_	9	advmod	_	_
-7	de	de	CCONJ	Conj	_	6	advmod:emph	_	_
-8	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	_	_
-9	gidip	git	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	12	nmod	_	_
-10	bu	bu	DET	Det	_	11	det	_	_
-11	adamı	adam	NOUN	Noun	Case=Acc|Number=Sing|Person=3	12	obj	_	_
-12	göreyim	gör	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	14	nmod	_	_
-13	diye	diye	ADP	PCNom	_	12	case	_	_
-14	düşünmüş	düşün	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
-15	ve	ve	CCONJ	Conj	_	23	cc	_	_
-16	kızın	kız	ADJ	NAdj	Case=Gen|Number=Sing|Person=3	17	nmod:poss	_	_
-17	peşine	peş	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	23	obl	_	_
-18	takılıp	takıl	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	17	compound	_	_
-19	şehrin	şehir	NOUN	Noun	Case=Gen|Number=Sing|Person=3	20	nmod:poss	_	_
-20-21	ucundaki	_	_	_	_	_	_	_	_
-20	ucunda	uç	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	22	nmod	_	_
-21	ki	ki	ADP	Rel	_	20	case	_	_
-22	eve	ev	NOUN	Noun	Case=Dat|Number=Sing|Person=3	23	obl	_	_
-23	gitmiş	git	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	14	conj	_	SpaceAfter=No
-24	.	.	PUNCT	Punc	_	23	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Anne	anne	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nsubj	_	_
+2	iyice	iyice	ADV	Adverb	_	4	advmod	_	_
+3	sağlığına	sağlık	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obl	_	_
+4	kavuşunca	kavuş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	13	nmod	_	_
+5	bir	bir	ADV	Adverb	_	8	advmod	_	_
+6	de	de	CCONJ	Conj	_	5	advmod:emph	_	_
+7	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	_	_
+8	gidip	git	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	11	nmod	_	_
+9	bu	bu	DET	Det	_	10	det	_	_
+10	adamı	adam	NOUN	Noun	Case=Acc|Number=Sing|Person=3	11	obj	_	_
+11	göreyim	gör	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	13	nmod	_	_
+12	diye	diye	ADP	PCNom	_	11	case	_	_
+13	düşünmüş	düşün	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+14	ve	ve	CCONJ	Conj	_	22	cc	_	_
+15	kızın	kız	ADJ	NAdj	Case=Gen|Number=Sing|Person=3	16	nmod:poss	_	_
+16	peşine	peş	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	22	obl	_	_
+17	takılıp	takıl	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	16	compound	_	_
+18	şehrin	şehir	NOUN	Noun	Case=Gen|Number=Sing|Person=3	19	nmod:poss	_	_
+19-20	ucundaki	_	_	_	_	_	_	_	_
+19	ucunda	uç	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	nmod	_	_
+20	ki	ki	ADP	Rel	_	19	case	_	_
+21	eve	ev	NOUN	Noun	Case=Dat|Number=Sing|Person=3	22	obl	_	_
+22	gitmiş	git	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	13	conj	_	SpaceAfter=No
+23	.	.	PUNCT	Punc	_	22	punct	_	_
 
 # sent_id = mst-3997
 # text = Aslında biz tarafız.
@@ -36630,21 +36596,19 @@
 
 # sent_id = mst-4071
 # text = Genelde bir erkeği mağazada ilgilendiği bölüme doğru sabırsızca hareket ederken görürsünüz.
+# Change 2.2/dev: merge -CA
 1	Genelde	genelde	ADV	Adverb	_	0	root	_	_
 2	bir	bir	NUM	ANum	NumType=Card	3	det	_	_
-3	erkeği	erkek	ADJ	NAdj	Case=Acc|Number=Sing|Person=3	13	obj	_	_
+3	erkeği	erkek	ADJ	NAdj	Case=Acc|Number=Sing|Person=2	11	obj	_	_
 4	mağazada	mağaza	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
 5	ilgilendiği	ilgilen	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	6	acl	_	_
-6	bölüme	bölüm	NOUN	Noun	Case=Dat|Number=Sing|Person=3	11	nmod	_	_
+6	bölüme	bölüm	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	nmod	_	_
 7	doğru	doğru	ADP	PCDat	_	6	case	_	_
-8-10	sabırsızca	_	_	_	_	_	_	_	_
-8	sabır	sabır	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nmod	_	_
-9	sız	siz	ADP	Without	_	8	case	_	_
-10	ca	ce	ADP	AsIf	_	8	case	_	_
-11	hareket	hareket	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obj	_	_
-12	ederken	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	11	compound:lvc	_	_
-13	görürsünüz	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
-14	.	.	PUNCT	Punc	_	13	punct	_	_
+8	sabırsızca	sabırsızca	ADV	Adverb	_	9	advmod	_	_
+9	hareket	hareket	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obj	_	_
+10	ederken	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	9	compound:lvc	_	_
+11	görürsünüz	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-4073
 # text = Siz, sonsuza dek yürüyeceksiniz.
@@ -38791,39 +38755,38 @@
 
 # sent_id = mst-4314
 # text = entelektüel yetilerde uzunca bir süre bozulma görülmeyeceğinden bağımlı kişilerde temelde yatan kişilik bozukluğuyla da beslenmiş, parlak bir zeka ve yalancı bir filozofluk çok belirgin bir ortak özelliktir.
+# Change 2.2/dev: merge -CA
 1	entelektüel	entelektüel	ADJ	Adj	_	2	amod	_	_
-2	yetilerde	yeti	NOUN	Noun	Case=Loc|Number=Plur|Person=3	8	obl	_	_
-3-4	uzunca	_	_	_	_	_	_	_	_
-3	uzun	uzun	ADJ	Adj	_	6	amod	_	_
-4	ca	ce	ADP	Ly	_	3	case	_	_
-5	bir	bir	NUM	ANum	NumType=Card	6	det	_	_
-6	süre	süre	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
-7	bozulma	boz	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	8	nsubj	_	_
-8	görülmeyeceğinden	gör	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Fut|VerbForm=Part|Voice=Pass	29	acl	_	_
-9	bağımlı	bağımlı	ADJ	Adj	_	10	amod	_	_
-10	kişilerde	kişi	NOUN	Noun	Case=Loc|Number=Plur|Person=3	16	obl	_	_
-11	temelde	temel	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	12	amod	_	_
-12	yatan	yat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	14	acl	_	_
-13	kişilik	kişilik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	nmod:poss	_	_
-14	bozukluğuyla	bozukluk	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obl	_	_
-15	da	da	CCONJ	Conj	_	14	advmod:emph	_	_
-16	beslenmiş	besle	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	20	acl	_	SpaceAfter=No
-17	,	,	PUNCT	Punc	_	16	punct	_	_
-18	parlak	parlak	ADJ	Adj	_	20	amod	_	_
-19	bir	bir	NUM	ANum	NumType=Card	20	det	_	_
-20	zeka	zeka	NOUN	Noun	Case=Nom|Number=Sing|Person=3	29	nsubj	_	_
-21	ve	ve	CCONJ	Conj	_	24	cc	_	_
-22	yalancı	yalancı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	24	nmod	_	_
-23	bir	bir	NUM	ANum	NumType=Card	24	det	_	_
-24	filozofluk	filozofluk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	conj	_	_
-25	çok	çok	ADJ	Adj	_	26	det	_	_
-26	belirgin	belirgin	ADJ	Adj	_	29	amod	_	_
-27	bir	bir	NUM	ANum	NumType=Card	29	det	_	_
-28	ortak	ortak	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	29	amod	_	_
-29-30	özelliktir	_	_	_	_	_	_	_	SpaceAfter=No
-29	özellik	özellik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-30	tir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	29	cop	_	_
-31	.	.	PUNCT	Punc	_	29	punct	_	_
+2	yetilerde	yeti	NOUN	Noun	Case=Loc|Number=Plur|Person=3	7	obl	_	_
+3	uzunca	uzunca	ADV	Adverb	_	5	advmod	_	_
+4	bir	bir	NUM	ANum	NumType=Card	5	det	_	_
+5	süre	süre	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
+6	bozulma	boz	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	7	nsubj	_	_
+7	görülmeyeceğinden	gör	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Fut|VerbForm=Part|Voice=Pass	28	acl	_	_
+8	bağımlı	bağımlı	ADJ	Adj	_	9	amod	_	_
+9	kişilerde	kişi	NOUN	Noun	Case=Loc|Number=Plur|Person=3	15	obl	_	_
+10	temelde	temel	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	11	amod	_	_
+11	yatan	yat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	13	acl	_	_
+12	kişilik	kişilik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nmod:poss	_	_
+13	bozukluğuyla	bozukluk	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obl	_	_
+14	da	da	CCONJ	Conj	_	13	advmod:emph	_	_
+15	beslenmiş	besle	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	19	acl	_	SpaceAfter=No
+16	,	,	PUNCT	Punc	_	15	punct	_	_
+17	parlak	parlak	ADJ	Adj	_	19	amod	_	_
+18	bir	bir	NUM	ANum	NumType=Card	19	det	_	_
+19	zeka	zeka	NOUN	Noun	Case=Nom|Number=Sing|Person=3	28	nsubj	_	_
+20	ve	ve	CCONJ	Conj	_	23	cc	_	_
+21	yalancı	yalancı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	nmod	_	_
+22	bir	bir	NUM	ANum	NumType=Card	23	det	_	_
+23	filozofluk	filozofluk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	conj	_	_
+24	çok	çok	ADJ	Adj	_	25	det	_	_
+25	belirgin	belirgin	ADJ	Adj	_	28	amod	_	_
+26	bir	bir	NUM	ANum	NumType=Card	28	det	_	_
+27	ortak	ortak	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	28	amod	_	_
+28-29	özelliktir	_	_	_	_	_	_	_	SpaceAfter=No
+28	özellik	özellik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
+29	tir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	28	cop	_	_
+30	.	.	PUNCT	Punc	_	28	punct	_	_
 
 # sent_id = mst-4316
 # text = Çözüm anahtarı değil.
@@ -40845,29 +40808,26 @@
 
 # sent_id = mst-4540
 # text = Heyecandan ara sıra nazikçe boğazlar temizlenir, dudakların üzerlerinde biriken ter damlacıkları rujların dağılmamasına özen gösterilerek hafifçe siliniverir.
-1	Heyecandan	heyecan	NOUN	Noun	Case=Abl|Number=Sing|Person=3	7	obl	_	_
-2	ara	ara	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	7	amod	_	_
+# Change 2.2/dev: merge -CA
+1	Heyecandan	heyecan	NOUN	Noun	Case=Abl|Number=Sing|Person=3	6	obl	_	_
+2	ara	ara	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	6	amod	_	_
 3	sıra	sıra	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound:redup	_	_
-4-5	nazikçe	_	_	_	_	_	_	_	_
-4	nazik	nazik	ADJ	Adj	_	7	amod	_	_
-5	çe	ce	ADP	Ly	_	4	case	_	_
-6	boğazlar	boğaz	NOUN	Noun	Case=Nom|Number=Plur|Person=3	7	nsubj	_	_
-7	temizlenir	temizle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
-8	,	,	PUNCT	Punc	_	7	punct	_	_
-9	dudakların	dudak	NOUN	Noun	Case=Gen|Number=Plur|Person=3	10	nmod:poss	_	_
-10	üzerlerinde	üzer	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	11	obl	_	_
-11	biriken	birik	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	13	acl	_	_
-12	ter	ter	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nmod:poss	_	_
-13	damlacıkları	damlacık	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	20	nsubj	_	_
-14	rujların	ruj	NOUN	Noun	Case=Gen|Number=Plur|Person=3	15	nsubj	_	_
-15	dağılmamasına	dağıl	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	16	nmod	_	_
-16	özen	özen	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	obl	_	_
-17	gösterilerek	göster	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	16	compound	_	_
-18-19	hafifçe	_	_	_	_	_	_	_	_
-18	hafif	hafif	ADJ	Adj	_	20	amod	_	_
-19	çe	ce	ADP	Ly	_	18	case	_	_
-20	siliniverir	sil	VERB	Verb	Aspect=Rapid|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	7	conj	_	SpaceAfter=No
-21	.	.	PUNCT	Punc	_	20	punct	_	_
+4	nazikçe	nazikçe	ADV	Adverb	_	6	advmod	_	_
+5	boğazlar	boğaz	NOUN	Noun	Case=Nom|Number=Plur|Person=3	6	nsubj	_	_
+6	temizlenir	temizle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+7	,	,	PUNCT	Punc	_	6	punct	_	_
+8	dudakların	dudak	NOUN	Noun	Case=Gen|Number=Plur|Person=3	9	nmod:poss	_	_
+9	üzerlerinde	üzer	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	10	obl	_	_
+10	biriken	birik	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	12	acl	_	_
+11	ter	ter	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nmod:poss	_	_
+12	damlacıkları	damlacık	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	18	nsubj	_	_
+13	rujların	ruj	NOUN	Noun	Case=Gen|Number=Plur|Person=3	14	nsubj	_	_
+14	dağılmamasına	dağıl	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	15	nmod	_	_
+15	özen	özen	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	obl	_	_
+16	gösterilerek	göster	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	15	compound	_	_
+17	hafifçe	hafifçe	ADV	Adverb	_	18	advmod	_	_
+18	siliniverir	sil	VERB	Verb	Aspect=Rapid|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	6	conj	_	SpaceAfter=No
+19	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-4543
 # text = Uluslararası onyedi. ekononomik Bilim Yarışması'nda dereceye giren öğrencilere ödüllerini veren Mumcu, daha sonra soruları yanıtladı.
@@ -44167,13 +44127,11 @@
 
 # sent_id = mst-4929
 # text = Götürdü tepsiyi sessizce.
+# Change 2.2/dev: merge -CA
 1	Götürdü	götür	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 2	tepsiyi	tepsi	NOUN	Noun	Case=Acc|Number=Sing|Person=3	1	obj	_	_
-3-5	sessizce	_	_	_	_	_	_	_	SpaceAfter=No
-3	ses	ses	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	obl	_	_
-4	siz	siz	ADP	Without	_	3	case	_	_
-5	ce	ce	ADP	Ly	_	3	case	_	_
-6	.	.	PUNCT	Punc	_	1	punct	_	_
+3	sessizce	sessizce	ADV	Adverb	_	1	advmod	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-4931
 # text = Gerçekten de oydu.
@@ -44383,13 +44341,14 @@
 
 # sent_id = mst-4954
 # text = Poynter direktörü Bob Steele, " Bence ' biz intihar haberi hiç vermiyoruz ' düşüncesi de açıkça sorgulanmalı " diyor.
+# Change 2.2/dev: merge -CA
 1	Poynter	Poynter	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	direktörü	direktör	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	nmod	_	_
-3	Bob	Bob	PROPN	Prop	Case=Nom|Number=Sing|Person=3	21	nsubj	_	_
+3	Bob	Bob	PROPN	Prop	Case=Nom|Number=Sing|Person=3	20	nsubj	_	_
 4	Steele	Steele	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	flat	_	SpaceAfter=No
-5	,	,	PUNCT	Punc	_	21	punct	_	_
-6	"	"	PUNCT	Punc	_	19	punct	_	_
-7	Bence	ben	PRON	Pers	Case=Equ|Number=Sing|Person=1|PronType=Prs	19	obl	_	_
+5	,	,	PUNCT	Punc	_	20	punct	_	_
+6	"	"	PUNCT	Punc	_	18	punct	_	_
+7	Bence	ben	PRON	Pers	Case=Equ|Number=Sing|Person=1|PronType=Prs	18	obl	_	_
 8	'	'	PUNCT	Punc	_	13	punct	_	_
 9	biz	biz	PRON	Pers	Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	_	_
 10	intihar	intihar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nmod:poss	_	_
@@ -44397,15 +44356,13 @@
 12	hiç	hiç	ADV	Adverb	_	13	advmod	_	_
 13	vermiyoruz	ver	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=1|Polarity=Neg|Polite=Infm|Tense=Pres	15	nmod:poss	_	_
 14	'	'	PUNCT	Punc	_	13	punct	_	_
-15	düşüncesi	düşünce	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	nsubj	_	_
+15	düşüncesi	düşünce	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	nsubj	_	_
 16	de	de	CCONJ	Conj	_	15	advmod:emph	_	_
-17-18	açıkça	_	_	_	_	_	_	_	_
-17	açık	açık	ADJ	Adj	_	19	amod	_	_
-18	ça	ce	ADP	Ly	_	17	case	_	_
-19	sorgulanmalı	sorgula	VERB	Verb	Aspect=Perf|Mood=Nec|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	21	obj	_	_
-20	"	"	PUNCT	Punc	_	19	punct	_	_
-21	diyor	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
-22	.	.	PUNCT	Punc	_	21	punct	_	_
+17	açıkça	açıkça	ADV	Adverb	_	18	advmod	_	_
+18	sorgulanmalı	sorgula	VERB	Verb	Aspect=Perf|Mood=Nec|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	20	obj	_	_
+19	"	"	PUNCT	Punc	_	18	punct	_	_
+20	diyor	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
+21	.	.	PUNCT	Punc	_	20	punct	_	_
 
 # sent_id = mst-4957
 # text = İtalya'da Salata olmuş.
@@ -45210,16 +45167,15 @@
 
 # sent_id = mst-5050
 # text = Kerem çayına iki şeker atıp yavaşça karıştırdı.
-1	Kerem	Kerem	PROPN	Prop	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
+# Change 2.2/dev: merge -CA
+1	Kerem	Kerem	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
 2	çayına	çay	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 3	iki	iki	NUM	ANum	NumType=Card	4	nummod	_	_
 4	şeker	şeker	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
-5	atıp	at	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	8	nmod	_	_
-6-7	yavaşça	_	_	_	_	_	_	_	_
-6	yavaş	yavaş	ADJ	Adj	_	8	amod	_	_
-7	ça	ce	ADP	Ly	_	6	case	_	_
-8	karıştırdı	karış	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
-9	.	.	PUNCT	Punc	_	8	punct	_	_
+5	atıp	at	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	_
+6	yavaşça	yavaşça	ADV	Adverb	_	7	advmod	_	_
+7	karıştırdı	karış	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	0	root	_	SpaceAfter=No
+8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-5052
 # text = Dişe değmek sözü tüm mezeler için geçerlidir.
@@ -45398,13 +45354,12 @@
 
 # sent_id = mst-5073
 # text = Kıpırdamadan, öylece duruyordu.
-1	Kıpırdamadan	kıpırda	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	5	nmod	_	SpaceAfter=No
+# Change 2.2/dev: merge -CA
+1	Kıpırdamadan	kıpırda	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	4	nmod	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	1	punct	_	_
-3-4	öylece	_	_	_	_	_	_	_	_
-3	öyle	öyle	ADJ	Adj	_	5	amod	_	_
-4	ce	ce	ADP	Ly	_	3	case	_	_
-5	duruyordu	dur	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	5	punct	_	_
+3	öylece	öylece	ADV	Adverb	_	4	advmod	_	_
+4	duruyordu	dur	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
+5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-5075
 # text = Keşkeymiş.
@@ -47867,20 +47822,19 @@
 
 # sent_id = mst-5380
 # text = İyice hastaydı, diyor, karnı davul gibi şişmişti.
-1-2	İyice	_	_	_	_	_	_	_	_
-1	İyi	iyi	ADJ	Adj	_	3	amod	_	_
-2	ce	ce	ADP	Ly	_	1	case	_	_
-3-4	hastaydı	_	_	_	_	_	_	_	SpaceAfter=No
-3	hasta	has	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	6	ccomp	_	_
-4	ydı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	3	cop	_	_
-5	,	,	PUNCT	Punc	_	6	punct	_	_
-6	diyor	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
-7	,	,	PUNCT	Punc	_	11	punct	_	_
-8	karnı	karın	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	nsubj	_	_
-9	davul	davul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obl	_	_
-10	gibi	gibi	ADP	PCNom	_	9	case	_	_
-11	şişmişti	şiş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	6	conj	_	SpaceAfter=No
-12	.	.	PUNCT	Punc	_	11	punct	_	_
+# Change 2.2/dev: merge -CA
+1	İyice	iyice	ADV	Adverb	_	2	advmod	_	_
+2-3	hastaydı	_	_	_	_	_	_	_	SpaceAfter=No
+2	hasta	has	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	5	ccomp	_	_
+3	ydı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	2	cop	_	_
+4	,	,	PUNCT	Punc	_	5	punct	_	_
+5	diyor	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
+6	,	,	PUNCT	Punc	_	10	punct	_	_
+7	karnı	karın	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nsubj	_	_
+8	davul	davul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obl	_	_
+9	gibi	gibi	ADP	PCNom	_	8	case	_	_
+10	şişmişti	şiş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	5	conj	_	SpaceAfter=No
+11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-5382
 # text = Uçları yukarı kıvrık sipsivri bıyıkları vardı babasının.
@@ -48520,27 +48474,27 @@
 
 # sent_id = mst-5440
 # text = Sonra, gözlüksüz olduğunu da iyice anımsıyorum.
-1	Sonra	sonra	ADV	Adverb	_	9	advmod	_	SpaceAfter=No
-2	,	,	PUNCT	Punc	_	9	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Sonra	sonra	ADV	Adverb	_	8	advmod	_	SpaceAfter=No
+2	,	,	PUNCT	Punc	_	8	punct	_	_
 3-4	gözlüksüz	_	_	_	_	_	_	_	_
 3	gözlük	gözlük	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
 4	süz	siz	ADP	Without	_	3	case	_	_
-5	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	9	obj	_	_
+5	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	8	obj	_	_
 6	da	da	CCONJ	Conj	_	5	advmod:emph	_	_
-7-8	iyice	_	_	_	_	_	_	_	_
-7	iyi	iyi	ADJ	Adj	_	9	amod	_	_
-8	ce	ce	ADP	Ly	_	7	case	_	_
-9	anımsıyorum	anımsa	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
-10	.	.	PUNCT	Punc	_	9	punct	_	_
+7	iyice	iyice	ADV	Adverb	_	8	advmod	_	_
+8	anımsıyorum	anımsa	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-5441
 # text = Nedenini anlayamadığım bu terk edilme korkusu ve kendime itiraf etmekten bile utandığım hırpalayıcı kıskançlığımla, aptalca olduğunu bile bile daha çok kadınla birlikte oluyor ve sonunda korktuğuma uğrayıp bir başka erkek için terk ediliyordum.
+# Change 2.2/dev: merge -CA
 1	Nedenini	neden	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	obj	_	_
 2	anlayamadığım	anla	VERB	Verb	Aspect=Perf|Mood=Pot|Number[psor]=Sing|Person[psor]=1|Polarity=Neg|Tense=Past|VerbForm=Part	6	acl	_	_
 3	bu	bu	DET	Det	_	6	det	_	_
 4	terk	terk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 5	edilme	et	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	4	compound:lvc	_	_
-6	korkusu	korku	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	25	obl	_	_
+6	korkusu	korku	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	24	obl	_	_
 7	ve	ve	CCONJ	Conj	_	15	cc	_	_
 8	kendime	kendi	PRON	Reflex	Case=Dat|Number=Sing|Number[psor]=Sing|Person=1|Person[psor]=1|Reflex=Yes	9	nmod	_	_
 9	itiraf	itiraf	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
@@ -48552,28 +48506,26 @@
 14	yıcı	ci	ADP	Agt	_	13	case	_	_
 15	kıskançlığımla	kıskançlık	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	6	conj	_	SpaceAfter=No
 16	,	,	PUNCT	Punc	_	15	punct	_	_
-17-18	aptalca	_	_	_	_	_	_	_	_
-17	aptal	aptal	ADJ	Adj	_	19	amod	_	_
-18	ca	ce	ADP	AsIf	_	17	case	_	_
-19	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	20	obj	_	_
-20	bile	bile	ADV	Adverb	_	25	advmod	_	_
-21	bile	bil	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	20	compound:redup	_	_
-22	daha	daha	ADV	Adverb	_	23	advmod	_	_
-23	çok	çok	ADJ	Adj	_	24	det	_	_
-24	kadınla	kadın	ADJ	NAdj	Case=Ins|Number=Sing|Person=3	25	amod	_	_
-25	birlikte	birlikte	ADV	Adverb	_	0	root	_	_
-26	oluyor	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	25	compound:lvc	_	_
-27	ve	ve	CCONJ	Conj	_	35	cc	_	_
-28	sonunda	sonunda	ADV	Adverb	_	35	advmod	_	_
-29	korktuğuma	kork	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	30	acl	_	_
-30	uğrayıp	uğra	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	35	nmod	_	_
-31	bir	bir	NUM	ANum	NumType=Card	33	det	_	_
-32	başka	başka	ADJ	Adj	_	33	amod	_	_
-33	erkek	erkek	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	35	amod	_	_
-34	için	için	ADP	PCNom	_	33	case	_	_
-35	terk	terk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	25	conj	_	_
-36	ediliyordum	et	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Pass	25	conj	_	SpaceAfter=No
-37	.	.	PUNCT	Punc	_	35	punct	_	_
+17	aptalca	aptalca	ADV	Adverb	_	18	advmod	_	_
+18	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	19	obj	_	_
+19	bile	bile	ADV	Adverb	_	24	advmod	_	_
+20	bile	bil	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	19	compound:redup	_	_
+21	daha	daha	ADV	Adverb	_	22	advmod	_	_
+22	çok	çok	ADJ	Adj	_	23	det	_	_
+23	kadınla	kadın	ADJ	NAdj	Case=Ins|Number=Sing|Person=3	24	amod	_	_
+24	birlikte	birlikte	ADV	Adverb	_	0	root	_	_
+25	oluyor	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	24	compound:lvc	_	_
+26	ve	ve	CCONJ	Conj	_	34	cc	_	_
+27	sonunda	sonunda	ADV	Adverb	_	34	advmod	_	_
+28	korktuğuma	kork	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	29	acl	_	_
+29	uğrayıp	uğra	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	34	nmod	_	_
+30	bir	bir	NUM	ANum	NumType=Card	32	det	_	_
+31	başka	başka	ADJ	Adj	_	32	amod	_	_
+32	erkek	erkek	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	34	amod	_	_
+33	için	için	ADP	PCNom	_	32	case	_	_
+34	terk	terk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	24	conj	_	_
+35	ediliyordum	et	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Pass	24	conj	_	SpaceAfter=No
+36	.	.	PUNCT	Punc	_	34	punct	_	_
 
 # sent_id = mst-5444
 # text = Hayatın böyle ya da başka türlü olmasını ne ya da kim sağlıyor, bu iyi mi kötü mü.
@@ -48945,12 +48897,11 @@
 
 # sent_id = mst-5486
 # text = Kapı hafifçe aralandı.
-1	Kapı	kapı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
-2-3	hafifçe	_	_	_	_	_	_	_	_
-2	hafif	hafif	ADJ	Adj	_	4	amod	_	_
-3	çe	ce	ADP	Ly	_	2	case	_	_
-4	aralandı	arala	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	4	punct	_	_
+# Change 2.2/dev: merge -CA
+1	Kapı	kapı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
+2	hafifçe	hafifçe	ADV	Adverb	_	3	advmod	_	_
+3	aralandı	arala	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-5489
 # text = Yağma yok diye diklendi Memo, hepiniz havanızı alırsınız.

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -2738,6 +2738,7 @@
 
 # sent_id = mst-0320
 # text = Bir yandan da Kahve'nin günde kaç öğün yemek yiyeceğini, hangi vitaminleri alacağını, muhallebisinin şekersiz olması gerektiğini yoksa gözlerinin bozulacağını, aşılarının tarihini anlatıp duruyordu.
+# Change 2.2/dev: mark 'hangi' as DET
 1	Bir	bir	NUM	ANum	NumType=Card	27	nummod	_	_
 2	yandan	yan	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	1	compound	_	_
 3	da	da	CCONJ	Conj	_	1	advmod:emph	_	_
@@ -2748,7 +2749,7 @@
 8	yemek	yemek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	27	obj	_	_
 9	yiyeceğini	yiyecek	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	compound	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	13	punct	_	_
-11	hangi	hangi	ADJ	Adj	_	12	det	_	_
+11	hangi	hangi	DET	Adj	_	12	det	_	_
 12	vitaminleri	vitamin	NOUN	Noun	Case=Acc|Number=Plur|Person=3	13	obj	_	_
 13	alacağını	al	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	8	conj	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	19	punct	_	_
@@ -3824,8 +3825,9 @@
 
 # sent_id = mst-0431
 # text = Gecenin hangi saatinde eve dönsem de, yakındaki açık gece mağazasından yiyecek birşeyler alabilirdim.
+# Change 2.2/dev: mark 'hangi' as DET
 1	Gecenin	gece	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
-2	hangi	hangi	ADJ	Adj	_	3	amod	_	_
+2	hangi	hangi	DET	Adj	_	3	det	_	_
 3	saatinde	saat	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 4	eve	ev	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
 5	dönsem	dön	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
@@ -5505,6 +5507,7 @@
 
 # sent_id = mst-0627
 # text = Tüketici kredisinin yabancı para birimi cinsinden kullanılması durumunda, geri ödemeye ilişkin taksitlerin ve toplam kredi tutarının hesaplanmasında, hangi tarihteki kurun dikkate alınacağına ilişkin bilginin sözleşmede yer alması koşulu getiriliyor.
+# Change 2.2/dev: mark 'hangi' as DET
 1	Tüketici	tüketici	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod:poss	_	_
 2	kredisinin	kredi	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	compound	_	_
 3	yabancı	yabancı	ADJ	Adj	_	5	amod	_	_
@@ -5524,7 +5527,7 @@
 17	tutarının	tutar	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	conj	_	_
 18	hesaplanmasında	hesapla	VERB	Verb	Aspect=Perf|Case=Loc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	32	nmod	_	SpaceAfter=No
 19	,	,	PUNCT	Punc	_	18	punct	_	_
-20	hangi	hangi	ADJ	Adj	_	21	amod	_	_
+20	hangi	hangi	DET	Adj	_	21	det	_	_
 21-22	tarihteki	_	_	_	_	_	_	_	_
 21	tarihte	tarih	NOUN	Noun	Case=Loc|Number=Sing|Person=3	23	nmod	_	_
 22	ki	ki	ADP	Rel	_	21	case	_	_
@@ -9734,7 +9737,8 @@
 
 # sent_id = mst-1080
 # text = Hangisini sen kazandın ki? deyip dik dik bakmıştı yüzüme.
-1	Hangisini	hangi	PRON	Ques	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
+# Change 2.2/dev: mark 'hangi' as DET
+1	Hangisini	hangi	DET	Ques	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
 2	sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
 3	kazandın	kazan	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Past	0	root	_	_
 4	ki	ki	CCONJ	Conj	_	3	advmod:emph	_	SpaceAfter=No
@@ -11035,7 +11039,8 @@
 
 # sent_id = mst-1234
 # text = Hangi fasulye.
-1	Hangi	hangi	ADJ	Adj	_	2	amod	_	_
+# Change 2.2/dev: mark 'hangi' as DET
+1	Hangi	hangi	DET	Adj	_	2	det	_	_
 2	fasulye	fasulye	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -11480,7 +11485,8 @@
 
 # sent_id = mst-1282
 # text = Hangi aday kazanırsa kazansın birlikte mücadeleyi sürdüreceklerini ifade eden Çelebi, ANAP'ı ayağa kaldırmak için hep birlikte çaba harcayacaklarını söyledi.
-1	Hangi	hangi	ADJ	Adj	_	2	det	_	_
+# Change 2.2/dev: mark 'hangi' as DET
+1	Hangi	hangi	DET	Adj	_	2	det	_	_
 2	aday	aday	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 3	kazanırsa	kazan	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	8	obj	_	_
 4	kazansın	kazan	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	compound	_	_
@@ -14081,7 +14087,8 @@
 
 # sent_id = mst-1573
 # text = Hangi özür, onların haklılığını değiştirebilir ki!..
-1	Hangi	hangi	ADJ	Adj	_	2	amod	_	_
+# Change 2.2/dev: mark 'hangi' as DET
+1	Hangi	hangi	DET	Adj	_	2	det	_	_
 2	özür	özür	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	6	punct	_	_
 4	onların	on	NUM	NNum	Case=Nom|Number=Plur|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=2	5	nmod:poss	_	_
@@ -21807,10 +21814,11 @@
 
 # sent_id = mst-2427
 # text = -En çok hangisini seviyorsun.
+# Change 2.2/dev: mark 'hangi' as DET
 1	-	-	PUNCT	Punc	_	0	root	_	SpaceAfter=No
 2	En	en	ADV	Adverb	_	3	advmod	_	_
 3	çok	çok	ADV	Adverb	_	5	advmod	_	_
-4	hangisini	hangi	PRON	Ques	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
+4	hangisini	hangi	DET	Ques	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
 5	seviyorsun	sev	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
@@ -22423,7 +22431,8 @@
 
 # sent_id = mst-2502
 # text = Hangi okuldansınız.
-1	Hangi	hangi	ADJ	Adj	_	2	amod	_	_
+# Change 2.2/dev: mark 'hangi' as DET
+1	Hangi	hangi	DET	Adj	_	2	det	_	_
 2-3	okuldansınız	_	_	_	_	_	_	_	SpaceAfter=No
 2	okuldan	okul	NOUN	Noun	Case=Abl|Number=Sing|Person=3	0	root	_	_
 3	sınız	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	2	cop	_	_
@@ -37040,9 +37049,10 @@
 
 # sent_id = mst-4138
 # text = Meral acaba hangi odadaydılar?
+# Change 2.2/dev: mark 'hangi' as DET
 1	Meral	Meral	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	_
 2	acaba	acaba	ADV	Adverb	_	1	conj	_	_
-3	hangi	hangi	ADJ	Adj	_	4	amod	_	_
+3	hangi	hangi	DET	Adj	_	4	det	_	_
 4-5	odadaydılar	_	_	_	_	_	_	_	SpaceAfter=No
 4	odada	oda	NOUN	Noun	Case=Loc|Number=Sing|Person=3	1	conj	_	_
 5	ydılar	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Tense=Past	4	cop	_	_

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -3553,6 +3553,7 @@
 
 # sent_id = mst-0401
 # text = Hiç anlamasalar da, hiç bilmeseler de, hiç ilgilenmeseler de, neden, kadınlar bütün erkeklerin iş hayatlarını pürdikkat dinlerler.
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Hiç	hiç	ADV	Adverb	_	2	advmod	_	_
 2	anlamasalar	anla	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	21	nmod	_	_
 3	da	da	CCONJ	Conj	_	2	advmod:emph	_	SpaceAfter=No
@@ -3565,7 +3566,7 @@
 10	ilgilenmeseler	ilgilen	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	2	conj	_	_
 11	de	de	CCONJ	Conj	_	10	advmod:emph	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	10	punct	_	_
-13	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	21	obl	_	SpaceAfter=No
+13	neden	neden	ADV	Ques	_	21	advmod	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	21	punct	_	_
 15	kadınlar	kadın	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	21	nsubj	_	_
 16	bütün	bütün	ADJ	Adj	_	17	amod	_	_
@@ -19882,9 +19883,11 @@
 
 # sent_id = mst-2197
 # text = Neden sonra Katana ağaçtan süzülüp indi.
-1	Neden	neden	ADV	Adverb	_	2	advmod	_	_
-2	sonra	sonra	ADV	Adverb	_	6	advmod	_	_
-3	Katana	katana	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
+# Change 2.2/dev: fix proper name Katana.
+# Change 2.2/dev: revise POS tag of 'neden'
+1	Neden	ne	PRON	Adverb	Case=Abl|Number=Sing|Person=3	6	obl	_	_
+2	sonra	sonra	ADP	Adverb	_	1	case	_	_
+3	Katana	Katana	PROPN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
 4	ağaçtan	ağaç	NOUN	Noun	Case=Abl|Number=Sing|Person=3	6	obl	_	_
 5	süzülüp	süzül	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
 6	indi	in	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -20095,6 +20098,7 @@
 
 # sent_id = mst-2216
 # text = Perakendecilikte araştırmaları ve metodoljik çalışmalarıyla tanınan Underhill, dünyada " Why We Buy: The Science of Shopping " (Neden satın Alıyoruz: Alışveriş Bilimi) adlı kitabıyla tanındı.
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Perakendecilikte	perakendecilik	NOUN	Noun	Case=Loc|Number=Sing|Person=3	2	obl	_	_
 2	araştırmaları	araştır	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	nmod	_	_
 3	ve	ve	CCONJ	Conj	_	5	cc	_	_
@@ -20115,7 +20119,7 @@
 18	Shopping	Shopping	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	compound	_	_
 19	"	"	PUNCT	Punc	_	11	punct	_	_
 20	(	(	PUNCT	Punc	_	26	punct	_	SpaceAfter=No
-21	Neden	neden	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	det	_	_
+21	Neden	neden	ADV	Noun	_	22	advmod	_	_
 22	satın	satın	ADV	Adverb	_	26	advmod	_	_
 23	Alıyoruz	al	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	22	compound	_	SpaceAfter=No
 24	:	:	PUNCT	Punc	_	31	punct	_	_
@@ -22708,12 +22712,13 @@
 
 # sent_id = mst-2536
 # text = Annenin veya babanın hemen evleneceğini neden aklına getiriyorsun?
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Annenin	anne	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	5	obl	_	_
 2	veya	veya	CCONJ	Conj	_	3	cc	_	_
 3	babanın	baba	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	1	conj	_	_
 4	hemen	hemen	ADV	Adverb	_	5	advmod	_	_
 5	evleneceğini	evlen	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	7	obj	_	_
-6	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	7	nmod	_	_
+6	neden	ne	ADV	Ques	_	7	advmod	_	_
 7	aklına	akıl	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 8	getiriyorsun	getir	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Polite=Infm|Tense=Pres	7	compound	_	SpaceAfter=No
 9	?	?	PUNCT	Punc	_	7	punct	_	_
@@ -32842,10 +32847,11 @@
 
 # sent_id = mst-3668
 # text = Ama bu düşünceleri neden buraya aktardığım, elbette merak edilecektir...
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Ama	ama	CCONJ	Conj	_	0	root	_	_
 2	bu	bu	DET	Det	_	3	det	_	_
 3	düşünceleri	düşünce	NOUN	Noun	Case=Acc|Number=Plur|Person=3	6	obj	_	_
-4	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	5	nmod	_	_
+4	neden	neden	ADV	Ques	_	6	advmod	_	_
 5	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
 6	aktardığım	aktar	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	9	obj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
@@ -37878,6 +37884,7 @@
 
 # sent_id = mst-4237
 # text = Patlıcan burunlu var da, neden patlıcan kulaklı yok?
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Patlıcan	patlıcan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod	_	_
 2-3	burunlu	_	_	_	_	_	_	_	_
 2	burun	burun	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
@@ -37885,7 +37892,7 @@
 4	var	var	ADJ	Adj	_	5	amod	_	_
 5	da	da	CCONJ	Conj	_	7	nmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	10	punct	_	_
-7	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	10	obl	_	_
+7	neden	neden	ADV	Ques	_	10	advmod	_	_
 8	patlıcan	patlıcan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
 9	kulaklı	kulaklı	ADJ	Adj	_	10	nsubj	_	_
 10	yok	yok	ADJ	Adj	_	0	root	_	SpaceAfter=No
@@ -43414,13 +43421,14 @@
 
 # sent_id = mst-4852
 # text = Kardeşini eleştiriyor gibi geldi bana, neden sokulgan onca?
+# Change 2.2/dev: revise POS tag of 'neden'
 1	Kardeşini	kardeş	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	obj	_	_
 2	eleştiriyor	eleştir	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	4	obj	_	_
 3	gibi	gibi	ADP	PCNom	_	2	case	_	_
 4	geldi	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 5	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	4	obl	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	4	punct	_	_
-7	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	8	obl	_	_
+7	neden	neden	ADV	Ques	Case=Abl|Number=Sing|Person=3	8	advmod	_	_
 8	sokulgan	sokulgan	ADJ	Adj	_	4	conj	_	_
 9	onca	onca	ADV	Adverb	_	8	advmod:emph	_	SpaceAfter=No
 10	?	?	PUNCT	Punc	_	8	punct	_	_

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -2227,7 +2227,7 @@
 11	Recep'in	Recep	PROPN	Prop	Case=Gen|Number=Sing|Person=3	12	nmod:poss	_	_
 12	darbukasının	darbuka	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	nmod:poss	_	_
 13	önünde	ön	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	amod	_	_
-14	dururdu	dur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	6	conj	_	SpaceAfter=No
+14	dururdu	dur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	6	conj	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-0287
@@ -2270,7 +2270,7 @@
 21	içtenlikle	içtenlik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	22	obl	_	_
 22	konuşmaya	konuş	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	23	nmod	_	_
 23	dikkat	dikkat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	conj	_	_
-24	ederdi	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	23	compound:lvc	_	SpaceAfter=No
+24	ederdi	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	23	compound:lvc	_	SpaceAfter=No
 25	.	.	PUNCT	Punc	_	23	punct	_	_
 
 # sent_id = mst-0291
@@ -2297,7 +2297,7 @@
 # sent_id = mst-0293
 # text = Bahse girebilirdim ki: i) şu anda Kemal'in ortaya attığı fikirler bugün değilse bile yarın genel kabul görecektir.
 1	Bahse	bahis	NOUN	Noun	Case=Dat|Number=Sing|Person=3	7	nmod	_	_
-2	girebilirdim	gir	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	1	compound	_	_
+2	girebilirdim	gir	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Past	1	compound	_	_
 3	ki	ki	CCONJ	Conj	_	1	mark	_	SpaceAfter=No
 4	:	:	PUNCT	Punc	_	18	punct	_	_
 5	i	i	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod	_	SpaceAfter=No
@@ -2517,7 +2517,7 @@
 15	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	18	nsubj	_	_
 16	da	da	CCONJ	Conj	_	15	advmod:emph	_	_
 17	aynılarını	aynı	ADJ	NAdj	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	18	obj	_	_
-18	yapardı	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+18	yapardı	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 19	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-0308
@@ -2727,11 +2727,11 @@
 7	,	,	PUNCT	Punc	_	17	punct	_	_
 8	buna	bu	PRON	Demons	Case=Dat|Number=Sing|Person=3|PronType=Dem	10	obl	_	_
 9	ne	ne	ADV	Adverb	_	10	advmod	_	_
-10	inanırmış	inan	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	17	nmod	_	SpaceAfter=No
+10	inanırmış	inan	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	17	nmod	_	SpaceAfter=No
 11	,	,	PUNCT	Punc	_	14	punct	_	_
 12	ne	ne	ADV	Adverb	_	14	advmod	_	_
 13	de	de	CCONJ	Conj	_	12	advmod:emph	_	_
-14	inanmazmış	inan	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	10	conj	_	_
+14	inanmazmış	inan	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	10	conj	_	_
 15	gibi	gibi	ADP	PCNom	_	10	case	_	_
 16	bir	bir	NUM	ANum	NumType=Card	17	det	_	_
 17	tavır	tavır	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
@@ -2807,7 +2807,7 @@
 16	ki	ki	ADP	Rel	_	15	case	_	_
 17	küçücük	küçücük	ADJ	Adj	_	18	amod	_	_
 18	vurgulamaları	vurgula	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	19	obj	_	_
-19	değiştiremezlerdi	değiş	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=AorPast|Voice=Cau	10	conj	_	SpaceAfter=No
+19	değiştiremezlerdi	değiş	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=Past|Voice=Cau	10	conj	_	SpaceAfter=No
 20	.	.	PUNCT	Punc	_	19	punct	_	_
 
 # sent_id = mst-0326
@@ -3845,7 +3845,7 @@
 12	mağazasından	mağaza	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obl	_	_
 13	yiyecek	yiyecek	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	14	compound	_	_
 14	birşeyler	birşey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	15	obj	_	_
-15	alabilirdim	al	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	5	conj	_	SpaceAfter=No
+15	alabilirdim	al	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Past	5	conj	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-0432
@@ -3871,7 +3871,7 @@
 19	birkaç	birkaç	DET	Det	_	20	det	_	_
 20	dakika	dakika	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	obl	_	_
 21	bile	bile	ADV	Adverb	_	20	advmod	_	_
-22	sürmezdi	sür	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
+22	sürmezdi	sür	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 23	.	.	PUNCT	Punc	_	22	punct	_	_
 
 # sent_id = mst-0434
@@ -4297,18 +4297,18 @@
 11	gibi	gibi	ADP	PCNom	_	10	case	_	_
 12	kadınların	kadın	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	13	nmod:poss	_	_
 13	sesini	ses	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	obj	_	_
-14	tanırdım	tanı	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+14	tanırdım	tanı	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 15	,	,	PUNCT	Punc	_	18	punct	_	_
 16	her	her	DET	Det	_	18	obj	_	_
 17	tonunu	ton	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	obj	_	_
-18	bilirdim	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	14	conj	_	SpaceAfter=No
+18	bilirdim	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	14	conj	_	SpaceAfter=No
 19	,	,	PUNCT	Punc	_	25	punct	_	_
 20	yalnızca	yalnızca	ADV	Adverb	_	21	advmod	_	_
 21	kulaklarımla	kulak	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=1	22	nmod	_	_
 22	değil	değil	CCONJ	Conj	_	25	nmod	_	_
 23	bütün	bütün	ADJ	Adj	_	24	det	_	_
 24	vücudumla	vücut	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	22	conj	_	_
-25	duyardım	duy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	14	conj	_	_
+25	duyardım	duy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	14	conj	_	_
 26	onların	o	PRON	Pers	Case=Gen|Number=Plur|Person=3|PronType=Prs	27	nmod:poss	_	_
 27	sesini	ses	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	25	obj	_	SpaceAfter=No
 28	.	.	PUNCT	Punc	_	25	punct	_	_
@@ -4704,7 +4704,7 @@
 2	göre	göre	ADP	PCDat	_	1	case	_	_
 3	bakanlık	bakanlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
 4	soruşturmayı	soruşturma	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	obj	_	_
-5	yenileyebilirdi	yenile	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+5	yenileyebilirdi	yenile	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-0522
@@ -5297,7 +5297,7 @@
 5	Recep'in	Recep	PROPN	Prop	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
 6	yüzüne	yüz	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	_
 7	küçümsemeyle	küçümse	VERB	Verb	Aspect=Perf|Case=Ins|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nmod	_	_
-8	bakardı	bak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+8	bakardı	bak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-0598
@@ -5898,7 +5898,7 @@
 6	buruşturup	buruş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	9	nmod	_	_
 7	İyi	iyi	ADJ	Adj	_	9	obj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	9	punct	_	_
-9	derdi	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+9	derdi	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-0672
@@ -6139,7 +6139,7 @@
 5	geçmişin	geçmiş	ADJ	NAdj	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
 6	korkularıyla	korku	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	3	conj	_	_
 7	bağlarını	bağ	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
-8	kopardı	kop	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	7	compound	_	_
+8	kopardı	kop	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	7	compound	_	_
 9	gidiyor	git	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	7	conj	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
@@ -6997,7 +6997,7 @@
 9	kesinlikle	kesinlik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	12	obl	_	_
 10	bu	bu	DET	Det	_	11	det	_	_
 11	noktalarda	nokta	NOUN	Noun	Case=Loc|Number=Plur|Person=3	12	obl	_	_
-12	bulunmazdım	bulun	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=AorPast	14	nmod:poss	_	_
+12	bulunmazdım	bulun	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Past	14	nmod:poss	_	_
 13	"	"	PUNCT	Punc	_	12	punct	_	_
 14	sözünün	söz	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	nmod:poss	_	_
 15	Milliyet	milliyet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nmod:poss	_	_
@@ -7383,7 +7383,7 @@
 2	günde	gün	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	nmod	_	_
 3	bir	bir	NUM	ANum	NumType=Card	5	nummod	_	_
 4	Diyarbakır'a	Diyarbakır	PROPN	Prop	Case=Dat|Number=Sing|Person=3	5	obl	_	_
-5	giderdi	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+5	giderdi	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-0846
@@ -7778,7 +7778,7 @@
 17	hayatım	hayat	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	20	nsubj	_	_
 18	başka	başka	ADJ	Adj	_	19	det	_	_
 19	türlü	türlü	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	20	amod	_	_
-20	olurdu	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	6	conj	_	SpaceAfter=No
+20	olurdu	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	6	conj	_	SpaceAfter=No
 21	.	.	PUNCT	Punc	_	20	punct	_	_
 
 # sent_id = mst-0880
@@ -8335,7 +8335,7 @@
 2	en	en	ADV	Adverb	_	3	advmod	_	_
 3	arka	arka	ADJ	Adj	_	4	amod	_	_
 4	sırada	sıra	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
-5	otururdu	otur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	_
+5	otururdu	otur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 6	Ramiz	Ramiz	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nsubj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
@@ -8554,7 +8554,7 @@
 3	bu	bu	DET	Det	_	4	det	_	_
 4	gösteriyi	gösteri	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	obj	_	_
 5	izlemeni	izle	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=2|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	obj	_	_
-6	isterdim	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+6	isterdim	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-0959
@@ -8811,7 +8811,7 @@
 6	kardeşleriyle	kardeş	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	8	nmod	_	_
 7	birlikte	birlikte	ADP	PCIns	_	6	case	_	_
 8	tıraş	tıraş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-9	ederdi	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	8	compound:lvc	_	_
+9	ederdi	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	8	compound:lvc	_	_
 10	onu	o	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	8	obj	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	8	punct	_	_
 
@@ -8972,7 +8972,7 @@
 4	,	,	PUNCT	Punc	_	6	punct	_	_
 5	yüzlerce	yüzlerce	NUM	ANum	NumType=Card	6	nummod	_	_
 6	soru	soru	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-7	sorabilirdim	sor	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	6	compound	_	_
+7	sorabilirdim	sor	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Past	6	compound	_	_
 8	daha	daha	ADV	Adverb	_	6	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	6	punct	_	_
 
@@ -9433,7 +9433,7 @@
 13	ki	ki	ADP	Rel	_	12	case	_	_
 14	kahvelerden	kahve	NOUN	Noun	Case=Abl|Number=Plur|Person=3	15	nmod:poss	_	_
 15	birinde	bir	NUM	NNum	Case=Loc|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=3	16	nummod	_	_
-16	rastlardım	rastla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	_
+16	rastlardım	rastla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
 17	şimdiye	şimdi	NOUN	Noun	Case=Dat|Number=Sing|Person=3	16	obl	_	_
 18	kadar	kadar	ADP	PCDat	_	17	case	_	SpaceAfter=No
 19	.	.	PUNCT	Punc	_	16	punct	_	_
@@ -9571,7 +9571,7 @@
 4	kravat	kravat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
 5	düzeneğine	düzenek	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nmod	_	_
 6	gerek	gerek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-7	kalmazdı	kal	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	6	compound	_	_
+7	kalmazdı	kal	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	6	compound	_	_
 8	artık	artık	ADV	Adverb	_	6	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	6	punct	_	_
 
@@ -10116,7 +10116,7 @@
 12	bir	bir	NUM	ANum	NumType=Card	13	det	_	_
 13	türküsünü	türkü	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	obj	_	_
 14	çalmaya	çal	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	15	nmod	_	_
-15	başlardı	başla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+15	başlardı	başla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-1122
@@ -10124,7 +10124,7 @@
 1	Hatta	hatta	CCONJ	Conj	_	4	advmod:emph	_	_
 2	siz	siz	PRON	Pers	Case=Nom|Number=Plur|Person=2|PronType=Prs	4	nsubj	_	_
 3	bile	bile	ADV	Adverb	_	2	advmod:emph	_	_
-4	denmezdi	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast|Voice=Pass	0	root	_	SpaceAfter=No
+4	denmezdi	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-1123
@@ -10546,7 +10546,7 @@
 3	daha	daha	ADV	Adverb	_	5	advmod	_	_
 4	kötü	kötü	ADJ	Adj	_	5	amod	_	_
 5	olaylar	olay	NOUN	Noun	Case=Nom|Number=Plur|Person=3	6	nsubj	_	_
-6	gelebilirdi	gel	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+6	gelebilirdi	gel	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-1177
@@ -11936,7 +11936,7 @@
 6	birçok	birçok	DET	Det	_	7	det	_	_
 7	yolculuğunu	yolculuk	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obj	_	_
 8	karayoluyla	karayolu	NOUN	Noun	Case=Ins|Number=Sing|Person=3	9	obl	_	_
-9	yapardı	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+9	yapardı	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-1340
@@ -12585,7 +12585,7 @@
 2	mutsuz	mutsuz	ADJ	Adj	_	3	amod	_	_
 3	olduklarını	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	5	obj	_	_
 4	ise	i	AUX	Conj	_	3	discourse	_	_
-5	söylemezlerdi	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
+5	söylemezlerdi	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	11	punct	_	_
 7	mutsuzluklarının	mutsuzluk	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	8	nmod:poss	_	_
 8	nedenini	neden	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obj	_	_
@@ -12599,7 +12599,7 @@
 15	keşfedemezseniz	keşfet	VERB	Verb	Aspect=Imp|Mood=CndPot|Number=Plur|Person=2|Polarity=Neg|Tense=Aor	18	nmod	_	_
 16	biraz	biraz	ADV	Adverb	_	17	advmod	_	_
 17	daha	daha	ADV	Adverb	_	18	advmod	_	_
-18	düşmanlaşırlardı	düşmanlaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	5	conj	_	SpaceAfter=No
+18	düşmanlaşırlardı	düşmanlaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	5	conj	_	SpaceAfter=No
 19	;	;	PUNCT	Punc	_	22	punct	_	_
 20	bu	bu	DET	Det	_	21	det	_	_
 21	düşmanlık	düşmanlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	32	nsubj	_	_
@@ -12756,7 +12756,7 @@
 19	her	her	DET	Det	_	20	det	_	_
 20	defasında	defa	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	obl	_	_
 21	yıkamak	yıka	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	22	nsubj	_	_
-22	gerekirdi	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	10	conj	_	SpaceAfter=No
+22	gerekirdi	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	10	conj	_	SpaceAfter=No
 23	.	.	PUNCT	Punc	_	22	punct	_	_
 
 # sent_id = mst-1432
@@ -13129,7 +13129,7 @@
 8	anlama	anla	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	3	conj	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10	bütün	bütün	ADJ	Adj	_	11	amod	_	_
-11	derdi	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	12	nsubj	_	_
+11	derdi	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	12	nsubj	_	_
 12-13	kendinleydi	_	_	_	_	_	_	_	SpaceAfter=No
 12	kendinle	kendi	PRON	Reflex	Case=Ins|Number=Sing|Number[psor]=Sing|Person=2|Person[psor]=2|Reflex=Yes	3	conj	_	_
 13	ydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	12	cop	_	_
@@ -13210,7 +13210,7 @@
 1	Kocacığım	Kocacığ	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	0	root	_	SpaceAfter=No
 2	!	!	PUNCT	Punc	_	3	punct	_	_
 3	El	el	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
-4	sallardım	salla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	3	compound	_	_
+4	sallardım	salla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	3	compound	_	_
 5	işine	iş	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	6	obl	_	_
 6	giderken	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	3	nmod	_	_
 7	balkondan	balkon	NOUN	Noun	Case=Abl|Number=Sing|Person=3	3	nmod	_	SpaceAfter=No
@@ -13375,7 +13375,7 @@
 # sent_id = mst-1492
 # text = Öğretmenler derlerdi ki.
 1	Öğretmenler	öğretmen	NOUN	Noun	Case=Nom|Number=Plur|Person=3	2	nsubj	_	_
-2	derlerdi	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	_
+2	derlerdi	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 3	ki	ki	CCONJ	Conj	_	2	advmod:emph	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -13607,7 +13607,7 @@
 26	sol	sol	ADJ	Adj	_	27	amod	_	_
 27	elini	el	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	28	obj	_	_
 28	harekete	hareket	NOUN	Noun	Case=Dat|Number=Sing|Person=3	0	root	_	_
-29	geçirirdi	geçir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	28	compound	_	SpaceAfter=No
+29	geçirirdi	geçir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	28	compound	_	SpaceAfter=No
 30	.	.	PUNCT	Punc	_	28	punct	_	_
 
 # sent_id = mst-1519
@@ -14986,7 +14986,7 @@
 12	yarın	yarın	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
 13	dönsem	dön	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	15	nmod	_	_
 14	iyi	iyi	ADJ	Adj	_	15	amod	_	_
-15	olurmuş	ol	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	10	conj	_	SpaceAfter=No
+15	olurmuş	ol	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	10	conj	_	SpaceAfter=No
 16	...	...	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-1670
@@ -15315,7 +15315,7 @@
 4	etmemişken	et	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Neg|Tense=Past|VerbForm=Conv	3	compound	_	_
 5	beyaz	beyaz	ADJ	Adj	_	6	amod	_	_
 6	peynir	peynir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
-7	bulunmazdı	bul	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast|Voice=Pass	0	root	_	SpaceAfter=No
+7	bulunmazdı	bul	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-1710
@@ -15677,7 +15677,7 @@
 8	-	-	PUNCT	Punc	_	11	punct	_	SpaceAfter=No
 9	Edebiyat	edebiyat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	compound	_	_
 10	diye	diye	ADP	PCNom	_	7	case	_	_
-11	ayrılırdı	ayrıl	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+11	ayrılırdı	ayrıl	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-1751
@@ -16185,7 +16185,7 @@
 18	aşırtıp	aşır	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	21	nmod	_	_
 19	sağ	sağ	ADJ	Adj	_	20	amod	_	_
 20	eliyle	el	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	obl	_	_
-21	tutardı	tut	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	6	conj	_	SpaceAfter=No
+21	tutardı	tut	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	6	conj	_	SpaceAfter=No
 22	.	.	PUNCT	Punc	_	21	punct	_	_
 
 # sent_id = mst-1807
@@ -18617,7 +18617,7 @@
 2	yetmediği	yet	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	4	acl	_	_
 3	fen	fen	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 4	derslerinde	ders	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
-5	düşünürdüm	düşün	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+5	düşünürdüm	düşün	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	:	:	PUNCT	Punc	_	12	punct	_	_
 7	Aynı	aynı	ADJ	Adj	_	8	amod	_	_
 8	hoca	hoca	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
@@ -19067,7 +19067,7 @@
 1	Ne	ne	ADJ	Adj	_	2	amod	_	_
 2	işe	iş	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
 3	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	2	nmod	_	_
-4	yarardı	yara	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+4	yarardı	yara	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2113
@@ -19411,7 +19411,7 @@
 10	benim	ben	PRON	Pers	Case=Gen|Number=Sing|Person=1|PronType=Prs	11	nmod:poss	_	_
 11	gözlerime	göz	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=1	12	obl	_	_
 12	bakarak	bak	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	13	nmod	_	_
-13	sevişirdik	seviş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	_
+13	sevişirdik	seviş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
 14	kalabalığın	kalabalık	NOUN	Noun	Case=Gen|Number=Sing|Person=3	15	nmod:poss	_	_
 15	içinde	iç	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	amod	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	13	punct	_	_
@@ -19603,12 +19603,12 @@
 # text = Nesrin bize kızardı, falan, konu değişirdi.
 1	Nesrin	Nesrin	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	bize	biz	PRON	Pers	Case=Dat|Number=Plur|Person=1|PronType=Prs	3	obl	_	_
-3	kızardı	kız	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+3	kızardı	kız	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	8	punct	_	_
 5	falan	falan	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	8	cc	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	8	punct	_	_
 7	konu	konu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8	değişirdi	değiş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	3	conj	_	SpaceAfter=No
+8	değişirdi	değiş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	conj	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-2170
@@ -20049,7 +20049,7 @@
 5	sevdiğim	sev	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	8	acl	_	_
 6	için	için	ADP	PCNom	_	5	case	_	_
 7	seninle	sen	PRON	Pers	Case=Ins|Number=Sing|Person=2|PronType=Prs	8	obl	_	_
-8	olamazdım	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=AorPast	14	obj	_	SpaceAfter=No
+8	olamazdım	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Past	14	obj	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	15	punct	_	_
 10	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	11	obl	_	_
 11	duyduğum	duy	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	12	acl	_	_
@@ -20058,7 +20058,7 @@
 14	korkuttu	korkut	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	17	obj	_	_
 15	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	8	conj	_	SpaceAfter=No
 16	,	,	PUNCT	Punc	_	15	punct	_	_
-17	diyemezdim	de	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
+17	diyemezdim	de	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-2211
@@ -20292,7 +20292,7 @@
 4	kuru	kuru	ADJ	Adj	_	5	amod	_	_
 5	leblebiyi	leblebi	NOUN	Noun	Case=Acc|Number=Sing|Person=3	6	obj	_	_
 6	tercih	tercih	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-7	ederdi	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	6	compound:lvc	_	SpaceAfter=No
+7	ederdi	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	6	compound:lvc	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-2237
@@ -20317,7 +20317,7 @@
 2	güneşte	güneş	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
 3	ne	ne	ADJ	Adj	_	4	det	_	_
 4	güzel	güzel	ADJ	Adj	_	5	amod	_	_
-5	görünürlerdi	görün	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	1	conj	_	SpaceAfter=No
+5	görünürlerdi	görün	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-2241
@@ -20386,7 +20386,7 @@
 12	cesur	cesur	ADJ	Adj	_	15	obj	_	_
 13	ve	ve	CCONJ	Conj	_	14	cc	_	_
 14	atak	atak	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	12	conj	_	_
-15	olurdu	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	3	conj	_	SpaceAfter=No
+15	olurdu	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	conj	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-2250
@@ -23864,7 +23864,7 @@
 23	benden	ben	PRON	Pers	Case=Abl|Number=Sing|Person=1|PronType=Prs	26	obl	_	_
 24	de	de	CCONJ	Conj	_	23	advmod:emph	_	_
 25	seslerini	ses	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	26	obj	_	_
-26	saklayamazlardı	sakla	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=AorPast	8	conj	_	SpaceAfter=No
+26	saklayamazlardı	sakla	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=Past	8	conj	_	SpaceAfter=No
 27	.	.	PUNCT	Punc	_	26	punct	_	_
 
 # sent_id = mst-2642
@@ -23892,7 +23892,7 @@
 # sent_id = mst-2644
 # text = Babam derdi ki.
 1	Babam	baba	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	nsubj	_	_
-2	derdi	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	_
+2	derdi	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 3	ki	ki	CCONJ	Conj	_	2	advmod:emph	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -24195,7 +24195,7 @@
 18	dolaşıp	dolaş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	19	nmod	_	_
 19	durmakla	dur	VERB	Verb	Aspect=Perf|Case=Ins|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	21	nmod	_	_
 20	vakit	vakit	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	obj	_	_
-21	tüketirmişim	tüket	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	11	conj	_	_
+21	tüketirmişim	tüket	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	11	conj	_	_
 22	gibi	gibi	ADP	PCNom	_	11	case	_	_
 23	geliyordu	gel	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	_
 24	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	23	obl	_	SpaceAfter=No
@@ -24313,7 +24313,7 @@
 6	türkü	türkü	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod	_	_
 7	için	için	ADP	PCNom	_	6	case	_	_
 8	izin	izin	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-9	verirdi	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	8	compound	_	_
+9	verirdi	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	8	compound	_	_
 10	bu	bu	DET	Det	_	11	det	_	_
 11	gösteriye	gösteri	NOUN	Noun	Case=Dat|Number=Sing|Person=3	8	nmod	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	8	punct	_	_
@@ -25107,7 +25107,7 @@
 # text = Kasketini yan iliştirirdi kafasına.
 1	Kasketini	kasket	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
 2	yan	yan	ADJ	Adj	_	3	amod	_	_
-3	iliştirirdi	iliş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast|Voice=Cau	0	root	_	_
+3	iliştirirdi	iliş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	0	root	_	_
 4	kafasına	kafa	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obl	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -25240,7 +25240,7 @@
 # sent_id = mst-2787
 # text = Ödümü kopardın.
 1	Ödümü	öd	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	0	root	_	_
-2	kopardın	kop	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=AorPast	1	compound	_	SpaceAfter=No
+2	kopardın	kop	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Past	1	compound	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-2788
@@ -25261,7 +25261,7 @@
 9	kesinlikle	kesinlik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	12	obl	_	_
 10	bu	bu	DET	Det	_	11	det	_	_
 11	noktalarda	nokta	NOUN	Noun	Case=Loc|Number=Plur|Person=3	12	obl	_	_
-12	bulunmazdım	bulun	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
+12	bulunmazdım	bulun	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-2790
@@ -25890,7 +25890,7 @@
 30	dolma	dolma	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	conj	_	_
 31	gibi	gibi	ADP	PCNom	_	21	case	_	_
 32	şeyler	şey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	33	obj	_	_
-33	alırdı	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+33	alırdı	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 34	.	.	PUNCT	Punc	_	33	punct	_	_
 
 # sent_id = mst-2868
@@ -25995,7 +25995,7 @@
 4	bile	bile	ADV	Adverb	_	5	advmod	_	_
 5	diyemeden	de	VERB	Verb	Aspect=Perf|Mood=Pot|Polarity=Neg|Tense=Pres|VerbForm=Conv	7	nmod	_	_
 6	pazar	pazar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
-7	bitermiş	bit	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+7	bitermiş	bit	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-2882
@@ -26432,7 +26432,7 @@
 33	tümüyle	tümüyle	ADV	Adverb	_	34	advmod	_	_
 34	sevdiği	sev	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	35	acl	_	_
 35	erkeğe	erkek	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	36	amod	_	_
-36	verirdi	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	13	conj	_	_
+36	verirdi	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	13	conj	_	_
 37	ve	ve	CCONJ	Conj	_	43	cc	_	_
 38	bir	bir	NUM	ANum	NumType=Card	39	det	_	_
 39	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	40	obl	_	_
@@ -26448,7 +26448,7 @@
 1	Kendimi	kendi	PRON	Reflex	Case=Acc|Number=Sing|Number[psor]=Sing|Person=1|Person[psor]=1|Reflex=Yes	3	obj	_	_
 2	katilin	katil	ADJ	NAdj	Case=Gen|Number=Sing|Person=3	3	amod	_	_
 3	yerine	yer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
-4	koyardım	koy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	3	compound	_	SpaceAfter=No
+4	koyardım	koy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	3	compound	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	17	punct	_	_
 6	onun	o	PRON	Pers	Case=Gen|Number=Sing|Person=3|PronType=Prs	15	nmod:poss	_	_
 7	o	o	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	8	det	_	_
@@ -26461,7 +26461,7 @@
 14	neler	ne	PRON	Ques	Case=Nom|Number=Plur|Person=3	15	obj	_	_
 15	hissettiğini	hisset	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	17	obj	_	_
 16	anlamaya	anla	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	17	nmod	_	_
-17	çalışırdım	çalış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	3	conj	_	SpaceAfter=No
+17	çalışırdım	çalış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	3	conj	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-2938
@@ -26486,7 +26486,7 @@
 7	çok	çok	ADV	Adverb	_	8	advmod	_	_
 8	falan	falan	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	10	amod	_	_
 9	filan	filan	ADJ	Adj	_	8	compound:redup	_	_
-10	bulurlarmış	bul	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+10	bulurlarmış	bul	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-2941
@@ -26537,7 +26537,7 @@
 24	kapattı	kapa	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Cau	6	conj	_	SpaceAfter=No
 25	,	,	PUNCT	Punc	_	27	punct	_	_
 26	eksikliğimi	eksiklik	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	27	obj	_	_
-27	giderdi	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	6	conj	_	SpaceAfter=No
+27	giderdi	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	6	conj	_	SpaceAfter=No
 28	.	.	PUNCT	Punc	_	27	punct	_	_
 
 # sent_id = mst-2947
@@ -26762,7 +26762,7 @@
 1	Yok	yok	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	3	amod	_	_
 2	sa	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	1	cop	_	_
 3	cuk	cuk	ADV	Adverb	_	0	root	_	_
-4	otururdu	otur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	3	compound	_	SpaceAfter=No
+4	otururdu	otur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	compound	_	SpaceAfter=No
 5	:	:	PUNCT	Punc	_	12	punct	_	_
 6	Milliyetçi	milliyetçi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
 7	Cephe	Cephe	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	flat	_	_
@@ -26851,7 +26851,7 @@
 8	yerken	ye	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	7	compound	_	_
 9	attığı	at	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	11	obj	_	_
 10	çığlıkları	çığlık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	9	compound	_	_
-11	dinlerdim	dinle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+11	dinlerdim	dinle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	5	conj	_	_
 
 # sent_id = mst-2984
@@ -26992,7 +26992,7 @@
 # text = Bazen şiirler okurdu.
 1	Bazen	bazen	ADV	Adverb	_	3	advmod	_	_
 2	şiirler	şiir	NOUN	Noun	Case=Nom|Number=Plur|Person=3	3	obj	_	_
-3	okurdu	oku	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+3	okurdu	oku	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-2998
@@ -27114,7 +27114,7 @@
 30	masalarına	masa	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	31	obl	_	_
 31	gitmeleri	git	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	32	obj	_	_
 32	gerektiğini	gerek	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	33	obj	_	_
-33	anlatırdı	anlat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	19	conj	_	SpaceAfter=No
+33	anlatırdı	anlat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	19	conj	_	SpaceAfter=No
 34	.	.	PUNCT	Punc	_	33	punct	_	_
 
 # sent_id = mst-3012
@@ -27160,7 +27160,7 @@
 3	yarısı	yarı	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
 4	gülerken	gül	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	6	nmod	_	_
 5	yarısı	yarı	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	amod	_	_
-6	ağlardı	ağla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+6	ağlardı	ağla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3017
@@ -28035,7 +28035,7 @@
 6	titrer	titre	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	compound	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	8	punct	_	_
 8	çekip	çek	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	3	conj	_	_
-9	çevirirdi	çevir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	8	compound	_	_
+9	çevirirdi	çevir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	8	compound	_	_
 10	seni	sen	PRON	Pers	Case=Acc|Number=Sing|Person=2|PronType=Prs	8	obj	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	8	punct	_	_
 
@@ -28295,7 +28295,7 @@
 # text = Ne okulu severdi, ne de Naci Beyi.
 1	Ne	ne	CCONJ	Conj	_	2	cc	_	_
 2	okulu	okul	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
-3	severdi	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+3	severdi	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	7	punct	_	_
 5	ne	ne	CCONJ	Conj	_	2	cc	_	_
 6	de	de	CCONJ	Conj	_	5	advmod:emph	_	_
@@ -28737,7 +28737,7 @@
 5	darbukasıyla	darbuka	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	8	punct	_	_
 7	Recep	Recep	PROPN	Prop	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
-8	olurdu	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+8	olurdu	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-3195
@@ -29105,7 +29105,7 @@
 5	,	,	PUNCT	Punc	_	8	punct	_	_
 6	sakız	sakız	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	compound	_	_
 7	leblebi	leblebi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8	severmiş	sev	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	2	obj	_	SpaceAfter=No
+8	severmiş	sev	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	2	obj	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-3237
@@ -29169,7 +29169,7 @@
 22	aynı	aynı	ADJ	Adj	_	23	amod	_	_
 23	nedenden	neden	NOUN	Noun	Case=Abl|Number=Sing|Person=3	20	conj	_	_
 24	terk	terk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	conj	_	_
-25	ederlerdi	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	24	compound:lvc	_	_
+25	ederlerdi	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	24	compound:lvc	_	_
 26	zaten	zaten	ADV	Adverb	_	24	conj	_	SpaceAfter=No
 27	.	.	PUNCT	Punc	_	26	punct	_	_
 
@@ -29529,7 +29529,7 @@
 18	sarı	sarı	ADJ	Adj	_	19	amod	_	_
 19	köpek	köpek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	conj	_	_
 20	de	de	CCONJ	Conj	_	19	advmod:emph	_	_
-21	bilirdi	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+21	bilirdi	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 22	.	.	PUNCT	Punc	_	21	punct	_	_
 
 # sent_id = mst-3281
@@ -29545,12 +29545,12 @@
 # sent_id = mst-3283
 # text = Konuşmayı sevmezdi, konuşunca da iyi konuşurdu.
 1	Konuşmayı	konuş	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	2	obj	_	_
-2	sevmezdi	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
+2	sevmezdi	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	7	punct	_	_
 4	konuşunca	konuş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	_
 5	da	da	CCONJ	Conj	_	4	advmod:emph	_	_
 6	iyi	iyi	ADJ	Adj	_	7	amod	_	_
-7	konuşurdu	konuş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	2	conj	_	SpaceAfter=No
+7	konuşurdu	konuş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-3284
@@ -29740,7 +29740,7 @@
 21	dişi	dişi	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	22	amod	_	_
 22	olması	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	23	nmod:poss	_	_
 23	gerektiğini	gerek	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	14	conj	_	_
-24	görebilirlerdi	gör	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	5	conj	_	SpaceAfter=No
+24	görebilirlerdi	gör	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Past	5	conj	_	SpaceAfter=No
 25	.	.	PUNCT	Punc	_	24	punct	_	_
 
 # sent_id = mst-3298
@@ -29975,7 +29975,7 @@
 
 # sent_id = mst-3325
 # text = Giderdik konserlere, tiyatrolara, sinemalara.
-1	Giderdik	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	_
+1	Giderdik	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
 2	konserlere	konser	NOUN	Noun	Case=Dat|Number=Plur|Person=3	1	obl	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	4	punct	_	_
 4	tiyatrolara	tiyatro	NOUN	Noun	Case=Dat|Number=Plur|Person=3	2	conj	_	SpaceAfter=No
@@ -30112,7 +30112,7 @@
 7	anne	anne	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
 8	ve	ve	CCONJ	Conj	_	9	cc	_	_
 9	kızı	kız	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	conj	_	_
-10	yaşarmış	yaşa	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+10	yaşarmış	yaşa	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-3341
@@ -30597,7 +30597,7 @@
 12	ertesi	ertesi	ADJ	Adj	_	13	amod	_	_
 13	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	nmod	_	_
 14	canlarına	can	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	1	conj	_	_
-15	okurdu	oku	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	14	compound	_	SpaceAfter=No
+15	okurdu	oku	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	14	compound	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-3403
@@ -31677,7 +31677,7 @@
 2	çocuğunda	çocuk	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 3	saça	saç	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
 4	hiç	hiç	ADV	Adverb	_	5	advmod	_	_
-5	dayanamazdı	dayan	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
+5	dayanamazdı	dayan	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-3536
@@ -31996,7 +31996,7 @@
 12	anını	an	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	obj	_	_
 13	gözümde	göz	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	15	obl	_	_
 14	canlandırmaya	canlan	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	13	compound	_	_
-15	uğraşırdım	uğraş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	7	conj	_	SpaceAfter=No
+15	uğraşırdım	uğraş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	7	conj	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-3576
@@ -32303,7 +32303,7 @@
 12	haberlerini	haber	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	13	obj	_	_
 13	kesip	kes	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	15	nmod	_	_
 14	dosyalarına	dosya	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	15	obl	_	_
-15	koyardım	koy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+15	koyardım	koy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 16	;	;	PUNCT	Punc	_	37	punct	_	_
 17	arada	ara	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	21	amod	_	_
 18	ilginç	ilginç	ADJ	Adj	_	20	amod	_	_
@@ -32326,7 +32326,7 @@
 34	defterime	defter	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	37	obl	_	_
 35	kendim	kendi	PRON	Reflex	Case=Nom|Number=Sing|Number[psor]=Sing|Person=1|Person[psor]=1|Reflex=Yes	37	obl	_	_
 36	için	için	ADP	PCNom	_	35	case	_	_
-37	kaydederdim	kaydet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	15	conj	_	SpaceAfter=No
+37	kaydederdim	kaydet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	15	conj	_	SpaceAfter=No
 38	.	.	PUNCT	Punc	_	37	punct	_	_
 
 # sent_id = mst-3614
@@ -33138,7 +33138,7 @@
 9	hatta	hatta	CCONJ	Conj	_	6	cc	_	_
 10	daha	daha	ADV	Adverb	_	11	advmod	_	_
 11	çok	çok	ADV	Adverb	_	12	advmod	_	_
-12	tanırdı	tanı	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	3	conj	_	_
+12	tanırdı	tanı	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	conj	_	_
 13	insanları	insan	NOUN	Noun	Case=Acc|Number=Plur|Person=3	12	obj	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	12	punct	_	_
 
@@ -33419,7 +33419,7 @@
 3	saçlarını	saç	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	6	obj	_	_
 4	evde	ev	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
 5	kendisi	kendi	PRON	Reflex	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	6	obl	_	_
-6	boyardı	boya	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+6	boyardı	boya	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3711
@@ -33809,7 +33809,7 @@
 5	bize	biz	PRON	Pers	Case=Dat|Number=Plur|Person=1|PronType=Prs	8	obl	_	_
 6	indirim	indirim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
 7	de	de	CCONJ	Conj	_	6	advmod:emph	_	_
-8	yapabilirmiş	yap	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+8	yapabilirmiş	yap	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-3756
@@ -33886,7 +33886,7 @@
 7	Hülya	Hülya	PROPN	Prop	Case=Nom|Number=Sing|Person=3	10	obj	_	_
 8	ve	ve	CCONJ	Conj	_	9	cc	_	_
 9	Selma'yı	Selma	PROPN	Prop	Case=Acc|Number=Sing|Person=3	7	conj	_	_
-10	ayartabilirdim	ayart	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+10	ayartabilirdim	ayart	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 11	,	,	PUNCT	Punc	_	14	punct	_	_
 12	o	o	DET	Det	_	14	obj	_	_
 13	da	da	CCONJ	Conj	_	12	advmod:emph	_	_
@@ -34037,7 +34037,7 @@
 39	tabure	tabure	NOUN	Noun	Case=Nom|Number=Sing|Person=3	40	obj	_	_
 40	koyar	koy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	42	nmod	_	SpaceAfter=No
 41	,	,	PUNCT	Punc	_	40	punct	_	_
-42	otururdu	otur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	18	conj	_	SpaceAfter=No
+42	otururdu	otur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	18	conj	_	SpaceAfter=No
 43	.	.	PUNCT	Punc	_	42	punct	_	_
 
 # sent_id = mst-3779
@@ -35456,7 +35456,7 @@
 6	fahişe	fahişe	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
 7	ile	ile	ADP	PCNom	_	6	case	_	_
 8	sevişmek	seviş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	obj	_	_
-9	istemezdi	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	1	conj	_	SpaceAfter=No
+9	istemezdi	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	1	conj	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-3930
@@ -35606,7 +35606,7 @@
 16	Cep	cep	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nmod:poss	_	_
 17	telefonunun	telefon	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	nmod:poss	_	_
 18	açılmaması	aç	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun|Voice=Pass	19	nsubj	_	_
-19	gerekirdi	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	13	conj	_	SpaceAfter=No
+19	gerekirdi	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	13	conj	_	SpaceAfter=No
 20	.	.	PUNCT	Punc	_	19	punct	_	_
 
 # sent_id = mst-3947
@@ -36021,7 +36021,7 @@
 2	,	,	PUNCT	Punc	_	3	punct	_	_
 3	kuralları	kural	NOUN	Noun	Case=Acc|Number=Plur|Person=3	1	conj	_	_
 4	iyi	iyi	ADJ	Adj	_	5	amod	_	_
-5	bilirdi	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+5	bilirdi	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4001
@@ -36161,7 +36161,7 @@
 6-7	söylenirse	_	_	_	_	_	_	_	_
 6	söylenir	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	8	acl	_	_
 7	se	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	6	cop	_	_
-8	olurmuş	ol	VERB	Verb	Aspect=Imp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+8	olurmuş	ol	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-4019
@@ -38472,7 +38472,7 @@
 2	size	siz	PRON	Pers	Case=Dat|Number=Plur|Person=2|PronType=Prs	3	nmod	_	_
 3	yardım	yardım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
 4	edebilmek	et	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	3	compound:lvc	_	_
-5	isterdim	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	7	obj	_	SpaceAfter=No
+5	isterdim	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	7	obj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	5	punct	_	_
 7	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 8	Jul	jul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	SpaceAfter=No
@@ -38631,7 +38631,7 @@
 7	bizim	biz	PRON	Pers	Case=Gen|Number=Plur|Person=1|PronType=Prs	10	nsubj	_	_
 8	kiler	ki	ADP	Rel	Case=Nom|Number=Plur|Person=3	7	case	_	_
 9	de	de	CCONJ	Conj	_	7	advmod:emph	_	_
-10	ayırmazdı	ayır	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	_
+10	ayırmazdı	ayır	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	_
 11	bizi	biz	PRON	Pers	Case=Acc|Number=Plur|Person=1|PronType=Prs	10	obj	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	10	punct	_	_
 
@@ -39212,7 +39212,7 @@
 2	beş	beş	NUM	ANum	NumType=Card	3	nummod	_	_
 3	saat	saat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
 4	Latince	Latince	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	obj	_	_
-5	okurduk	oku	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	_
+5	okurduk	oku	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
 6	lise	lise	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod:poss	_	_
 7	dersleri	ders	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	8	nmod:poss	_	_
 8	yanında	yan	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	amod	_	SpaceAfter=No
@@ -42827,13 +42827,13 @@
 8	kırk	kırk	NUM	ANum	NumType=Card	9	nummod	_	_
 9	defa	defa	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obl	_	_
 10	bakan	bakan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obj	_	_
-11	olurdum	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+11	olurdum	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	17	punct	_	_
 13	elli	elli	NUM	ANum	NumType=Card	14	nummod	_	_
 14	defa	defa	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	obl	_	_
 15	genel	genel	ADJ	Adj	_	16	amod	_	_
 16	başkan	başkan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	obj	_	_
-17	olurdum	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	11	conj	_	SpaceAfter=No
+17	olurdum	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	11	conj	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-4798
@@ -43655,7 +43655,7 @@
 16	hızlandırıp	hızlan	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	18	nmod	_	_
 17	Saffet'i	Saffet	PROPN	Prop	Case=Acc|Number=Sing|Person=3	18	obj	_	_
 18	zorlamaya	zorla	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	13	conj	_	_
-19	başlardı	başla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	9	conj	_	SpaceAfter=No
+19	başlardı	başla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	9	conj	_	SpaceAfter=No
 20	.	.	PUNCT	Punc	_	19	punct	_	_
 
 # sent_id = mst-4874
@@ -44127,7 +44127,7 @@
 11	denli	denli	ADJ	Adj	_	10	compound	_	_
 12	tesadüfi	tesadüfi	ADV	Adverb	_	13	advmod	_	_
 13	çizilebileceğini	çiz	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	14	obj	_	_
-14	bilemezdi	bil	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	_
+14	bilemezdi	bil	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	_
 15	belki	belki	ADV	Adverb	_	14	advmod	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	14	punct	_	_
 
@@ -44276,7 +44276,7 @@
 5	memnun	memnun	ADJ	Adj	_	8	obj	_	_
 6	olmadıkları	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	5	compound:lvc	_	_
 7	da	da	CCONJ	Conj	_	5	advmod:emph	_	_
-8	söylenemezdi	söyle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast|Voice=Pass	0	root	_	SpaceAfter=No
+8	söylenemezdi	söyle	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-4946
@@ -45253,7 +45253,7 @@
 29	sahnenin	sahne	NOUN	Noun	Case=Gen|Number=Sing|Person=3	31	nmod:poss	_	_
 30	canlanmakta	canlan	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Form|Tense=Pres	31	nmod	_	_
 31	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	32	obj	_	_
-32	sezerlerdi	sez	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+32	sezerlerdi	sez	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 33	.	.	PUNCT	Punc	_	32	punct	_	_
 
 # sent_id = mst-5060
@@ -45604,7 +45604,7 @@
 # sent_id = mst-5104
 # text = Ne derdik.
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	2	obj	_	_
-2	derdik	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+2	derdik	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-5105
@@ -46084,7 +46084,7 @@
 # text = Kahve iyi gelirdi.
 1	Kahve	kahve	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	iyi	iyi	ADJ	Adj	_	3	amod	_	_
-3	gelirdi	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+3	gelirdi	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-5172
@@ -46258,7 +46258,7 @@
 6	ulaşana	ulaş	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	8	acl	_	_
 7	dek	dek	ADP	PCDat	_	6	case	_	_
 8	özenle	özen	NOUN	Noun	Case=Ins|Number=Sing|Person=3	9	obl	_	_
-9	sürerdi	sür	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	0	root	_	SpaceAfter=No
+9	sürerdi	sür	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-5197
@@ -47720,7 +47720,7 @@
 13	gösterdiğinden	göster	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	16	acl	_	_
 14	bir	bir	NUM	ANum	NumType=Card	15	det	_	_
 15	erdem	erdem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	obl	_	_
-16	sayılabilirdi	say	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast|Voice=Pass	6	parataxis	_	SpaceAfter=No
+16	sayılabilirdi	say	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	6	parataxis	_	SpaceAfter=No
 17	-	-	PUNCT	Punc	_	16	punct	_	SpaceAfter=No
 18	Necmi	Necmi	PROPN	Prop	Case=Nom|Number=Sing|Person=3	19	nsubj	_	_
 19	Bey'i	Bey	PROPN	Prop	Case=Acc|Number=Sing|Person=3	20	nmod	_	_
@@ -47867,7 +47867,7 @@
 8	daima	daima	ADV	Adverb	_	9	advmod	_	_
 9	bir	bir	NUM	ANum	NumType=Card	0	root	_	_
 10	yolu	yol	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	compound	_	_
-11	bulunurdu	bulun	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=AorPast	9	compound	_	SpaceAfter=No
+11	bulunurdu	bulun	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	9	compound	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	19	punct	_	_
 13	ama	ama	CCONJ	Conj	_	19	cc	_	_
 14	insanın	insan	NOUN	Noun	Case=Gen|Number=Sing|Person=3	17	nmod:poss	_	_
@@ -48587,7 +48587,7 @@
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10	gözünden	göz	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 11	asla	asla	ADV	Adverb	_	10	advmod	_	_
-12	kaçmazdı	kaç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=AorPast	10	compound	_	SpaceAfter=No
+12	kaçmazdı	kaç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	10	compound	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-5452
@@ -49642,7 +49642,7 @@
 3	kendi	kendi	PRON	Reflex	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	5	nmod	_	_
 4	kendime	kendi	PRON	Reflex	Case=Dat|Number=Sing|Number[psor]=Sing|Person=1|Person[psor]=1|Reflex=Yes	3	compound:redup	_	_
 5	idare	idare	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-6	ederdim	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=AorPast	5	compound	_	_
+6	ederdim	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	5	compound	_	_
 7	ama	ama	CCONJ	Conj	_	17	cc	_	_
 8	şu	şu	DET	Det	_	9	det	_	_
 9	dersler	ders	NOUN	Noun	Case=Nom|Number=Plur|Person=3	10	nsubj	_	_

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -332,7 +332,7 @@
 1	Kapıcı	Kapıcı	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	hergelesinin	hergele	ADJ	NAdj	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	nmod:poss	_	_
 3	bakışını	bakış	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
-4	görsen	gör	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
+4	görsen	gör	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	6	punct	_	_
 6	aç	aç	ADJ	Adj	_	4	conj	_	_
 7	kurt	kurt	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	compound	_	_
@@ -1681,7 +1681,7 @@
 # text = Bir mucize gerçekleşse.
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	mucize	mucize	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
-3	gerçekleşse	gerçekleş	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
+3	gerçekleşse	gerçekleş	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-0221
@@ -1993,7 +1993,7 @@
 # text = Evlilik aşkı desek!..
 1	Evlilik	evlilik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	aşkı	aşk	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
-3	desek	de	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
+3	desek	de	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	!	!	PUNCT	Punc	_	3	punct	_	SpaceAfter=No
 5	..	..	PUNCT	Punc	_	3	punct	_	_
 
@@ -2512,7 +2512,7 @@
 10	büyük	büyük	ADJ	Adj	_	12	amod	_	_
 11	bir	bir	NUM	ANum	NumType=Card	12	det	_	_
 12	kardeşim	kardeş	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	13	nsubj	_	_
-13	olsaydı	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Past	18	nmod	_	SpaceAfter=No
+13	olsaydı	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Past	18	nmod	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	13	punct	_	_
 15	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	18	nsubj	_	_
 16	da	da	CCONJ	Conj	_	15	advmod:emph	_	_
@@ -3369,7 +3369,7 @@
 7	iki	iki	NUM	ANum	NumType=Card	8	nummod	_	_
 8	kalem	kalem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obl	_	_
 9	de	de	CCONJ	Conj	_	8	advmod:emph	_	_
-10	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	15	nmod	_	_
+10	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	15	nmod	_	_
 11	mutlaka	mutlaka	ADV	Adverb	_	14	advmod	_	_
 12	parmaklarını	parmak	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=2	14	obj	_	_
 13	avucuna	avuç	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	obl	_	_
@@ -3505,7 +3505,7 @@
 10	insan	insan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
 11	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	13	obl	_	_
 12	kadar	kadar	ADP	PCDat	_	11	case	_	_
-13	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	SpaceAfter=No
+13	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-0396
@@ -3557,15 +3557,15 @@
 # text = Hiç anlamasalar da, hiç bilmeseler de, hiç ilgilenmeseler de, neden, kadınlar bütün erkeklerin iş hayatlarını pürdikkat dinlerler.
 # Change 2.2/dev: revise POS tag of 'neden'
 1	Hiç	hiç	ADV	Adverb	_	2	advmod	_	_
-2	anlamasalar	anla	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	21	nmod	_	_
+2	anlamasalar	anla	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	21	nmod	_	_
 3	da	da	CCONJ	Conj	_	2	advmod:emph	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	2	punct	_	_
 5	hiç	hiç	ADV	Adverb	_	6	advmod	_	_
-6	bilmeseler	bil	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	2	conj	_	_
+6	bilmeseler	bil	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	2	conj	_	_
 7	de	de	CCONJ	Conj	_	6	advmod:emph	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	6	punct	_	_
 9	hiç	hiç	ADV	Adverb	_	10	advmod	_	_
-10	ilgilenmeseler	ilgilen	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	2	conj	_	_
+10	ilgilenmeseler	ilgilen	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	2	conj	_	_
 11	de	de	CCONJ	Conj	_	10	advmod:emph	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	10	punct	_	_
 13	neden	neden	ADV	Ques	_	21	advmod	_	SpaceAfter=No
@@ -3834,7 +3834,7 @@
 2	hangi	hangi	DET	Adj	_	3	det	_	_
 3	saatinde	saat	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 4	eve	ev	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
-5	dönsem	dön	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
+5	dönsem	dön	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 6	de	de	CCONJ	Conj	_	15	cc	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	15	punct	_	_
 8-9	yakındaki	_	_	_	_	_	_	_	_
@@ -4500,7 +4500,7 @@
 
 # sent_id = mst-0498
 # text = Kursanız bile sonunu çok başka bir biçimde bitirirsiniz.
-1	Kursanız	kur	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	2	nmod	_	_
+1	Kursanız	kur	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	2	nmod	_	_
 2	bile	bile	ADV	Adverb	_	8	advmod	_	_
 3	sonunu	son	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obj	_	_
 4	çok	çok	ADV	Adverb	_	5	advmod:emph	_	_
@@ -6993,7 +6993,7 @@
 5	onun	o	PRON	Pers	Case=Gen|Number=Sing|Person=3|PronType=Prs	6	nmod:poss	_	_
 6	yanlışlarına	yanlış	ADJ	NAdj	Case=Dat|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	7	amod	_	_
 7	ortak	ortak	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	12	amod	_	_
-8	olsaydım	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Past	7	compound:lvc	_	_
+8	olsaydım	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Past	7	compound:lvc	_	_
 9	kesinlikle	kesinlik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	12	obl	_	_
 10	bu	bu	DET	Det	_	11	det	_	_
 11	noktalarda	nokta	NOUN	Noun	Case=Loc|Number=Plur|Person=3	12	obl	_	_
@@ -7773,7 +7773,7 @@
 12	tartışacak	tartış	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	14	acl	_	_
 13	bir	bir	NUM	ANum	NumType=Card	14	det	_	_
 14	cesaretim	cesaret	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	15	nsubj	_	_
-15	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	20	nmod	_	_
+15	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	20	nmod	_	_
 16	zaten	zaten	ADV	Adverb	_	15	advmod	_	_
 17	hayatım	hayat	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	20	nsubj	_	_
 18	başka	başka	ADJ	Adj	_	19	det	_	_
@@ -8742,7 +8742,7 @@
 # sent_id = mst-0974
 # text = -İstemesen de gidelim.
 1	-	-	PUNCT	Punc	_	0	root	_	SpaceAfter=No
-2	İstemesen	iste	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	4	nmod	_	_
+2	İstemesen	iste	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	4	nmod	_	_
 3	de	de	CCONJ	Conj	_	2	advmod:emph	_	_
 4	gidelim	git	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
@@ -8870,7 +8870,7 @@
 11	li	li	ADP	With	_	10	case	_	_
 12	bir	bir	NUM	ANum	NumType=Card	13	det	_	_
 13	ad	ad	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	obl	_	_
-14	taksak	tak	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	13	compound	_	_
+14	taksak	tak	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	13	compound	_	_
 15	fena	fena	ADJ	Adj	_	17	amod	_	_
 16	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	15	advmod:emph	_	_
 17	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	nmod	_	_
@@ -9005,7 +9005,7 @@
 2	şimdiden	şimdiden	ADV	Adverb	_	4	advmod	_	_
 3	davetiyeleri	davetiye	NOUN	Noun	Case=Acc|Number=Plur|Person=3	4	obj	_	_
 4	yazıp	yaz	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	5	nmod	_	_
-5	dağıtsam	dağıt	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	1	conj	_	_
+5	dağıtsam	dağıt	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	1	conj	_	_
 6	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	5	aux:q	_	SpaceAfter=No
 7	?	?	PUNCT	Punc	_	5	punct	_	_
 
@@ -9419,7 +9419,7 @@
 # text = Durum böyle olsaydı, ona şu kentin en canlı yeri olan alandaki kahvelerden birinde rastlardım şimdiye kadar.
 1	Durum	durum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 2	böyle	böyle	ADV	Adverb	_	3	advmod	_	_
-3	olsaydı	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Past	16	nmod	_	SpaceAfter=No
+3	olsaydı	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Past	16	nmod	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	3	punct	_	_
 5	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	16	obl	_	_
 6	şu	şu	DET	Det	_	7	det	_	_
@@ -9498,7 +9498,7 @@
 
 # sent_id = mst-1055
 # text = Versem mi acaba? Yanlış bir şey yapmış olmayalım? diye sordu.
-1	Versem	ver	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
+1	Versem	ver	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 2	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	1	aux:q	_	_
 3	acaba	acaba	ADV	Adverb	_	4	advmod	_	SpaceAfter=No
 4	?	?	PUNCT	Punc	_	12	punct	_	_
@@ -9546,7 +9546,7 @@
 7	kadar	kadar	ADP	PCDat	_	6	case	_	_
 8	tam	tam	ADJ	Adj	_	10	amod	_	_
 9	olarak	olarak	ADP	PCNom	_	8	case	_	_
-10	bilemese	bil	VERB	Verb	Aspect=Perf|Mood=DesPot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	15	nmod	_	_
+10	bilemese	bil	VERB	Verb	Aspect=Perf|Mood=CndPot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	15	nmod	_	_
 11	de	de	CCONJ	Conj	_	10	mark	_	_
 12	Senem	Senem	PROPN	Prop	Case=Nom|Number=Sing|Person=3	15	nsubj	_	_
 13	başlarına	baş	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	15	obj	_	_
@@ -14402,7 +14402,7 @@
 # text = Pencerelerde ışık olsa gidip kapıyı çalacak mıydım, emin değildim.
 1	Pencerelerde	pencere	NOUN	Noun	Case=Loc|Number=Plur|Person=3	6	obl	_	_
 2	ışık	ışık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obl	_	_
-3	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	nmod	_	_
+3	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	nmod	_	_
 4	gidip	git	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	5	nmod	_	_
 5	kapıyı	kapı	NOUN	Noun	Case=Acc|Number=Sing|Person=3	6	obj	_	_
 6	çalacak	çal	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
@@ -14703,7 +14703,7 @@
 7	,	,	PUNCT	Punc	_	14	punct	_	_
 8	geçici	geçici	ADJ	Adj	_	14	amod	_	_
 9	de	de	CCONJ	Conj	_	8	advmod:emph	_	_
-10	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	compound:lvc	_	_
+10	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	compound:lvc	_	_
 11	yeter	yeter	ADJ	Adj	_	12	amod	_	_
 12	ki	ki	CCONJ	Conj	_	14	nmod	_	_
 13	deliği	delik	ADJ	NAdj	Case=Acc|Number=Sing|Person=3	14	obj	_	_
@@ -14984,7 +14984,7 @@
 10	söyledi	söyle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 11	,	,	PUNCT	Punc	_	15	punct	_	_
 12	yarın	yarın	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
-13	dönsem	dön	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	15	nmod	_	_
+13	dönsem	dön	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	15	nmod	_	_
 14	iyi	iyi	ADJ	Adj	_	15	amod	_	_
 15	olurmuş	ol	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	10	conj	_	SpaceAfter=No
 16	...	...	PUNCT	Punc	_	15	punct	_	_
@@ -16628,7 +16628,7 @@
 1	Kelime	kelime	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
 2	Rumca	Rumca	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	obl	_	_
 3	gibi	gibi	ADP	PCNom	_	2	case	_	_
-4	görünse	görün	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	nmod	_	_
+4	görünse	görün	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	nmod	_	_
 5	de	de	CCONJ	Conj	_	4	advmod:emph	_	_
 6	değil	değil	VERB	Neg	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
@@ -17777,7 +17777,7 @@
 12	tanıyor	tanı	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	5	conj	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	16	punct	_	_
 14	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	15	obj	_	_
-15	desem	de	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	16	nmod	_	_
+15	desem	de	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	16	nmod	_	_
 16	boş	boş	ADJ	Adj	_	5	conj	_	SpaceAfter=No
 17	,	,	PUNCT	Punc	_	20	punct	_	_
 18	inanılmaz	inan	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	19	acl	_	_
@@ -17896,7 +17896,7 @@
 18	içinde	iç	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	amod	_	_
 19	tutarlı	tutarlı	ADJ	Adj	_	21	amod	_	_
 20	da	da	CCONJ	Conj	_	19	advmod:emph	_	_
-21	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	27	nmod	_	_
+21	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	27	nmod	_	_
 22	mantıksal	mantıksal	ADJ	Adj	_	24	amod	_	_
 23	olarak	olarak	ADP	PCNom	_	22	case	_	_
 24-25	zayıftır	_	_	_	_	_	_	_	SpaceAfter=No
@@ -18107,7 +18107,7 @@
 20	anlatmaya	anlat	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	21	nmod	_	_
 21	başladık	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	23	obj	_	SpaceAfter=No
 22	...	...	PUNCT	Punc	_	21	punct	_	_
-23	dese	de	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	28	nmod	_	_
+23	dese	de	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	28	nmod	_	_
 24	diye	diye	ADP	PCNom	_	23	case	_	SpaceAfter=No
 25	,	,	PUNCT	Punc	_	23	punct	_	_
 26	sabırsızlana	sabırsızlan	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	28	nmod	_	_
@@ -18714,7 +18714,7 @@
 2	hiçbir	hiçbir	DET	Det	_	4	det	_	_
 3	şeye	şey	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	compound	_	_
 4	yaramadıklarını	yara	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	5	obj	_	_
-5	düşünsem	düşün	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	10	nmod	_	_
+5	düşünsem	düşün	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	10	nmod	_	_
 6	de	de	CCONJ	Conj	_	5	mark	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	5	punct	_	_
 8	yaşayabilmek	yaşa	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	10	nmod	_	_
@@ -19850,7 +19850,7 @@
 17	aynı	aynı	ADJ	Adj	_	18	amod	_	_
 18	haltı	halt	NOUN	Noun	Case=Acc|Number=Sing|Person=3	20	obj	_	_
 19	yiyeceğini	ye	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=2|Polarity=Pos|Tense=Fut|VerbForm=Part	18	compound	_	_
-20	bilsen	bil	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	24	nmod	_	_
+20	bilsen	bil	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	24	nmod	_	_
 21	bile	bile	ADV	Adverb	_	20	advmod:emph	_	_
 22	bir	bir	NUM	ANum	NumType=Card	23	det	_	_
 23	güvencen	güvence	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	24	nsubj	_	_
@@ -19924,7 +19924,7 @@
 # sent_id = mst-2200
 # text = Hiç konuşmasanız da aklınızdan geçirdiğiniz her şey duyulacak.
 1	Hiç	hiç	ADV	Adverb	_	2	advmod	_	_
-2	konuşmasanız	konuş	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	8	nmod	_	_
+2	konuşmasanız	konuş	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	8	nmod	_	_
 3	da	da	CCONJ	Conj	_	2	advmod:emph	_	_
 4	aklınızdan	akıl	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	5	obl	_	_
 5	geçirdiğiniz	geçir	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	6	acl	_	_
@@ -21118,7 +21118,7 @@
 2-3	hocayız	_	_	_	_	_	_	_	_
 2	hoca	hoca	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	ccomp	_	_
 3	yız	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Tense=Pres	2	cop	_	_
-4	desek	de	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	8	nmod	_	_
+4	desek	de	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	8	nmod	_	_
 5-6	Şüpheli	_	_	_	_	_	_	_	_
 5	Şüphe	şüphe	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	compound	_	_
 6	li	li	ADP	With	_	5	case	_	_
@@ -23034,7 +23034,7 @@
 # sent_id = mst-2562
 # text = Anneme sorsan hiç özlemediğini söyler; ama bence herkes birbirini arıyor.
 1	Anneme	anne	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	obl	_	_
-2	sorsan	sor	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	5	nmod	_	_
+2	sorsan	sor	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	5	nmod	_	_
 3	hiç	hiç	ADV	Adverb	_	4	advmod	_	_
 4	özlemediğini	özle	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	5	obj	_	_
 5	söyler	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
@@ -23840,7 +23840,7 @@
 # sent_id = mst-2640
 # text = Sesler değişse bile duyguların seslere kattığı tonlamalar değişmez, ne kadar saklamak isteseler de bunu beceremezler, bir köpekten kokularını saklayamayacakları gibi benden de seslerini saklayamazlardı.
 1	Sesler	ses	NOUN	Noun	Case=Nom|Number=Plur|Person=3	2	nsubj	_	_
-2	değişse	değiş	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	_
+2	değişse	değiş	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	_
 3	bile	bile	ADV	Adverb	_	2	advmod:emph	_	_
 4	duyguların	duygu	NOUN	Noun	Case=Gen|Number=Plur|Person=3	6	nmod:poss	_	_
 5	seslere	ses	NOUN	Noun	Case=Dat|Number=Plur|Person=3	6	obl	_	_
@@ -23851,7 +23851,7 @@
 10	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	13	obl	_	_
 11	kadar	kadar	ADP	PCDat	_	10	case	_	_
 12	saklamak	sakla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	13	obj	_	_
-13	isteseler	iste	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	16	nmod	_	_
+13	isteseler	iste	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	16	nmod	_	_
 14	de	de	CCONJ	Conj	_	13	mark	_	_
 15	bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	16	obj	_	_
 16	beceremezler	becer	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	8	conj	_	SpaceAfter=No
@@ -25257,7 +25257,7 @@
 5	onun	o	PRON	Pers	Case=Gen|Number=Sing|Person=3|PronType=Prs	6	nmod:poss	_	_
 6	yanlışlarına	yanlış	ADJ	NAdj	Case=Dat|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	7	amod	_	_
 7	ortak	ortak	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	12	amod	_	_
-8	olsaydım	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Past	7	compound:lvc	_	_
+8	olsaydım	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Past	7	compound:lvc	_	_
 9	kesinlikle	kesinlik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	12	obl	_	_
 10	bu	bu	DET	Det	_	11	det	_	_
 11	noktalarda	nokta	NOUN	Noun	Case=Loc|Number=Plur|Person=3	12	obl	_	_
@@ -26246,7 +26246,7 @@
 4	yaşamsal	yaşamsal	ADJ	Adj	_	5	amod	_	_
 5	sorunlardan	sorun	NOUN	Noun	Case=Abl|Number=Plur|Person=3	6	nmod:poss	_	_
 6	biri	biri	PRON	Quant	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	2	conj	_	_
-7	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	obj	_	_
+7	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	obj	_	_
 8	mesele	mesele	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
 9	yok	yok	ADJ	Adj	_	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
@@ -27959,7 +27959,7 @@
 9	yapan	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	12	nsubj	_	_
 10	mimar	mimar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
 11	da	da	CCONJ	Conj	_	10	advmod:emph	_	_
-12	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	24	nmod	_	SpaceAfter=No
+12	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	24	nmod	_	SpaceAfter=No
 13	-	-	PUNCT	Punc	_	12	punct	_	SpaceAfter=No
 14	o	o	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	15	det	_	_
 15	başkalarının	başka	ADJ	NAdj	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	19	nmod:poss	_	SpaceAfter=No
@@ -28027,7 +28027,7 @@
 
 # sent_id = mst-3122
 # text = Evlenseydiniz, bak nasıl üstüne titrer, çekip çevirirdi seni.
-1	Evlenseydiniz	evlen	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=2|Polarity=Pos|Tense=Past	3	nmod	_	SpaceAfter=No
+1	Evlenseydiniz	evlen	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Past	3	nmod	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	1	punct	_	_
 3	bak	bak	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	_
 4	nasıl	nasıl	ADV	Adverb	_	5	advmod	_	_
@@ -28198,7 +28198,7 @@
 2	,	,	PUNCT	Punc	_	9	punct	_	_
 3	geçmişte	geçmiş	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	5	amod	_	_
 4	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	5	obl	_	_
-5	varsa	var	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	obj	_	_
+5	varsa	var	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	obj	_	_
 6	güzel	güzel	ADJ	Adj	_	7	amod	_	_
 7	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	acl	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	7	punct	_	_
@@ -28536,7 +28536,7 @@
 2	sürekli	sürekli	ADV	Adverb	_	4	advmod	_	_
 3	tekrarladığınızı	tekrarla	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	4	obj	_	_
 4	fark	fark	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
-5	etseler	et	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	4	compound:lvc	_	_
+5	etseler	et	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	4	compound:lvc	_	_
 6	bile	bile	ADV	Adverb	_	9	advmod	_	_
 7	utangaç	utangaç	ADJ	Adj	_	8	nmod:poss	_	_
 8	ifadelerini	ifade	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	9	obj	_	_
@@ -29113,8 +29113,8 @@
 1	Ailesinden	aile	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	obl	_	_
 2	kalan	kal	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	acl	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	2	punct	_	_
-4	harcasa	harca	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	nmod	_	_
-5	harcasa	harca	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	compound:redup	_	_
+4	harcasa	harca	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	nmod	_	_
+5	harcasa	harca	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	compound:redup	_	_
 6	bitiremeyeceği	bitir	VERB	Verb	Aspect=Perf|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Fut|VerbForm=Part	8	acl	_	_
 7	kadar	kadar	ADP	PCDat	_	6	case	_	_
 8	çok	çok	ADJ	Adj	_	9	det	_	_
@@ -29357,7 +29357,7 @@
 20	(	(	PUNCT	Punc	_	23	punct	_	SpaceAfter=No
 21	eğer	eğer	CCONJ	Conj	_	23	advmod:emph	_	_
 22	bugün	bugün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	obl	_	_
-23	yaşasa	yaşa	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	31	parataxis	_	SpaceAfter=No
+23	yaşasa	yaşa	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	31	parataxis	_	SpaceAfter=No
 24	)	)	PUNCT	Punc	_	23	punct	_	_
 25	George	George	PROPN	Prop	Case=Nom|Number=Sing|Person=3	17	conj	_	_
 26	Politzer'in	Politzer	PROPN	Prop	Case=Gen|Number=Sing|Person=3	25	flat	_	_
@@ -29365,7 +29365,7 @@
 28	paralel	paralel	ADJ	Adj	_	30	amod	_	_
 29	bir	bir	NUM	ANum	NumType=Card	30	det	_	_
 30	bağlantıyla	bağlantı	NOUN	Noun	Case=Ins|Number=Sing|Person=3	31	obl	_	_
-31	bağlansa	bağla	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	48	nmod	_	SpaceAfter=No
+31	bağlansa	bağla	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	48	nmod	_	SpaceAfter=No
 32	,	,	PUNCT	Punc	_	31	punct	_	_
 33-34	kazadaki	_	_	_	_	_	_	_	_
 33	kazada	kaza	NOUN	Noun	Case=Loc|Number=Sing|Person=3	35	nmod	_	_
@@ -29721,7 +29721,7 @@
 2	kıçlarını	kıç	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
 3	kaldırma	kaldırma	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 4	zahmetine	zahmet	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
-5	katlansalardı	katlan	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=3|Polarity=Pos|Tense=Past	1	conj	_	_
+5	katlansalardı	katlan	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Past	1	conj	_	_
 6	kendilerine	kendi	PRON	Reflex	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|Reflex=Yes	7	obl	_	_
 7	bıraktığım	bırak	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	8	acl	_	_
 8	dosyada	dosya	NOUN	Noun	Case=Loc|Number=Sing|Person=3	9	obl	_	_
@@ -30688,9 +30688,9 @@
 2	,	,	PUNCT	Punc	_	18	punct	_	_
 3	"	"	PUNCT	Punc	_	16	punct	_	_
 4	BDDK	Bddk	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
-5	istese	iste	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	16	nmod	_	_
+5	istese	iste	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	16	nmod	_	_
 6	de	de	CCONJ	Conj	_	5	advmod:emph	_	_
-7	istemese	iste	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	5	conj	_	_
+7	istemese	iste	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	5	conj	_	_
 8	de	de	CCONJ	Conj	_	7	advmod:emph	_	_
 9	kamuda	kamu	NOUN	Noun	Case=Loc|Number=Sing|Person=3	10	obl	_	_
 10	rahatlama	rahatla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	14	nmod	_	_
@@ -31171,7 +31171,7 @@
 18	görüşlerinin	görüş	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	20	nmod:poss	_	_
 19	bir	bir	NUM	ANum	NumType=Card	20	det	_	_
 20	yansıması	yansı	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	21	obj	_	_
-21	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	22	obj	_	_
+21	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	22	obj	_	_
 22	gerek	gerek	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 23	.	.	PUNCT	Punc	_	22	punct	_	_
 
@@ -31399,7 +31399,7 @@
 3	süre	süre	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound	_	_
 4	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	2	cop	_	_
 5	nereye	nere	PRON	Ques	Case=Dat|Number=Sing|Person=3	6	obl	_	_
-6	baksam	bak	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	9	nmod	_	_
+6	baksam	bak	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	9	nmod	_	_
 7	Tibet'in	Tibet	PROPN	Prop	Case=Gen|Number=Sing|Person=3	8	nmod:poss	_	_
 8	gözlerini	göz	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	9	obj	_	_
 9	görüyorum	gör	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
@@ -32210,7 +32210,7 @@
 4	sinirleri	sinir	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	7	nsubj	_	_
 5	kaç	kaç	NUM	Adj	NumType=Card	6	nummod	_	_
 6	kişiye	kişi	NOUN	Noun	Case=Dat|Number=Sing|Person=3	7	obl	_	_
-7	bağlansa	bağla	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	19	nmod	_	_
+7	bağlansa	bağla	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	19	nmod	_	_
 8	bunların	bu	PRON	Demons	Case=Gen|Number=Plur|Person=3|PronType=Dem	9	nmod:poss	_	_
 9	hepsi	hepsi	PRON	Quant	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	19	nsubj	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	19	punct	_	_
@@ -33394,7 +33394,7 @@
 1	Geleceğe	gelecek	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	4	amod	_	_
 2	dair	dair	ADP	PCDat	_	1	case	_	_
 3	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	4	obj	_	_
-4	varsa	var	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	nsubj	_	_
+4	varsa	var	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	nsubj	_	_
 5	yükte	yük	NOUN	Noun	Case=Loc|Number=Sing|Person=3	11	nmod	_	_
 6	hafif	hafif	ADJ	Adj	_	5	compound	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	11	punct	_	_
@@ -34828,7 +34828,7 @@
 2	durum	durum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
 3	aykırı	aykırı	ADJ	Adj	_	5	amod	_	_
 4	da	da	CCONJ	Conj	_	3	advmod:emph	_	_
-5	gelse	gel	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	SpaceAfter=No
+5	gelse	gel	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	5	punct	_	_
 7	bir	bir	NUM	ANum	NumType=Card	8	det	_	_
 8-9	olgudur	_	_	_	_	_	_	_	_
@@ -37621,7 +37621,7 @@
 # sent_id = mst-4203
 # text = Nasıl anlatsam bilemiyorum, ama seviniyordum.
 1	Nasıl	nasıl	ADV	Adverb	_	2	advmod	_	_
-2	anlatsam	anlat	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	nmod	_	_
+2	anlatsam	anlat	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	nmod	_	_
 3	bilemiyorum	bil	VERB	Verb	Aspect=Prog|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	6	punct	_	_
 5	ama	ama	CCONJ	Conj	_	6	cc	_	_
@@ -38560,13 +38560,13 @@
 # text = Üçümüz birden girsek, dedi Miskoye, sen konuşsan.
 1	Üçümüz	üç	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Plur|NumType=Card|Person=3|Person[psor]=1	3	nsubj	_	_
 2	birden	birden	ADV	Adverb	_	3	advmod	_	_
-3	girsek	gir	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	5	obj	_	SpaceAfter=No
+3	girsek	gir	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	5	obj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	3	punct	_	_
 5	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 6	Miskoye	Miskoye	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nsubj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	5	punct	_	_
 8	sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	9	nsubj	_	_
-9	konuşsan	konuş	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	5	conj	_	SpaceAfter=No
+9	konuşsan	konuş	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	5	conj	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-4295
@@ -39080,7 +39080,7 @@
 13	hayatta	hayat	NOUN	Noun	Case=Loc|Number=Sing|Person=3	16	obl	_	_
 14	bir	bir	NUM	ANum	NumType=Card	15	det	_	_
 15	çift	çift	ADJ	Adj	_	16	obj	_	_
-16	oluşturmasalar	oluş	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=3|Polarity=Neg|Tense=Pres|Voice=Cau	8	nmod	_	_
+16	oluşturmasalar	oluş	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=3|Polarity=Neg|Tense=Pres|Voice=Cau	8	nmod	_	_
 17	bile	bile	ADV	Adverb	_	16	advmod:emph	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	16	punct	_	_
 
@@ -39255,7 +39255,7 @@
 6	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	5	aux:q	_	_
 7	geçecek	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	21	obj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	17	punct	_	_
-9	geçse	geç	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	17	nmod	_	_
+9	geçse	geç	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	17	nmod	_	_
 10	bile	bile	ADV	Adverb	_	9	advmod	_	_
 11	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	17	obl	_	_
 12	her	her	DET	Det	_	17	obl	_	_
@@ -39605,7 +39605,7 @@
 10	bu	bu	DET	Det	_	12	det	_	_
 11	zeka	zeka	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nmod:poss	_	_
 12	pırıltılarını	pırıltı	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	13	obj	_	_
-13	eleştirse	eleştir	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
+13	eleştirse	eleştir	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 14	de	de	CCONJ	Conj	_	13	advmod:emph	_	SpaceAfter=No
 15	:	:	PUNCT	Punc	_	13	punct	_	SpaceAfter=No
 16	...	...	PUNCT	Punc	_	13	punct	_	_
@@ -40098,7 +40098,7 @@
 10	başka	başka	ADJ	Adj	_	11	amod	_	_
 11	bir	bir	NUM	ANum	NumType=Card	9	obj	_	_
 12	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	compound	_	_
-13	koysa	koy	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	compound	_	_
+13	koysa	koy	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	compound	_	_
 14	da	da	CCONJ	Conj	_	9	advmod:emph	_	_
 15	o	o	DET	Det	_	16	det	_	_
 16	şeyi	şey	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	obj	_	_
@@ -40350,7 +40350,7 @@
 # sent_id = mst-4486
 # text = Sinek uçsa vızıltısı duyulacaktı.
 1	Sinek	sinek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
-2	uçsa	uç	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	nmod	_	_
+2	uçsa	uç	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	nmod	_	_
 3	vızıltısı	vızıltı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
 4	duyulacaktı	duy	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past|Voice=Pass	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
@@ -42781,7 +42781,7 @@
 5	duran	dur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	12	acl	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	10	punct	_	_
 7	dönüp	dön	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	8	nmod	_	_
-8	baksam	bak	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	10	nmod	_	_
+8	baksam	bak	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	10	nmod	_	_
 9	benim	ben	PRON	Pers	Case=Gen|Number=Sing|Person=1|PronType=Prs	10	nmod	_	_
 10	göremeyeceğim	gör	VERB	Verb	Aspect=Perf|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Fut	5	conj	_	_
 11	bir	bir	NUM	ANum	NumType=Card	12	det	_	_
@@ -42803,7 +42803,7 @@
 4	yüz	yüz	NUM	ANum	NumType=Card	7	obj	_	_
 5	bin	bin	NUM	ANum	NumType=Card	4	flat	_	_
 6	lira	lira	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	flat	_	_
-7	kazansam	kazan	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	14	nmod	_	SpaceAfter=No
+7	kazansam	kazan	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	14	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	kış	kış	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obj	_	_
 10	gelene	gel	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	14	acl	_	_
@@ -42823,7 +42823,7 @@
 4	onun	o	PRON	Pers	Case=Gen|Number=Sing|Person=3|PronType=Prs	5	nmod:poss	_	_
 5	yanlışlarına	yanlış	ADJ	NAdj	Case=Dat|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	6	amod	_	_
 6	ortak	ortak	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	11	amod	_	_
-7	olsaydım	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Past	6	compound:lvc	_	_
+7	olsaydım	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Past	6	compound:lvc	_	_
 8	kırk	kırk	NUM	ANum	NumType=Card	9	nummod	_	_
 9	defa	defa	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obl	_	_
 10	bakan	bakan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obj	_	_
@@ -42951,10 +42951,10 @@
 # sent_id = mst-4807
 # text = Siz olmasanız, ben olmasam, yani nasıl...
 1	Siz	siz	PRON	Pers	Case=Nom|Number=Plur|Person=2|PronType=Prs	2	nsubj	_	_
-2	olmasanız	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
+2	olmasanız	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	5	punct	_	_
 4	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
-5	olmasam	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	2	conj	_	SpaceAfter=No
+5	olmasam	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	2	conj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	5	punct	_	_
 7	yani	yani	CCONJ	Conj	_	2	conj	_	_
 8	nasıl	nasıl	ADV	Adverb	_	7	conj	_	SpaceAfter=No
@@ -43641,7 +43641,7 @@
 2	bu	bu	DET	Det	_	3	det	_	_
 3	bakışın	bakış	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
 4	farkında	fark	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nmod	_	_
-5	olmasalar	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	4	compound:lvc	_	_
+5	olmasalar	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	4	compound:lvc	_	_
 6	da	da	CCONJ	Conj	_	4	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	9	punct	_	_
 8	Recep	Recep	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
@@ -46070,7 +46070,7 @@
 1	Ara	ara	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	4	amod	_	_
 2	sıra	sıra	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound:redup	_	_
 3	temizliği	temizlik	NOUN	Noun	Case=Acc|Number=Sing|Person=3	4	obj	_	_
-4	aksatsa	aksa	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	11	nmod	_	_
+4	aksatsa	aksa	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	11	nmod	_	_
 5	da	da	CCONJ	Conj	_	4	advmod:emph	_	_
 6	kendisine	kendi	PRON	Reflex	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	9	obl	_	_
 7	hep	hep	ADV	Adverb	_	9	advmod	_	_
@@ -46485,9 +46485,9 @@
 9	dinleyici	dinleyici	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod:poss	_	_
 10	sıralarına	sıra	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	12	obl	_	_
 11	parmağını	parmak	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	obj	_	_
-12	uzatsa	uza	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	8	conj	_	_
+12	uzatsa	uza	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	8	conj	_	_
 13	ve	ve	CCONJ	Conj	_	14	cc	_	_
-14	sorsa	sor	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	conj	_	SpaceAfter=No
+14	sorsa	sor	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	conj	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-5229
@@ -46721,7 +46721,7 @@
 2	ki	ki	ADP	Rel	_	1	case	_	_
 3	adam	adam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 4	komaya	koma	NOUN	Noun	Case=Dat|Number=Sing|Person=3	8	nmod	_	_
-5	girse	gir	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	compound	_	SpaceAfter=No
+5	girse	gir	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	compound	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	8	punct	_	_
 7	hepsi	hepsi	PRON	Quant	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	8	nsubj	_	_
 8	komaya	koma	NOUN	Noun	Case=Dat|Number=Sing|Person=3	0	root	_	_
@@ -46732,7 +46732,7 @@
 # text = Tanışmadınız, görsen şaşarsın, çok zeki, anlayışlı ama...
 1	Tanışmadınız	tanış	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	4	punct	_	_
-3	görsen	gör	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	4	nmod	_	_
+3	görsen	gör	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	4	nmod	_	_
 4	şaşarsın	şaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	7	punct	_	_
 6	çok	çok	ADV	Adverb	_	7	advmod	_	_
@@ -47472,6 +47472,7 @@
 
 # sent_id = mst-5355
 # text = Ya dayak yerseniz, ya karakola gidersiniz.
+# NOTE: this example has a type, carried over from the original text.
 1	Ya	ya	CCONJ	Conj	_	3	nmod	_	_
 2	dayak	dayak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 3	yerseniz	ye	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
@@ -47533,7 +47534,7 @@
 # sent_id = mst-5360
 # text = Nereye yönelsem arkamdan yetişiyordu, Sen kömür sobasını beceremezsin, yan odadan elektrikli zamazingoyu al, dolaptaki rakı çok soğuktur, en iyisi yattığım odanın aç kapısını, bak hemen kapının arkasında, kap gel...
 1	Nereye	nere	PRON	Ques	Case=Dat|Number=Sing|Person=3	2	obl	_	_
-2	yönelsem	yönel	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	4	nmod	_	_
+2	yönelsem	yönel	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	4	nmod	_	_
 3	arkamdan	arka	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	4	amod	_	_
 4	yetişiyordu	yetiş	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	9	punct	_	_
@@ -47710,7 +47711,7 @@
 3	argoyla	argo	NOUN	Noun	Case=Ins|Number=Sing|Person=3	4	nmod	_	_
 4	karışık	karışık	ADJ	Adj	_	6	amod	_	_
 5	da	da	CCONJ	Conj	_	4	advmod:emph	_	_
-6	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	23	nmod	_	SpaceAfter=No
+6	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	23	nmod	_	SpaceAfter=No
 7	-	-	PUNCT	Punc	_	6	punct	_	SpaceAfter=No
 8	ki	ki	CCONJ	Conj	_	16	nmod	_	_
 9	bu	bu	DET	Det	_	16	nsubj	_	SpaceAfter=No
@@ -48583,7 +48584,7 @@
 5	uygunsuz	uygunsuz	ADJ	Adj	_	7	amod	_	_
 6	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
 7	ilişki	ilişki	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
-8	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	10	nmod	_	SpaceAfter=No
+8	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	10	nmod	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10	gözünden	göz	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 11	asla	asla	ADV	Adverb	_	10	advmod	_	_
@@ -48661,14 +48662,14 @@
 # sent_id = mst-5460
 # text = Israr etseydin bize, daha güzel bir isim önerseydin!..
 1	Israr	ısrar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	etseydin	et	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Pos|Tense=Past	1	compound:lvc	_	_
+2	etseydin	et	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Past	1	compound:lvc	_	_
 3	bize	biz	PRON	Pers	Case=Dat|Number=Plur|Person=1|PronType=Prs	1	nmod	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	1	punct	_	_
 5	daha	daha	ADV	Adverb	_	6	advmod	_	_
 6	güzel	güzel	ADJ	Adj	_	8	amod	_	_
 7	bir	bir	NUM	ANum	NumType=Card	8	det	_	_
 8	isim	isim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
-9	önerseydin	öner	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
+9	önerseydin	öner	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
 10	!	!	PUNCT	Punc	_	9	punct	_	SpaceAfter=No
 11	..	..	PUNCT	Punc	_	9	punct	_	_
 
@@ -48831,7 +48832,7 @@
 15	,	,	PUNCT	Punc	_	13	punct	_	_
 16	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	18	advmod:emph	_	_
 17	de	de	CCONJ	Conj	_	16	advmod:emph	_	_
-18	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	13	conj	_	_
+18	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	13	conj	_	_
 19	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	22	nsubj	_	_
 20	artık	artık	ADV	Adverb	_	22	advmod	_	_
 21	evimizin	ev	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	22	nmod:poss	_	_
@@ -49302,7 +49303,7 @@
 # sent_id = mst-5537
 # text = Nereye dokunsam altın ışıklar saçılıyordu zarif kol hareketlerimden.
 1	Nereye	nere	PRON	Ques	Case=Dat|Number=Sing|Person=3	2	obl	_	_
-2	dokunsam	dokun	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	5	nmod	_	_
+2	dokunsam	dokun	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	5	nmod	_	_
 3	altın	altın	ADJ	Adj	_	4	amod	_	_
 4	ışıklar	ışık	NOUN	Noun	Case=Nom|Number=Plur|Person=3	5	nsubj	_	_
 5	saçılıyordu	saç	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Pass	0	root	_	_
@@ -49745,7 +49746,7 @@
 2	,	,	PUNCT	Punc	_	10	punct	_	_
 3	incecik	incecik	ADJ	Adj	_	5	amod	_	_
 4	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
-5	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	_
+5	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	_
 6	altın	altın	ADJ	Adj	_	7	amod	_	_
 7	bilezik	bilezik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
 8	alabiliriz	al	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	10	obj	_	SpaceAfter=No

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -3100,21 +3100,20 @@
 
 # sent_id = mst-0357
 # text = Ne kadar ürkütücü ve bir o kadar da çekici bir yer orası.
+# Change 2.2/dev: merge -(y)IcI
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	3	obl	_	_
 2	kadar	kadar	ADP	PCNom	_	1	case	_	_
-3-4	ürkütücü	_	_	_	_	_	_	_	_
-3	ürküt	ürküt	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	12	nmod	_	_
-4	ücü	ci	ADP	Agt	_	3	case	_	_
-5	ve	ve	CCONJ	Conj	_	3	cc	_	_
-6	bir	bir	ADV	Adverb	_	7	advmod	_	_
-7	o	o	DET	Det	_	10	det	_	_
-8	kadar	kadar	ADP	PCNom	_	7	case	_	_
-9	da	da	CCONJ	Conj	_	7	advmod:emph	_	_
-10	çekici	çekici	ADJ	Adj	_	12	amod	_	_
-11	bir	bir	NUM	ANum	NumType=Card	12	det	_	_
-12	yer	yer	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-13	orası	ora	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	nsubj	_	SpaceAfter=No
-14	.	.	PUNCT	Punc	_	12	punct	_	_
+3	ürkütücü	ürk	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	11	acl	_	_
+4	ve	ve	CCONJ	Conj	_	3	cc	_	_
+5	bir	bir	ADV	Adverb	_	6	advmod	_	_
+6	o	o	DET	Det	_	9	det	_	_
+7	kadar	kadar	ADP	PCNom	_	6	case	_	_
+8	da	da	CCONJ	Conj	_	6	advmod:emph	_	_
+9	çekici	çekici	ADJ	Adj	_	11	amod	_	_
+10	bir	bir	NUM	ANum	NumType=Card	11	det	_	_
+11	yer	yer	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
+12	orası	ora	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	nsubj	_	SpaceAfter=No
+13	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-0358
 # text = Hele bunlar erkek ve kadınsa...
@@ -6088,13 +6087,12 @@
 
 # sent_id = mst-0695
 # text = Can sıkıcı bir iş.
-1	Can	can	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod	_	_
-2-3	sıkıcı	_	_	_	_	_	_	_	_
-2	sık	sık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	1	compound	_	_
-3	ıcı	ci	ADP	Agt	_	1	case	_	_
-4	bir	bir	NUM	ANum	NumType=Card	5	det	_	_
-5	iş	iş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	5	punct	_	_
+# Change 2.2/dev: merge -(y)IcI
+1	Can	can	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod	_	_
+2	sıkıcı	sık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	1	compound	_	_
+3	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
+4	iş	iş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
+5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-0696
 # text = Sanırım gezmediği ülke, danışmanı olmadığı kimse, bilmediği ilke kalmadı.
@@ -10579,9 +10577,10 @@
 
 # sent_id = mst-1181
 # text = Hükümetin hedefleri tutturabilmek için önümüzdeki yaklaşık on günlük süreçte yeni gelir artırıcı veya harcama azaltıcı tedbir paketleri hazırlaması gerekiyor.
-1	Hükümetin	hükümet	NOUN	Noun	Case=Gen|Number=Sing|Person=3	21	nmod:poss	_	_
+# Change 2.2/dev: merge -(y)IcI
+1	Hükümetin	hükümet	NOUN	Noun	Case=Gen|Number=Sing|Person=3	19	nmod:poss	_	_
 2	hedefleri	hedef	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
-3	tutturabilmek	tut	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	22	nmod	_	_
+3	tutturabilmek	tut	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	20	nmod	_	_
 4	için	için	ADP	PCNom	_	3	case	_	_
 5-6	önümüzdeki	_	_	_	_	_	_	_	_
 5	önümüzde	ön	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	9	amod	_	_
@@ -10589,22 +10588,18 @@
 7	yaklaşık	yaklaşık	ADJ	Adj	_	9	amod	_	_
 8	on	on	NUM	ANum	NumType=Card	9	nummod	_	_
 9	günlük	günlük	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	10	compound	_	_
-10	süreçte	süreç	NOUN	Noun	Case=Loc|Number=Sing|Person=3	22	obl	_	_
+10	süreçte	süreç	NOUN	Noun	Case=Loc|Number=Sing|Person=3	20	obl	_	_
 11	yeni	yeni	ADJ	Adj	_	12	amod	_	_
 12	gelir	gelir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obj	_	_
-13-14	artırıcı	_	_	_	_	_	_	_	_
-13	artır	artır	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	20	nmod	_	_
-14	ıcı	ci	ADP	Agt	_	13	case	_	_
-15	veya	veya	CCONJ	Conj	_	17	cc	_	_
-16	harcama	harca	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	17	compound	_	_
-17-18	azaltıcı	_	_	_	_	_	_	_	_
-17	azalt	azal	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|Voice=Cau	13	conj	_	_
-18	ıcı	ci	ADP	Agt	_	17	case	_	_
-19	tedbir	tedbir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nmod:poss	_	_
-20	paketleri	paket	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	21	obj	_	_
-21	hazırlaması	hazırla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	22	nsubj	_	_
-22	gerekiyor	gerek	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
-23	.	.	PUNCT	Punc	_	22	punct	_	_
+13	artırıcı	art	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	18	acl	_	_
+14	veya	veya	CCONJ	Conj	_	16	cc	_	_
+15	harcama	harca	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	16	compound	_	_
+16	azaltıcı	azal	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	12	conj	_	_
+17	tedbir	tedbir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nmod:poss	_	_
+18	paketleri	paket	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	19	obj	_	_
+19	hazırlaması	hazırla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	20	nsubj	_	_
+20	gerekiyor	gerek	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
+21	.	.	PUNCT	Punc	_	20	punct	_	_
 
 # sent_id = mst-1182
 # text = Okyanus ötesine...
@@ -12574,6 +12569,7 @@
 
 # sent_id = mst-1419
 # text = Niye mutsuz olduklarını ise söylemezlerdi, mutsuzluklarının nedenini siz keşfetmek zorundaydınız, bunu keşfedemezseniz biraz daha düşmanlaşırlardı; bu düşmanlık gerçek değildi, yalnızca mutsuzluklarının üstüne örtmeye çalıştıkları yakıcı bir örtüydü.
+# Change 2.2/dev: merge -(y)IcI
 1	Niye	niye	ADV	Adverb	_	3	advmod	_	_
 2	mutsuz	mutsuz	ADJ	Adj	_	3	amod	_	_
 3	olduklarını	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	5	obj	_	_
@@ -12595,23 +12591,21 @@
 18	düşmanlaşırlardı	düşmanlaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=AorPast	5	conj	_	SpaceAfter=No
 19	;	;	PUNCT	Punc	_	22	punct	_	_
 20	bu	bu	DET	Det	_	21	det	_	_
-21	düşmanlık	düşmanlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	33	nsubj	_	_
+21	düşmanlık	düşmanlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	32	nsubj	_	_
 22	gerçek	gerçek	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	5	conj	_	_
 23	değildi	değil	VERB	Neg	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	22	cop	_	SpaceAfter=No
-24	,	,	PUNCT	Punc	_	33	punct	_	_
-25	yalnızca	yalnızca	ADV	Adverb	_	33	advmod	_	_
+24	,	,	PUNCT	Punc	_	32	punct	_	_
+25	yalnızca	yalnızca	ADV	Adverb	_	32	advmod	_	_
 26	mutsuzluklarının	mutsuzluk	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	27	nmod:poss	_	_
 27	üstüne	üst	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	28	amod	_	_
 28	örtmeye	ört	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	29	nmod	_	_
-29	çalıştıkları	çalış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	33	acl	_	_
-30-31	yakıcı	_	_	_	_	_	_	_	_
-30	yak	yak	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	33	nmod	_	_
-31	ıcı	ci	ADP	Agt	_	30	case	_	_
-32	bir	bir	NUM	ANum	NumType=Card	33	det	_	_
-33-34	örtüydü	_	_	_	_	_	_	_	SpaceAfter=No
-33	örtü	örtü	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	conj	_	_
-34	ydü	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	33	cop	_	_
-35	.	.	PUNCT	Punc	_	33	punct	_	_
+29	çalıştıkları	çalış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	32	acl	_	_
+30	yakıcı	yak	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	32	acl	_	_
+31	bir	bir	NUM	ANum	NumType=Card	32	det	_	_
+32-33	örtüydü	_	_	_	_	_	_	_	SpaceAfter=No
+32	örtü	örtü	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	conj	_	_
+33	ydü	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	32	cop	_	_
+34	.	.	PUNCT	Punc	_	32	punct	_	_
 
 # sent_id = mst-1421
 # text = Kurtulmak istemiyorum.
@@ -12996,21 +12990,20 @@
 
 # sent_id = mst-1450
 # text = Mali Barış'tan yararlanacakların hürriyeti bağlayıcı cezalarla ilgili düzenlemeler karşısında sorumlulukları devam etmeli.
+# Change 2.2/dev: merge -(y)IcI
 1	Mali	mali	ADJ	Adj	_	3	amod	_	_
 2	Barış'tan	Barış	PROPN	Prop	Case=Abl|Number=Sing|Person=3	1	compound	_	_
-3	yararlanacakların	yararlan	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	11	nmod:poss	_	_
+3	yararlanacakların	yararlan	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	10	nmod:poss	_	_
 4	hürriyeti	hürriyet	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
-5-6	bağlayıcı	_	_	_	_	_	_	_	_
-5	bağla	bağla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	7	nmod	_	_
-6	yıcı	ci	ADP	Agt	_	5	case	_	_
-7	cezalarla	ceza	NOUN	Noun	Case=Ins|Number=Plur|Person=3	8	nmod	_	_
-8	ilgili	ilgili	ADJ	Adj	_	9	amod	_	_
-9	düzenlemeler	düzenle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	10	nmod:poss	_	_
-10	karşısında	karşı	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	amod	_	_
-11	sorumlulukları	sorumluluk	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	12	nsubj	_	_
-12	devam	devam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-13	etmeli	et	VERB	Verb	Aspect=Perf|Mood=Nec|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	12	compound:lvc	_	SpaceAfter=No
-14	.	.	PUNCT	Punc	_	12	punct	_	_
+5	bağlayıcı	bağla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	acl	_	_
+6	cezalarla	ceza	NOUN	Noun	Case=Ins|Number=Plur|Person=3	7	nmod	_	_
+7	ilgili	ilgili	ADJ	Adj	_	8	amod	_	_
+8	düzenlemeler	düzenle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	nmod:poss	_	_
+9	karşısında	karşı	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	amod	_	_
+10	sorumlulukları	sorumluluk	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	11	nsubj	_	_
+11	devam	devam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
+12	etmeli	et	VERB	Verb	Aspect=Perf|Mood=Nec|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	compound:lvc	_	SpaceAfter=No
+13	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-1452
 # text = Dolaştığın o itler var ya, o itler; onlar da seyirci...
@@ -13378,15 +13371,14 @@
 
 # sent_id = mst-1493
 # text = Evet, ürkütücü, dedi Kerem.
+# Change 2.2/dev: merge -(y)IcI
 1	Evet	evet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	3	punct	_	_
-3-4	ürkütücü	_	_	_	_	_	_	_	SpaceAfter=No
-3	ürküt	ürküt	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	6	nsubj	_	_
-4	ücü	ci	ADP	Agt	_	3	case	_	_
-5	,	,	PUNCT	Punc	_	3	punct	_	_
-6	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
-7	Kerem	Kerem	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nsubj	_	SpaceAfter=No
-8	.	.	PUNCT	Punc	_	6	punct	_	_
+3	ürkütücü	ürk	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	5	ccomp	_	SpaceAfter=No
+4	,	,	PUNCT	Punc	_	3	punct	_	_
+5	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+6	Kerem	Kerem	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nsubj	_	SpaceAfter=No
+7	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1495
 # text = Tamam oğlum, haydi çık sudan, diye yineledi Recep, çocuğun pantolonuna doğru giderken.
@@ -14325,21 +14317,20 @@
 
 # sent_id = mst-1601
 # text = Ama belki de o kadar kuşku yaratıcı bir durum değildir onun durumu.
-1	Ama	ama	CCONJ	Conj	_	0	root	_	_
+# Change 2.2/dev: merge -(y)IcI
+1	Ama	ama	CCONJ	Conj	_	10	cc	_	_
 2	belki	belki	ADV	Adverb	_	11	advmod	_	_
 3	de	de	CCONJ	Conj	_	2	advmod:emph	_	_
 4	o	o	DET	Det	_	6	det	_	_
 5	kadar	kadar	ADP	PCDat	_	4	case	_	_
 6	kuşku	kuşku	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
-7-8	yaratıcı	_	_	_	_	_	_	_	_
-7	yarat	yarat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	10	nmod	_	_
-8	ıcı	ci	ADP	Agt	_	7	case	_	_
-9	bir	bir	NUM	ANum	NumType=Card	10	det	_	_
-10	durum	durum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obj	_	_
-11	değildir	değil	VERB	Neg	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	1	conj	_	_
-12	onun	o	PRON	Pers	Case=Gen|Number=Sing|Person=3|PronType=Prs	13	nmod:poss	_	_
-13	durumu	durum	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	nsubj	_	SpaceAfter=No
-14	.	.	PUNCT	Punc	_	11	punct	_	_
+7	yaratıcı	yarat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	acl	_	_
+8	bir	bir	NUM	ANum	NumType=Card	9	det	_	_
+9	durum	durum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obj	_	_
+10	değildir	değil	VERB	Neg	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
+11	onun	o	PRON	Pers	Case=Gen|Number=Sing|Person=3|PronType=Prs	12	nmod:poss	_	_
+12	durumu	durum	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nsubj	_	SpaceAfter=No
+13	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-1603
 # text = Eline geçirdiği kişiyi kendi kölesi yapmayı çok iyi bilir; eroin tacirleri gibi...
@@ -15948,13 +15939,14 @@
 
 # sent_id = mst-1782
 # text = Neleri sevmediklerine gelince, müşteri, beklemeyi, kendisine gereksiz soruların sorulmasını, stokta kalmamış ürünleri, okunamayan fiyat etiketlerini ve rahatsız edici hizmeti sevmez.
+# Change 2.2/dev: merge -(y)IcI
 1	Neleri	ne	PRON	Ques	Case=Acc|Number=Plur|Person=3	2	obj	_	_
 2	sevmediklerine	sev	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	3	acl	_	_
-3	gelince	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	26	nmod	_	SpaceAfter=No
+3	gelince	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	25	nmod	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	3	punct	_	_
-5	müşteri	müşteri	NOUN	Noun	Case=Nom|Number=Sing|Person=3	26	nsubj	_	SpaceAfter=No
-6	,	,	PUNCT	Punc	_	26	punct	_	_
-7	beklemeyi	bekle	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	26	obj	_	SpaceAfter=No
+5	müşteri	müşteri	NOUN	Noun	Case=Nom|Number=Sing|Person=3	25	nsubj	_	SpaceAfter=No
+6	,	,	PUNCT	Punc	_	25	punct	_	_
+7	beklemeyi	bekle	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	25	obj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	12	punct	_	_
 9	kendisine	kendi	PRON	Reflex	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	12	obl	_	_
 10	gereksiz	gereksiz	ADJ	Adj	_	11	amod	_	_
@@ -15968,14 +15960,12 @@
 18	okunamayan	oku	VERB	Verb	Aspect=Perf|Mood=Pot|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	19	acl	_	_
 19	fiyat	fiyat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	conj	_	_
 20	etiketlerini	etiket	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	19	compound	_	_
-21	ve	ve	CCONJ	Conj	_	25	cc	_	_
-22	rahatsız	rahatsız	ADJ	Adj	_	25	amod	_	_
-23-24	edici	_	_	_	_	_	_	_	_
-23	ed	et	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	22	compound:lvc	_	_
-24	ici	ci	ADP	Agt	_	22	case	_	_
-25	hizmeti	hizmet	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	conj	_	_
-26	sevmez	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
-27	.	.	PUNCT	Punc	_	26	punct	_	_
+21	ve	ve	CCONJ	Conj	_	24	cc	_	_
+22	rahatsız	rahatsız	ADJ	Adj	_	24	amod	_	_
+23	edici	et	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	22	compound:lvc	_	_
+24	hizmeti	hizmet	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	conj	_	_
+25	sevmez	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+26	.	.	PUNCT	Punc	_	25	punct	_	_
 
 # sent_id = mst-1785
 # text = İkilinin elinde Askeri Savcılığın verdiği takipsizlik kararı ve KKK Uçuş Emniyet Kurulu'nun düzenlediği müşterek kanaat raporu vardı.
@@ -16279,6 +16269,7 @@
 
 # sent_id = mst-1817
 # text = Büyük dayının aşık olması ne kadar heyecan verici.
+# Change 2.2/dev: merge -(y)IcI
 1	Büyük	büyük	ADJ	Adj	_	2	amod	_	_
 2	dayının	dayı	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	3	nmod	_	_
 3	aşık	aşık	ADJ	Adj	_	7	nsubj	_	_
@@ -16286,10 +16277,8 @@
 5	ne	ne	ADJ	Adj	_	7	advmod:emph	_	_
 6	kadar	kadar	ADP	PCNom	_	5	case	_	_
 7	heyecan	heyecan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-8-9	verici	_	_	_	_	_	_	_	SpaceAfter=No
-8	ver	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	7	compound	_	_
-9	ici	ci	ADP	Agt	_	7	case	_	_
-10	.	.	PUNCT	Punc	_	7	punct	_	_
+8	verici	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	compound	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-1819
 # text = Mutfak daracık.
@@ -16479,13 +16468,11 @@
 
 # sent_id = mst-1841
 # text = ekşimtırak, yakıcı lezzetiyle.
-1	ekşimtırak	ekşimtırak	ADJ	Adj	_	5	amod	_	SpaceAfter=No
-2	,	,	PUNCT	Punc	_	5	punct	_	_
-3-4	yakıcı	_	_	_	_	_	_	_	_
-3	yak	yak	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	5	nmod	_	_
-4	ıcı	ci	ADP	Agt	_	3	case	_	_
-5	lezzetiyle	lezzet	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	5	punct	_	_
+1	ekşimtırak	ekşimtırak	ADJ	Adj	_	4	amod	_	SpaceAfter=No
+2	,	,	PUNCT	Punc	_	4	punct	_	_
+3	yakıcı	yak	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	acl	_	_
+4	lezzetiyle	lezzet	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	SpaceAfter=No
+5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-1843
 # text = Merdivenden aşağıya indim.
@@ -19565,17 +19552,15 @@
 # sent_id = mst-2165
 # text = Bilimsel bilgiler de teknoloji aracılığıyla bir üretici güce dönüşür.
 1	Bilimsel	bilimsel	ADJ	Adj	_	2	amod	_	_
-2	bilgiler	bilgi	NOUN	Noun	Case=Nom|Number=Plur|Person=3	10	nsubj	_	_
+2	bilgiler	bilgi	NOUN	Noun	Case=Nom|Number=Plur|Person=3	9	nsubj	_	_
 3	de	de	CCONJ	Conj	_	2	advmod:emph	_	_
 4	teknoloji	teknoloji	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod	_	_
-5	aracılığıyla	aracılık	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obl	_	_
-6	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
-7-8	üretici	_	_	_	_	_	_	_	_
-7	üret	üre	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|Voice=Cau	9	nmod	_	_
-8	ici	ci	ADP	Agt	_	7	case	_	_
-9	güce	güç	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	10	amod	_	_
-10	dönüşür	dönüş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	10	punct	_	_
+5	aracılığıyla	aracılık	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
+6	bir	bir	NUM	ANum	NumType=Card	8	det	_	_
+7	üretici	üre	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	8	acl	_	_
+8	güce	güç	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	9	amod	_	_
+9	dönüşür	dönüş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2167
 # text = Eşi de on gün önce yıllık izninin bir bölümünü kullanmak için İstanbul'a geldi.
@@ -24145,28 +24130,27 @@
 
 # sent_id = mst-2670
 # text = Bütün bu olasılıklardan daha da can sıkıcı olanı, zamansız uyanan ayıların civarda olabileceği endişesiydi.
+# Change 2.2/dev: merge -(y)IcI
 1	Bütün	bütün	ADJ	Adj	_	3	det	_	_
 2	bu	bu	DET	Det	_	3	det	_	_
 3	olasılıklardan	olasılık	NOUN	Noun	Case=Abl|Number=Plur|Person=3	6	nmod	_	_
 4	daha	daha	ADV	Adverb	_	6	advmod	_	_
 5	da	da	CCONJ	Conj	_	4	advmod:emph	_	_
 6	can	can	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
-7-8	sıkıcı	_	_	_	_	_	_	_	_
-7	sık	sık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	6	compound	_	_
-8	ıcı	ci	ADP	Agt	_	6	case	_	_
-9-10	olanı	_	_	_	_	_	_	_	SpaceAfter=No
-9	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	17	nsubj	_	_
-10	ı	_	ADP	Zero	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	case	_	_
-11	,	,	PUNCT	Punc	_	9	punct	_	_
-12	zamansız	zamansız	ADJ	Adj	_	13	amod	_	_
-13	uyanan	uyan	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	14	acl	_	_
-14	ayıların	ayı	NOUN	Noun	Case=Gen|Number=Plur|Person=3	16	nmod:poss	_	_
-15	civarda	civar	NOUN	Noun	Case=Loc|Number=Sing|Person=3	16	obl	_	_
-16	olabileceği	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	17	nmod:poss	_	_
-17-18	endişesiydi	_	_	_	_	_	_	_	SpaceAfter=No
-17	endişesi	endişe	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
-18	ydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	17	cop	_	_
-19	.	.	PUNCT	Punc	_	17	punct	_	_
+7	sıkıcı	sık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	compound	_	_
+8-9	olanı	_	_	_	_	_	_	_	SpaceAfter=No
+8	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	16	nsubj	_	_
+9	ı	_	ADP	Zero	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	case	_	_
+10	,	,	PUNCT	Punc	_	8	punct	_	_
+11	zamansız	zamansız	ADJ	Adj	_	12	amod	_	_
+12	uyanan	uyan	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	13	acl	_	_
+13	ayıların	ayı	NOUN	Noun	Case=Gen|Number=Plur|Person=3	15	nmod:poss	_	_
+14	civarda	civar	NOUN	Noun	Case=Loc|Number=Sing|Person=3	15	obl	_	_
+15	olabileceği	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	16	nmod:poss	_	_
+16-17	endişesiydi	_	_	_	_	_	_	_	SpaceAfter=No
+16	endişesi	endişe	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
+17	ydi	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	16	cop	_	_
+18	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-2671
 # text = Öğleden sonra kanallar kıyısında dolaşırken, sanki uzun yıllardır buradaymışım, hep de kanallar kıyısında dolaşıp durmakla vakit tüketirmişim gibi geliyordu bana.
@@ -24348,30 +24332,29 @@
 
 # sent_id = mst-2691
 # text = İnsanın nesnel gerçekliği yoktur; insanın algılayıcı organı beyindir ama onun da nesnel gerçekliği yoktur.
+# Change 2.2/dev: merge -(y)IcI
 1	İnsanın	insan	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod	_	_
 2	nesnel	nesnel	ADJ	Adj	_	3	amod	_	_
 3	gerçekliği	gerçeklik	NOUN	Noun	Case=Acc|Number=Sing|Person=3	4	nsubj	_	_
 4-5	yoktur	_	_	_	_	_	_	_	SpaceAfter=No
 4	yok	yok	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
 5	tur	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	4	cop	_	_
-6	;	;	PUNCT	Punc	_	11	punct	_	_
-7	insanın	insan	NOUN	Noun	Case=Gen|Number=Sing|Person=3	10	nmod	_	_
-8-9	algılayıcı	_	_	_	_	_	_	_	_
-8	algıla	algıla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	10	nmod	_	_
-9	yıcı	ci	ADP	Agt	_	8	case	_	_
-10	organı	organ	NOUN	Noun	Case=Acc|Number=Sing|Person=3	11	nsubj	_	_
-11-12	beyindir	_	_	_	_	_	_	_	_
-11	beyin	beyin	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	conj	_	_
-12	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	11	cop	_	_
-13	ama	ama	CCONJ	Conj	_	18	cc	_	_
-14	onun	o	PRON	Demons	Case=Gen|Number=Sing|Person=3|PronType=Dem	17	nmod:poss	_	_
-15	da	da	CCONJ	Conj	_	14	advmod:emph	_	_
-16	nesnel	nesnel	ADJ	Adj	_	17	amod	_	_
-17	gerçekliği	gerçeklik	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	nsubj	_	_
-18-19	yoktur	_	_	_	_	_	_	_	SpaceAfter=No
-18	yok	yok	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	4	conj	_	_
-19	tur	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	18	cop	_	_
-20	.	.	PUNCT	Punc	_	18	punct	_	_
+6	;	;	PUNCT	Punc	_	10	punct	_	_
+7	insanın	insan	NOUN	Noun	Case=Gen|Number=Sing|Person=3	9	nmod	_	_
+8	algılayıcı	algıla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	acl	_	_
+9	organı	organ	NOUN	Noun	Case=Acc|Number=Sing|Person=3	10	nsubj	_	_
+10-11	beyindir	_	_	_	_	_	_	_	_
+10	beyin	beyin	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	conj	_	_
+11	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	10	cop	_	_
+12	ama	ama	CCONJ	Conj	_	17	cc	_	_
+13	onun	o	PRON	Demons	Case=Gen|Number=Sing|Person=3|PronType=Dem	16	nmod:poss	_	_
+14	da	da	CCONJ	Conj	_	13	advmod:emph	_	_
+15	nesnel	nesnel	ADJ	Adj	_	16	amod	_	_
+16	gerçekliği	gerçeklik	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	nsubj	_	_
+17-18	yoktur	_	_	_	_	_	_	_	SpaceAfter=No
+17	yok	yok	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	4	conj	_	_
+18	tur	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	17	cop	_	_
+19	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-2692
 # text = Kim bu hatun?
@@ -27894,14 +27877,13 @@
 
 # sent_id = mst-3113
 # text = Sloganla çarpıcı tanıtma yapmaya çalıştım.
-1	Sloganla	slogan	NOUN	Noun	Case=Ins|Number=Sing|Person=3	6	obl	_	_
-2-3	çarpıcı	_	_	_	_	_	_	_	_
-2	çarp	çarp	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	4	nmod	_	_
-3	ıcı	ci	ADP	Agt	_	2	case	_	_
-4	tanıtma	tanı	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	6	obj	_	_
-5	yapmaya	yap	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	nmod	_	_
-6	çalıştım	çalış	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	6	punct	_	_
+# Change 2.2/dev: merge -(y)IcI
+1	Sloganla	slogan	NOUN	Noun	Case=Ins|Number=Sing|Person=3	5	obl	_	_
+2	çarpıcı	çarp	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	acl	_	_
+3	tanıtma	tanı	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	5	obj	_	_
+4	yapmaya	yap	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	nmod	_	_
+5	çalıştım	çalış	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
+6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-3114
 # text = Son köşeyi dönerken, bembeyaz elbisesi içinde, kucağında yastığı, kaldırımda cansız yatan Hülya'nın üzerine kapanmaya hazırdım.
@@ -28242,28 +28224,27 @@
 
 # sent_id = mst-3140
 # text = Diskoteği sandığı kadar ürkütücü bulmadı, belki de gençlere uyum sağlamak için ister istemez içtiği iki kadeh viski yüzünden.
-1	Diskoteği	diskotek	NOUN	Noun	Case=Acc|Number=Sing|Person=3	6	obj	_	_
-2	sandığı	san	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	6	acl	_	_
+# Change 2.2/dev: merge -(y)IcI
+1	Diskoteği	diskotek	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	obj	_	_
+2	sandığı	san	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	5	acl	_	_
 3	kadar	kadar	ADP	PCDat	_	2	case	_	_
-4-5	ürkütücü	_	_	_	_	_	_	_	_
-4	ürküt	ürküt	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	6	obj	_	_
-5	ücü	ci	ADP	Agt	_	4	case	_	_
-6	bulmadı	bul	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
-7	,	,	PUNCT	Punc	_	6	punct	_	_
-8	belki	belki	ADV	Adverb	_	6	advmod	_	_
-9	de	de	CCONJ	Conj	_	8	advmod:emph	_	_
-10	gençlere	genç	ADJ	NAdj	Case=Dat|Number=Plur|Person=3	12	amod	_	_
-11	uyum	uyum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obj	_	_
-12	sağlamak	sağla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	16	nmod	_	_
-13	için	için	ADP	PCNom	_	12	case	_	_
-14	ister	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	16	nmod	_	_
-15	istemez	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	14	compound	_	_
-16	içtiği	iç	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	19	acl	_	_
-17	iki	iki	NUM	ANum	NumType=Card	18	nummod	_	_
-18	kadeh	kadeh	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	nmod	_	_
-19	viski	viski	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nmod	_	_
-20	yüzünden	yüz	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	SpaceAfter=No
-21	.	.	PUNCT	Punc	_	6	punct	_	_
+4	ürkütücü	ürk	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	5	ccomp	_	_
+5	bulmadı	bul	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
+6	,	,	PUNCT	Punc	_	5	punct	_	_
+7	belki	belki	ADV	Adverb	_	5	advmod	_	_
+8	de	de	CCONJ	Conj	_	7	advmod:emph	_	_
+9	gençlere	genç	ADJ	NAdj	Case=Dat|Number=Plur|Person=3	11	amod	_	_
+10	uyum	uyum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obj	_	_
+11	sağlamak	sağla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	15	nmod	_	_
+12	için	için	ADP	PCNom	_	11	case	_	_
+13	ister	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	15	nmod	_	_
+14	istemez	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	13	compound	_	_
+15	içtiği	iç	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	18	acl	_	_
+16	iki	iki	NUM	ANum	NumType=Card	17	nummod	_	_
+17	kadeh	kadeh	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nmod	_	_
+18	viski	viski	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	nmod	_	_
+19	yüzünden	yüz	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	SpaceAfter=No
+20	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-3142
 # text = Gerçekten de bu bin yılda önce evrenin merkezinde değil, Güneş etrafında dönen sıradan bir gezegende olduğumuzu öğrendik; sonra sıradan bir canlı türü olduğumuzu.
@@ -29196,20 +29177,19 @@
 
 # sent_id = mst-3246
 # text = Üretici güçlerin gelişimine olan etkisi, bu dönemde dolaylıdır.
-1-2	Üretici	_	_	_	_	_	_	_	_
-1	Üret	üre	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|Voice=Cau	3	nmod	_	_
-2	ici	ci	ADP	Agt	_	1	case	_	_
-3	güçlerin	güç	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	4	nmod:poss	_	_
-4	gelişimine	gelişim	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
-5	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	acl	_	_
-6	etkisi	etki	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nsubj	_	SpaceAfter=No
-7	,	,	PUNCT	Punc	_	10	punct	_	_
-8	bu	bu	DET	Det	_	9	det	_	_
-9	dönemde	dönem	NOUN	Noun	Case=Loc|Number=Sing|Person=3	10	obl	_	_
-10-11	dolaylıdır	_	_	_	_	_	_	_	SpaceAfter=No
-10	dolaylı	dolaylı	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
-11	dır	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	10	cop	_	_
-12	.	.	PUNCT	Punc	_	10	punct	_	_
+# Change 2.2/dev: merge -(y)IcI
+1	Üretici	üre	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	2	acl	_	_
+2	güçlerin	güç	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	3	nmod:poss	_	_
+3	gelişimine	gelişim	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obl	_	_
+4	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	acl	_	_
+5	etkisi	etki	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	nsubj	_	SpaceAfter=No
+6	,	,	PUNCT	Punc	_	9	punct	_	_
+7	bu	bu	DET	Det	_	8	det	_	_
+8	dönemde	dönem	NOUN	Noun	Case=Loc|Number=Sing|Person=3	9	obl	_	_
+9-10	dolaylıdır	_	_	_	_	_	_	_	SpaceAfter=No
+9	dolaylı	dolaylı	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
+10	dır	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	9	cop	_	_
+11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-3248
 # text = Evet, dedi adam.
@@ -29572,25 +29552,25 @@
 
 # sent_id = mst-3285
 # text = Bir de en önemlisi, ot toplayıcılığı vardı halk arasında.
-1	Bir	bir	NUM	ANum	NumType=Card	12	nummod	_	_
+# Change 2.2/dev: merge -(y)IcI
+1	Bir	bir	NUM	ANum	NumType=Card	11	nummod	_	_
 2	de	de	CCONJ	Conj	_	1	advmod:emph	_	_
 3	en	en	ADV	Adverb	_	6	advmod	_	_
 4-6	önemlisi	_	_	_	_	_	_	_	SpaceAfter=No
-4	önem	önem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
+4	önem	önem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obl	_	_
 5	li	li	ADP	With	_	4	case	_	_
 6	si	_	ADP	Zero	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	case	_	_
-7	,	,	PUNCT	Punc	_	12	punct	_	_
+7	,	,	PUNCT	Punc	_	11	punct	_	_
 8	ot	ot	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
-9-11	toplayıcılığı	_	_	_	_	_	_	_	_
-9	topla	topla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	12	nsubj	_	_
-10	yıcı	ci	ADP	Agt	_	9	case	_	_
-11	lığı	lik	ADP	Ness	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	case	_	_
-12-13	vardı	_	_	_	_	_	_	_	_
-12	var	var	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
-13	dı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	12	cop	_	_
-14	halk	halk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	nmod:poss	_	_
-15	arasında	ara	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	amod	_	SpaceAfter=No
-16	.	.	PUNCT	Punc	_	12	punct	_	_
+9-10	toplayıcılığı	_	_	_	_	_	_	_	_
+9	toplayıcı	topla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	csubj	_	_
+10	lığı	lik	ADP	Ness	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	case	_	_
+11-12	vardı	_	_	_	_	_	_	_	_
+11	var	var	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
+12	dı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	11	cop	_	_
+13	halk	halk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	nmod:poss	_	_
+14	arasında	ara	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	amod	_	SpaceAfter=No
+15	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-3286
 # text = Komutanlar, bu açıklamaların Başbakan ve resmi yetkililer tarafından da yapılmasında fayda olacağını ifade ettiler.
@@ -33912,6 +33892,7 @@
 
 # sent_id = mst-3768
 # text = Eski Devlet Bakanı ve Başbakan Yardımcısı, Toplumcu Kurtuluş Partisi (TKP) Lefkoşa Milletvekili Mustafa Akıncı da, " Denktaş'ın, izlediği politikayla Kıbrıs'ı kalıcı taksime götürdüğünü " öne sürdü.
+# Change 2.2/dev: merge -(y)IcI
 1	Eski	eski	ADJ	Adj	_	3	amod	_	_
 2	Devlet	devlet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 3	Bakanı	bakan	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	nmod	_	_
@@ -33927,25 +33908,23 @@
 13	)	)	PUNCT	Punc	_	12	punct	_	_
 14	Lefkoşa	Lefkoşa	PROPN	Prop	Case=Nom|Number=Sing|Person=3	15	nmod:poss	_	_
 15	Milletvekili	milletvekili	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	conj	_	_
-16	Mustafa	Mustafa	PROPN	Prop	Case=Nom|Number=Sing|Person=3	31	nsubj	_	_
+16	Mustafa	Mustafa	PROPN	Prop	Case=Nom|Number=Sing|Person=3	30	nsubj	_	_
 17	Akıncı	Akıncı	PROPN	Prop	Case=Nom|Number=Sing|Person=3	16	flat	_	_
 18	da	da	CCONJ	Conj	_	16	advmod:emph	_	SpaceAfter=No
-19	,	,	PUNCT	Punc	_	31	punct	_	_
-20	"	"	PUNCT	Punc	_	29	punct	_	_
+19	,	,	PUNCT	Punc	_	30	punct	_	_
+20	"	"	PUNCT	Punc	_	28	punct	_	_
 21	Denktaş'ın	Denktaş	PROPN	Prop	Case=Gen|Number=Sing|Person=3	23	nmod:poss	_	SpaceAfter=No
 22	,	,	PUNCT	Punc	_	23	punct	_	_
 23	izlediği	izle	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	24	acl	_	_
-24	politikayla	politika	NOUN	Noun	Case=Ins|Number=Sing|Person=3	29	obl	_	_
-25	Kıbrıs'ı	Kıbrıs	PROPN	Prop	Case=Acc|Number=Sing|Person=3	29	obj	_	_
-26-27	kalıcı	_	_	_	_	_	_	_	_
-26	kal	kal	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	28	nmod	_	_
-27	ıcı	ci	ADP	Agt	_	26	case	_	_
-28	taksime	taksim	NOUN	Noun	Case=Dat|Number=Sing|Person=3	29	obl	_	_
-29	götürdüğünü	götür	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	31	obj	_	_
-30	"	"	PUNCT	Punc	_	29	punct	_	_
-31	öne	ön	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	0	root	_	_
-32	sürdü	sür	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	31	compound	_	SpaceAfter=No
-33	.	.	PUNCT	Punc	_	31	punct	_	_
+24	politikayla	politika	NOUN	Noun	Case=Ins|Number=Sing|Person=3	28	obl	_	_
+25	Kıbrıs'ı	Kıbrıs	PROPN	Prop	Case=Acc|Number=Sing|Person=3	28	obj	_	_
+26	kalıcı	kal	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	27	acl	_	_
+27	taksime	taksim	NOUN	Noun	Case=Dat|Number=Sing|Person=3	28	obl	_	_
+28	götürdüğünü	götür	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	30	obj	_	_
+29	"	"	PUNCT	Punc	_	28	punct	_	_
+30	öne	ön	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	0	root	_	_
+31	sürdü	sür	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	30	compound	_	SpaceAfter=No
+32	.	.	PUNCT	Punc	_	30	punct	_	_
 
 # sent_id = mst-3771
 # text = Mersedes buldum mu bırakmam abi.
@@ -34262,23 +34241,22 @@
 
 # sent_id = mst-3799
 # text = Onun arkasından öbür silici çocuklar da arabanın önüne atladılar ve birbirleriyle itişip kakışmaya başladılar.
+# Change 2.2/dev: merge -(y)IcI
 1	Onun	o	PRON	Pers	Case=Gen|Number=Sing|Person=3|PronType=Prs	2	nmod:poss	_	_
-2	arkasından	arka	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	amod	_	_
-3	öbür	öbür	ADJ	Adj	_	6	amod	_	_
-4-5	silici	_	_	_	_	_	_	_	_
-4	sil	sil	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	6	nmod	_	_
-5	ici	ci	ADP	Agt	_	4	case	_	_
-6	çocuklar	çocuk	NOUN	Noun	Case=Nom|Number=Plur|Person=3	10	nsubj	_	_
-7	da	da	CCONJ	Conj	_	6	advmod:emph	_	_
-8	arabanın	araba	NOUN	Noun	Case=Gen|Number=Sing|Person=3	9	nmod:poss	_	_
-9	önüne	ön	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	10	amod	_	_
-10	atladılar	atla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
-11	ve	ve	CCONJ	Conj	_	15	cc	_	_
-12	birbirleriyle	birbiri	PRON	Quant	Case=Ins|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	13	obl	_	_
-13	itişip	itiş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	15	nmod	_	_
-14	kakışmaya	kakış	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	13	compound	_	_
-15	başladılar	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	10	conj	_	SpaceAfter=No
-16	.	.	PUNCT	Punc	_	15	punct	_	_
+2	arkasından	arka	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	amod	_	_
+3	öbür	öbür	ADJ	Adj	_	5	amod	_	_
+4	silici	sil	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	acl	_	_
+5	çocuklar	çocuk	NOUN	Noun	Case=Nom|Number=Plur|Person=3	9	nsubj	_	_
+6	da	da	CCONJ	Conj	_	5	advmod:emph	_	_
+7	arabanın	araba	NOUN	Noun	Case=Gen|Number=Sing|Person=3	8	nmod:poss	_	_
+8	önüne	ön	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	9	amod	_	_
+9	atladılar	atla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+10	ve	ve	CCONJ	Conj	_	14	cc	_	_
+11	birbirleriyle	birbiri	PRON	Quant	Case=Ins|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	12	obl	_	_
+12	itişip	itiş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	14	nmod	_	_
+13	kakışmaya	kakış	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	12	compound	_	_
+14	başladılar	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	9	conj	_	SpaceAfter=No
+15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-3804
 # text = Belki de bir daha bulamayacağım orayı.
@@ -34370,6 +34348,7 @@
 
 # sent_id = mst-3814
 # text = O anda anladım ki, büyük amcan gidici.
+# Change 2.2/dev: merge -(y)IcI
 1	O	o	DET	Det	_	2	det	_	_
 2	anda	an	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
 3	anladım	anla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	8	nmod	_	_
@@ -34377,10 +34356,8 @@
 5	,	,	PUNCT	Punc	_	3	punct	_	_
 6	büyük	büyük	ADJ	Adj	_	7	amod	_	_
 7	amcan	amca	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	8	nsubj	_	_
-8-9	gidici	_	_	_	_	_	_	_	SpaceAfter=No
-8	gid	git	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	0	root	_	_
-9	ici	ci	ADP	Agt	_	8	case	_	_
-10	.	.	PUNCT	Punc	_	8	punct	_	_
+8	gidici	git	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	0	root	_	SpaceAfter=No
+9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-3816
 # text = Oysa yeşil değil, akik de, gitsin.
@@ -34542,35 +34519,34 @@
 
 # sent_id = mst-3834
 # text = Kemal devam etti: Ben bunun, hem tek tek hepimiz için çok rahatlatıcı olacağından eminim hem de birbirimize yaklaşımımızı, ilişkilerimizi olumlu etkileyecektir, eminim.
+# Change 2.2/dev: merge -(y)IcI
 1	Kemal	Kemal	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
 2	devam	devam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 3	etti	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	2	compound:lvc	_	SpaceAfter=No
-4	:	:	PUNCT	Punc	_	17	punct	_	_
-5	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	_	_
-6	bunun	bu	PRON	Demons	Case=Gen|Number=Sing|Person=3|PronType=Dem	16	nmod:poss	_	SpaceAfter=No
+4	:	:	PUNCT	Punc	_	16	punct	_	_
+5	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	_	_
+6	bunun	bu	PRON	Demons	Case=Gen|Number=Sing|Person=3|PronType=Dem	15	nmod:poss	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	2	punct	_	_
-8	hem	hem	CCONJ	Conj	_	17	cc	_	_
+8	hem	hem	CCONJ	Conj	_	16	cc	_	_
 9	tek	tek	ADJ	Adj	_	11	amod	_	_
 10	tek	tek	ADJ	Adj	_	9	compound:redup	_	_
-11	hepimiz	hep	PRON	Quant	Case=Nom|Number=Plur|Number[psor]=Plur|Person=1|Person[psor]=1|PronType=Ind	16	obl	_	_
+11	hepimiz	hep	PRON	Quant	Case=Nom|Number=Plur|Number[psor]=Plur|Person=1|Person[psor]=1|PronType=Ind	15	obl	_	_
 12	için	için	ADP	PCNom	_	11	case	_	_
 13	çok	çok	ADJ	Adj	_	14	det	_	_
-14-15	rahatlatıcı	_	_	_	_	_	_	_	_
-14	rahatlat	rahatla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|Voice=Cau	16	nmod	_	_
-15	ıcı	ci	ADP	Agt	_	14	case	_	_
-16	olacağından	olacak	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	amod	_	_
-17	eminim	emin	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	conj	_	_
-18	hem	hem	CCONJ	Conj	_	25	cc	_	_
-19	de	de	CCONJ	Conj	_	18	advmod:emph	_	_
-20	birbirimize	birbiri	PRON	Quant	Case=Dat|Number=Plur|Number[psor]=Plur|Person=1|Person[psor]=1|PronType=Ind	21	nmod	_	_
-21	yaklaşımımızı	yaklaşım	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	25	obj	_	SpaceAfter=No
-22	,	,	PUNCT	Punc	_	23	punct	_	_
-23	ilişkilerimizi	ilişki	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=1	21	conj	_	_
-24	olumlu	olumlu	ADJ	Adj	_	25	amod	_	_
-25	etkileyecektir	etkile	VERB	Verb	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	2	conj	_	SpaceAfter=No
-26	,	,	PUNCT	Punc	_	27	punct	_	_
-27	eminim	emin	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	conj	_	SpaceAfter=No
-28	.	.	PUNCT	Punc	_	27	punct	_	_
+14	rahatlatıcı	rahatla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	15	ccomp	_	_
+15	olacağından	olacak	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	amod	_	_
+16	eminim	emin	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	conj	_	_
+17	hem	hem	CCONJ	Conj	_	24	cc	_	_
+18	de	de	CCONJ	Conj	_	17	advmod:emph	_	_
+19	birbirimize	birbiri	PRON	Quant	Case=Dat|Number=Plur|Number[psor]=Plur|Person=1|Person[psor]=1|PronType=Ind	20	nmod	_	_
+20	yaklaşımımızı	yaklaşım	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	24	obj	_	SpaceAfter=No
+21	,	,	PUNCT	Punc	_	22	punct	_	_
+22	ilişkilerimizi	ilişki	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=1	20	conj	_	_
+23	olumlu	olumlu	ADJ	Adj	_	24	amod	_	_
+24	etkileyecektir	etkile	VERB	Verb	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	2	conj	_	SpaceAfter=No
+25	,	,	PUNCT	Punc	_	26	punct	_	_
+26	eminim	emin	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	conj	_	SpaceAfter=No
+27	.	.	PUNCT	Punc	_	26	punct	_	_
 
 # sent_id = mst-3836
 # text = Yay sesleri dindi yavaş yavaş, uyum sağlandı.
@@ -34906,6 +34882,7 @@
 
 # sent_id = mst-3872
 # text = Günümüzde ise bu ilişki bütünüyle tersine dönmüş, bilim adeta tümüyle bir üretici güç haline indirgenmiştir.
+# Change 2.2/dev: merge -(y)IcI
 1	Günümüzde	gün	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	7	obl	_	_
 2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
 3	bu	bu	DET	Det	_	4	det	_	_
@@ -34913,18 +34890,16 @@
 5	bütünüyle	bütün	ADJ	NAdj	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	amod	_	_
 6	tersine	tersine	ADV	Adverb	_	7	advmod	_	_
 7	dönmüş	dön	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
-8	,	,	PUNCT	Punc	_	17	punct	_	_
-9	bilim	bilim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nsubj	_	_
+8	,	,	PUNCT	Punc	_	16	punct	_	_
+9	bilim	bilim	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nsubj	_	_
 10	adeta	adeta	ADV	Adverb	_	11	advmod:emph	_	_
-11	tümüyle	tümüyle	ADV	Adverb	_	17	advmod	_	_
+11	tümüyle	tümüyle	ADV	Adverb	_	16	advmod	_	_
 12	bir	bir	NUM	ANum	NumType=Card	13	det	_	_
-13-14	üretici	_	_	_	_	_	_	_	_
-13	üret	üre	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|Voice=Cau	15	nmod	_	_
-14	ici	ci	ADP	Agt	_	13	case	_	_
-15	güç	güç	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	16	nmod:poss	_	_
-16	haline	hal	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	obl	_	_
-17	indirgenmiştir	indirge	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Gen|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	7	conj	_	SpaceAfter=No
-18	.	.	PUNCT	Punc	_	17	punct	_	_
+13	üretici	üre	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	14	acl	_	_
+14	güç	güç	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	15	nmod:poss	_	_
+15	haline	hal	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obl	_	_
+16	indirgenmiştir	indirge	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Gen|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	7	conj	_	SpaceAfter=No
+17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-3874
 # text = Ağbim de çok iyi bir öğrenci, hep sınıf ikincisi.
@@ -40121,13 +40096,12 @@
 
 # sent_id = mst-4463
 # text = Ürkütücü şeyler bu anlattıklarınız.
-1-2	Ürkütücü	_	_	_	_	_	_	_	_
-1	Ürküt	ürküt	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	3	nmod	_	_
-2	ücü	ci	ADP	Agt	_	1	case	_	_
-3	şeyler	şey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	0	root	_	_
-4	bu	bu	DET	Det	_	5	det	_	_
-5	anlattıklarınız	anlat	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	3	nsubj	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	5	punct	_	_
+# Change 2.2/dev: merge -(y)IcI
+1	Ürkütücü	ürk	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	2	acl	_	_
+2	şeyler	şey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	0	root	_	_
+3	bu	bu	DET	Det	_	4	det	_	_
+4	anlattıklarınız	anlat	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	2	nsubj	_	SpaceAfter=No
+5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4465
 # text = Onu görmek için, tüm zamanınızı o parkta geçirmeye başlarsınız.
@@ -44504,25 +44478,24 @@
 
 # sent_id = mst-4972
 # text = Onlara hiç anlamıyorlarmış gibi gelirken birden en can alıcı soruyu, nasıl olup da bulup sorabilirler.
-1	Onlara	o	PRON	Pers	Case=Dat|Number=Plur|Person=3|PronType=Prs	17	obl	_	_
+# Change 2.2/dev: merge -(y)IcI
+1	Onlara	o	PRON	Pers	Case=Dat|Number=Plur|Person=3|PronType=Prs	16	obl	_	_
 2	hiç	hiç	ADV	Adverb	_	3	advmod	_	_
 3	anlamıyorlarmış	anla	VERB	Verb	Aspect=Prog|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Polite=Infm|Tense=Past	5	nmod	_	_
 4	gibi	gibi	ADP	PCNom	_	3	case	_	_
-5	gelirken	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	17	nmod	_	_
-6	birden	birden	ADV	Adverb	_	17	advmod	_	_
+5	gelirken	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	16	nmod	_	_
+6	birden	birden	ADV	Adverb	_	16	advmod	_	_
 7	en	en	ADV	Adverb	_	9	advmod	_	_
 8	can	can	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
-9-10	alıcı	_	_	_	_	_	_	_	_
-9	al	al	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	11	nmod	_	_
-10	ıcı	ci	ADP	Agt	_	9	case	_	_
-11	soruyu	soru	NOUN	Noun	Case=Acc|Number=Sing|Person=3	17	obj	_	SpaceAfter=No
-12	,	,	PUNCT	Punc	_	17	punct	_	_
-13	nasıl	nasıl	ADV	Adverb	_	17	advmod	_	_
-14	olup	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	17	nmod	_	_
-15	da	da	CCONJ	Conj	_	14	advmod:emph	_	_
-16	bulup	bul	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	14	conj	_	_
-17	sorabilirler	sor	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
-18	.	.	PUNCT	Punc	_	17	punct	_	_
+9	alıcı	al	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	10	acl	_	_
+10	soruyu	soru	NOUN	Noun	Case=Acc|Number=Sing|Person=3	16	obj	_	SpaceAfter=No
+11	,	,	PUNCT	Punc	_	16	punct	_	_
+12	nasıl	nasıl	ADV	Adverb	_	16	advmod	_	_
+13	olup	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	16	nmod	_	_
+14	da	da	CCONJ	Conj	_	13	advmod:emph	_	_
+15	bulup	bul	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	13	conj	_	_
+16	sorabilirler	sor	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-4974
 # text = Kısık kısık gülüyor arada bir.
@@ -48493,43 +48466,42 @@
 # sent_id = mst-5441
 # text = Nedenini anlayamadığım bu terk edilme korkusu ve kendime itiraf etmekten bile utandığım hırpalayıcı kıskançlığımla, aptalca olduğunu bile bile daha çok kadınla birlikte oluyor ve sonunda korktuğuma uğrayıp bir başka erkek için terk ediliyordum.
 # Change 2.2/dev: merge -CA
+# Change 2.2/dev: merge -(y)IcI
 1	Nedenini	neden	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	obj	_	_
 2	anlayamadığım	anla	VERB	Verb	Aspect=Perf|Mood=Pot|Number[psor]=Sing|Person[psor]=1|Polarity=Neg|Tense=Past|VerbForm=Part	6	acl	_	_
 3	bu	bu	DET	Det	_	6	det	_	_
 4	terk	terk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 5	edilme	et	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	4	compound:lvc	_	_
-6	korkusu	korku	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	24	obl	_	_
-7	ve	ve	CCONJ	Conj	_	15	cc	_	_
+6	korkusu	korku	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	23	obl	_	_
+7	ve	ve	CCONJ	Conj	_	14	cc	_	_
 8	kendime	kendi	PRON	Reflex	Case=Dat|Number=Sing|Number[psor]=Sing|Person=1|Person[psor]=1|Reflex=Yes	9	nmod	_	_
 9	itiraf	itiraf	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
 10	etmekten	et	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	compound:lvc	_	_
 11	bile	bile	ADV	Adverb	_	9	advmod:emph	_	_
-12	utandığım	utan	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	15	acl	_	_
-13-14	hırpalayıcı	_	_	_	_	_	_	_	_
-13	hırpala	hırpala	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres	15	nmod	_	_
-14	yıcı	ci	ADP	Agt	_	13	case	_	_
-15	kıskançlığımla	kıskançlık	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	6	conj	_	SpaceAfter=No
-16	,	,	PUNCT	Punc	_	15	punct	_	_
-17	aptalca	aptalca	ADV	Adverb	_	18	advmod	_	_
-18	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	19	obj	_	_
-19	bile	bile	ADV	Adverb	_	24	advmod	_	_
-20	bile	bil	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	19	compound:redup	_	_
-21	daha	daha	ADV	Adverb	_	22	advmod	_	_
-22	çok	çok	ADJ	Adj	_	23	det	_	_
-23	kadınla	kadın	ADJ	NAdj	Case=Ins|Number=Sing|Person=3	24	amod	_	_
-24	birlikte	birlikte	ADV	Adverb	_	0	root	_	_
-25	oluyor	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	24	compound:lvc	_	_
-26	ve	ve	CCONJ	Conj	_	34	cc	_	_
-27	sonunda	sonunda	ADV	Adverb	_	34	advmod	_	_
-28	korktuğuma	kork	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	29	acl	_	_
-29	uğrayıp	uğra	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	34	nmod	_	_
-30	bir	bir	NUM	ANum	NumType=Card	32	det	_	_
-31	başka	başka	ADJ	Adj	_	32	amod	_	_
-32	erkek	erkek	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	34	amod	_	_
-33	için	için	ADP	PCNom	_	32	case	_	_
-34	terk	terk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	24	conj	_	_
-35	ediliyordum	et	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Pass	24	conj	_	SpaceAfter=No
-36	.	.	PUNCT	Punc	_	34	punct	_	_
+12	utandığım	utan	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	14	acl	_	_
+13	hırpalayıcı	hırpala	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	15	acl	_	_
+14	kıskançlığımla	kıskançlık	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	6	conj	_	SpaceAfter=No
+15	,	,	PUNCT	Punc	_	14	punct	_	_
+16	aptalca	aptalca	ADV	Adverb	_	18	advmod	_	_
+17	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	18	obj	_	_
+18	bile	bile	ADV	Adverb	_	23	advmod	_	_
+19	bile	bil	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	compound:redup	_	_
+20	daha	daha	ADV	Adverb	_	21	advmod	_	_
+21	çok	çok	ADJ	Adj	_	22	det	_	_
+22	kadınla	kadın	ADJ	NAdj	Case=Ins|Number=Sing|Person=3	23	amod	_	_
+23	birlikte	birlikte	ADV	Adverb	_	0	root	_	_
+24	oluyor	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	23	compound:lvc	_	_
+25	ve	ve	CCONJ	Conj	_	33	cc	_	_
+26	sonunda	sonunda	ADV	Adverb	_	33	advmod	_	_
+27	korktuğuma	kork	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	28	acl	_	_
+28	uğrayıp	uğra	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	33	nmod	_	_
+29	bir	bir	NUM	ANum	NumType=Card	31	det	_	_
+30	başka	başka	ADJ	Adj	_	31	amod	_	_
+31	erkek	erkek	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	33	amod	_	_
+32	için	için	ADP	PCNom	_	31	case	_	_
+33	terk	terk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	conj	_	_
+34	ediliyordum	et	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Pass	23	conj	_	SpaceAfter=No
+35	.	.	PUNCT	Punc	_	33	punct	_	_
 
 # sent_id = mst-5444
 # text = Hayatın böyle ya da başka türlü olmasını ne ya da kim sağlıyor, bu iyi mi kötü mü.

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -26888,7 +26888,7 @@
 # sent_id = mst-2988
 # text = Yüzde 3'lük Gabay kaldırılsın.
 # Fix 2.2/dev: form with '_'
-1	Yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	3	nummod	_	_
+1	Yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	4	nummod	_	_
 2-3	3'lük	_	_	_	_	_	_	_	_
 2	3	3	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	1	flat	_	_
 3	'lük	lik	ADP	Ness	_	2	case	_	_
@@ -31263,7 +31263,7 @@
 19	yoksullara	yoksul	ADJ	NAdj	Case=Dat|Number=Plur|Person=3	20	amod	_	_
 20	ulaştırılmak	ulaş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=CauPass	26	nmod	_	_
 21	üzere	üzere	ADP	PCNom	_	20	case	_	_
-22	onsekiz	onsekiz	NUM	ANum	NumType=Card	24	nummod	_	_
+22	onsekiz	onsekiz	NUM	ANum	NumType=Card	25	nummod	_	_
 23-24	trilyonluk	_	_	_	_	_	_	_	_
 23	trilyon	trilyon	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	22	flat	_	_
 24	luk	lik	ADP	Ness	_	23	case	_	_

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -5637,12 +5637,12 @@
 20	bir	bir	NUM	ANum	NumType=Card	22	nummod	_	_
 21	entelektüel	entelektüel	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	22	amod	_	_
 22	performans	performans	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	conj	_	_
-23	onlarla	on	NUM	NNum	Case=Ins|Number=Plur|NumType=Card|Person=3	25	nummod	_	_
-24	tanışanları	tanış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Part	26	ccomp	_	_
+23	onlarla	o	PRON	Demons	Case=Ins|Number=Plur|Person=3	24	obl	_	_
+24	tanışanları	tanış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Part	25	ccomp	_	_
 25	şaşırtır	şaşır	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	_
-26	ve	ve	CCONJ	Conj	_	28	cc	_	_
-27	çarpar	çarp	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	26	conj	_	SpaceAfter=No
-28	.	.	PUNCT	Punc	_	28	punct	_	_
+26	ve	ve	CCONJ	Conj	_	27	cc	_	_
+27	çarpar	çarp	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	25	conj	_	SpaceAfter=No
+28	.	.	PUNCT	Punc	_	27	punct	_	_
 
 # sent_id = mst-0641
 # text = Viski bardağını aldı, dikip bitirdi.
@@ -9888,10 +9888,10 @@
 # sent_id = mst-1096
 # text = Katana içeri girdi.
 # Change 2.2/dev: fix wrong analysis of proper name Katana
-1	Katana	Katana	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
+1	Katana	Katana	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
 2	içeri	içeri	NOUN	Noun	Case=Dat|Number=Sing|Person=3	0	root	_	_
-3	girdi	gir	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	compound	_	SpaceAfter=No
-4	.	.	PUNCT	Punc	_	3	punct	_	_
+3	girdi	gir	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	2	compound	_	SpaceAfter=No
+4	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-1098
 # text = Görgü tanıklarının ifadesine göre havada çarpışan uçaklar, İnkaya mevkiindeki ormanlık alanda ateş topu halinde düştü.
@@ -14796,7 +14796,7 @@
 9	Katana	Katana	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	conj	_	_
 10	Muharrem	Muharrem	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	conj	_	_
 11	gibileriyle	gibi	ADP	PCNom	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	12	obl	_	_
-12	arkadaşlık	arkadaşlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
+12	arkadaşlık	arkadaşlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	obl	_	_
 13	etmemden	et	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	12	compound:lvc	_	_
 14	kaynaklanıyor	kaynakla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
@@ -45151,7 +45151,7 @@
 18	yıl	yıl	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	nmod	_	_
 19-20	önceki	_	_	_	_	_	_	_	_
 19	önce	önce	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	nmod	_	_
-20	ki	ki	ADP	Rel	_	20	case	_	_
+20	ki	ki	ADP	Rel	_	19	case	_	_
 21	bir	bir	NUM	ANum	NumType=Card	22	det	_	_
 22	uygarlığın	uygarlık	NOUN	Noun	Case=Gen|Number=Sing|Person=3	23	nmod	_	_
 23	torunları	torun	NOUN	Noun	Case=Acc|Number=Plur|Person=3	24	obl	_	_

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -18849,6 +18849,7 @@
 
 # sent_id = mst-2087
 # text = Hazine garantileri nedeniyle doğabilecek ödemeler için de üçyüzyirmialtı trilyon liralık ödenek ayrıldı.
+# Fix 2.2/dev: form with '_'
 1	Hazine	hazine	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	garantileri	garanti	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	3	nmod	_	_
 3	nedeniyle	neden	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obl	_	_
@@ -18859,8 +18860,8 @@
 8	üçyüzyirmialtı	üçyüzyirmialtı	NUM	ANum	NumType=Card	11	nummod	_	_
 9	trilyon	trilyon	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	8	flat	_	_
 10-11	liralık	_	_	_	_	_	_	_	_
-10	_	lira	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	flat	_	_
-11	liralık	_	ADJ	Adj	_	12	amod	_	_
+10	lira	lira	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nmod	_	_
+11	lık	lik	ADP	Ness	_	10	case	_	_
 12	ödenek	ödenek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obj	_	_
 13	ayrıldı	ayrıl	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
@@ -26886,10 +26887,11 @@
 
 # sent_id = mst-2988
 # text = Yüzde 3'lük Gabay kaldırılsın.
+# Fix 2.2/dev: form with '_'
 1	Yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	3	nummod	_	_
 2-3	3'lük	_	_	_	_	_	_	_	_
-2	_	3	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	1	flat	_	_
-3	3'lük	_	ADJ	Adj	_	4	amod	_	_
+2	3	3	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	1	flat	_	_
+3	'lük	lik	ADP	Ness	_	2	case	_	_
 4	Gabay	Gabay	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	obj	_	_
 5	kaldırılsın	kal	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=CauPass	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
@@ -31239,6 +31241,7 @@
 
 # sent_id = mst-3476
 # text = Başbakan Abdullah Gül imzasıyla dün tüm valilere gönderilen genelgede yoksullukla mücadele için ilk adım olarak Ramazan Bayramı öncesi yoksullara ulaştırılmak üzere onsekiz trilyonluk kaynak ayırdığı belirtildi.
+# Fix 2.2/dev: form with '_'
 1	Başbakan	başbakan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod	_	_
 2	Abdullah	Abdullah	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 3	Gül	Gül	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	flat	_	_
@@ -31262,8 +31265,8 @@
 21	üzere	üzere	ADP	PCNom	_	20	case	_	_
 22	onsekiz	onsekiz	NUM	ANum	NumType=Card	24	nummod	_	_
 23-24	trilyonluk	_	_	_	_	_	_	_	_
-23	_	trilyon	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	22	flat	_	_
-24	trilyonluk	_	ADJ	Adj	_	25	amod	_	_
+23	trilyon	trilyon	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	22	flat	_	_
+24	luk	lik	ADP	Ness	_	23	case	_	_
 25	kaynak	kaynak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	26	obj	_	_
 26	ayırdığı	ayır	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	27	nsubj	_	_
 27	belirtildi	belir	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=CauPass	0	root	_	SpaceAfter=No
@@ -47106,6 +47109,7 @@
 
 # sent_id = mst-5310
 # text = Yapı ve Kredi Bankası, sermaye artırımına katıldığı parayla şirkete yüzde yirmibeş'lik payla ortak oldu.
+# Fix 2.2/dev: form with '_'
 1	Yapı	yapı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	nsubj	_	_
 2	ve	ve	CCONJ	Conj	_	1	flat	_	_
 3	Kredi	kredi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	flat	_	_
@@ -47118,8 +47122,8 @@
 10	şirkete	şirket	NOUN	Noun	Case=Dat|Number=Sing|Person=3	15	obl	_	_
 11	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	13	nummod	_	_
 12-13	yirmibeş'lik	_	_	_	_	_	_	_	_
-12	_	yirmibeş	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	11	flat	_	_
-13	yirmibeş'lik	_	ADJ	Adj	_	14	amod	_	_
+12	yirmibeş	yirmibeş	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	11	flat	_	_
+13	'lik	lik	ADP	Ness	_	14	case	_	_
 14	payla	pay	NOUN	Noun	Case=Ins|Number=Sing|Person=3	15	obl	_	_
 15	ortak	ortak	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
 16	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	15	compound:lvc	_	SpaceAfter=No
@@ -50043,6 +50047,7 @@
 
 # sent_id = mst-5618
 # text = Bu kuruluşların ciro büyüklüklerine göre yaklaşık elli trilyonluk bir gelir sağlanacak.
+# Fix 2.2/dev: form with '_'
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	kuruluşların	kuruluş	NOUN	Noun	Case=Gen|Number=Plur|Person=3	4	nmod:poss	_	_
 3	ciro	ciro	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
@@ -50051,8 +50056,8 @@
 6	yaklaşık	yaklaşık	ADJ	Adj	_	7	amod	_	_
 7	elli	elli	NUM	ANum	NumType=Card	9	nummod	_	_
 8-9	trilyonluk	_	_	_	_	_	_	_	_
-8	_	trilyon	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	7	flat	_	_
-9	trilyonluk	_	ADJ	Adj	_	11	amod	_	_
+8	trilyon	trilyon	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	7	flat	_	_
+9	luk	lik	ADJ	Adj	_	11	amod	_	_
 10	bir	bir	NUM	ANum	NumType=Card	11	det	_	_
 11	gelir	gelir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
 12	sağlanacak	sağla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut|Voice=Pass	0	root	_	SpaceAfter=No

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -6,7 +6,7 @@
 3	sa	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	2	cop	_	_
 4	bunların	bu	PRON	Demons	Case=Gen|Number=Plur|Person=3|PronType=Dem	5	nmod:poss	_	_
 5	hiçbirini	hiçbiri	PRON	Quant	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	6	obj	_	_
-6	yapamazlar	yap	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+6	yapamazlar	yap	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-0004
@@ -396,7 +396,7 @@
 11	hisselerini	hisse	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	14	obj	_	_
 12	olumsuz	olumsuz	ADJ	Adj	_	13	amod	_	_
 13	yönde	yön	NOUN	Noun	Case=Loc|Number=Sing|Person=3	14	obl	_	_
-14	etkileyebilir	etkile	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+14	etkileyebilir	etkile	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-0053
@@ -405,7 +405,7 @@
 2	defasında	defa	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 3	laf	laf	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
 4	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
-5	gelir	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	7	acl	_	_
+5	gelir	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	acl	_	_
 6	gibi	gibi	ADP	PCNom	_	5	case	_	_
 7	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	17	punct	_	_
@@ -653,10 +653,10 @@
 2	öğretmen	öğretmen	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
 3	daha	daha	ADV	Adverb	_	4	advmod	_	_
 4	sert	sert	ADJ	Adj	_	5	amod	_	_
-5	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	10	nmod	_	SpaceAfter=No
+5	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	10	nmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	8	punct	_	_
 7	kızlarla	kız	ADJ	NAdj	Case=Ins|Number=Plur|Person=3	8	amod	_	_
-8	anlaşamaz	anlaş	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	5	conj	_	_
+8	anlaşamaz	anlaş	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	5	conj	_	_
 9	diye	diye	ADP	PCNom	_	5	case	_	_
 10	düşünüyorum	düşün	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
@@ -705,7 +705,7 @@
 4	mutlaka	mutlaka	ADV	Adverb	_	7	advmod	_	_
 5	sevgi	sevgi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	compound	_	_
 6	sözcükleri	sözcük	NOUN	Noun	Case=Acc|Number=Plur|Person=3	7	obj	_	_
-7	kullanır	kullan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+7	kullanır	kullan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-0093
@@ -770,12 +770,12 @@
 # sent_id = mst-0100
 # text = İzini bulursanız, bu numaraya haber verirsiniz, dedi.
 1	İzini	iz	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	obj	_	_
-2	bulursanız	bul	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	9	obj	_	SpaceAfter=No
+2	bulursanız	bul	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	9	obj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	6	punct	_	_
 4	bu	bu	DET	Det	_	5	det	_	_
 5	numaraya	numara	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	nmod	_	_
 6	haber	haber	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	conj	_	_
-7	verirsiniz	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	6	compound	_	SpaceAfter=No
+7	verirsiniz	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	6	compound	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	6	punct	_	_
 9	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
@@ -948,7 +948,7 @@
 # sent_id = mst-0116
 # text = Keşfetmeyi severler.
 1	Keşfetmeyi	keşfet	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	2	obj	_	_
-2	severler	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	severler	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0117
@@ -961,7 +961,7 @@
 6	yapacağımız	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=1|Polarity=Pos|Tense=Fut|VerbForm=Part	7	acl	_	_
 7	çalışmayı	çalış	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	obj	_	_
 8	asistanıma	asistan	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	9	obl	_	_
-9	anlatırken	anlat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	11	nmod	_	_
+9	anlatırken	anlat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	11	nmod	_	_
 10	kapı	kapı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
 11	çaldı	çal	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
@@ -976,7 +976,7 @@
 # sent_id = mst-0121
 # text = Ütüden anlamam.
 1	Ütüden	ütü	NOUN	Noun	Case=Abl|Number=Sing|Person=3	2	obl	_	_
-2	anlamam	anla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+2	anlamam	anla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0122
@@ -1023,7 +1023,7 @@
 7	sözcüğüne	sözcük	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obl	_	_
 8	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	_	_
 9	hala	hala	ADV	Adverb	_	10	advmod	_	_
-10	şaşarım	şaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+10	şaşarım	şaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-0131
@@ -1545,7 +1545,7 @@
 # text = Yerini pek değiştirmez.
 1	Yerini	yer	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
 2	pek	pek	ADV	Adverb	_	3	advmod	_	_
-3	değiştirmez	değiş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+3	değiştirmez	değiş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-0202
@@ -1577,7 +1577,7 @@
 # text = Soğuk iklimi severler.
 1	Soğuk	soğuk	ADJ	Adj	_	2	amod	_	_
 2	iklimi	iklim	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	obj	_	_
-3	severler	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	severler	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-0206
@@ -1746,7 +1746,7 @@
 # text = Bir kuramı oluştururken kullanılan ilk ilkelerin, hipotezlerin gözlemlerden türetilmiş olması istenen bir durumdur.
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	kuramı	kuram	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
-3	oluştururken	oluş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv|Voice=Cau	4	nmod	_	_
+3	oluştururken	oluş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	4	nmod	_	_
 4	kullanılan	kullan	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	6	acl	_	_
 5	ilk	ilk	ADJ	Adj	_	6	amod	_	_
 6	ilkelerin	ilke	NOUN	Noun	Case=Gen|Number=Plur|Person=3	11	nmod:poss	_	SpaceAfter=No
@@ -1823,7 +1823,7 @@
 2	odasında	oda	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 3	cam	cam	ADJ	Adj	_	4	amod	_	_
 4	kaseye	kase	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
-5	kurulur	kur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+5	kurulur	kur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-0236
@@ -1880,7 +1880,7 @@
 5	gasp	gasp	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
 6	edildi	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	5	compound:lvc	_	_
 7	'	'	PUNCT	Punc	_	5	punct	_	_
-8	diyebiliriz	de	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+8	diyebiliriz	de	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-0243
@@ -1926,7 +1926,7 @@
 6	çakıştıran	çakış	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	5	compound	_	_
 7	bir	bir	NUM	ANum	NumType=Card	8	det	_	_
 8	çocuk	çocuk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
-9	yetiştirir	yetiş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	11	nmod	_	_
+9	yetiştirir	yetiş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	11	nmod	_	_
 10	diye	diye	ADP	PCNom	_	9	case	_	_
 11	şaşakalmıştık	şaşakal	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
@@ -2112,7 +2112,7 @@
 
 # sent_id = mst-0274
 # text = Anlatırım.
-1	Anlatırım	anlat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+1	Anlatırım	anlat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-0275
@@ -2138,7 +2138,7 @@
 4	protokolün	protokol	NOUN	Noun	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
 5	bir	bir	NUM	ANum	NumType=Card	6	det	_	_
 6	tarafında	taraf	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obl	_	_
-7	otururken	otur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	14	nmod	_	SpaceAfter=No
+7	otururken	otur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	14	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	diğer	diğer	ADJ	Adj	_	10	amod	_	_
 10	tarafta	taraf	NOUN	Noun	Case=Loc|Number=Sing|Person=3	14	nmod	_	_
@@ -2261,7 +2261,7 @@
 12	kendiliğinden	kendiliğinden	ADV	Adverb	_	15	advmod	_	_
 13	soğuk	soğuk	ADJ	Adj	_	15	obj	_	_
 14	kaçtığını	kaç	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	13	compound	_	_
-15	anlar	anla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+15	anlar	anla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 16	,	,	PUNCT	Punc	_	23	punct	_	_
 17	bir	bir	ADV	Adverb	_	23	advmod	_	_
 18	daha	daha	ADV	Adverb	_	17	advmod	_	_
@@ -2291,7 +2291,7 @@
 9	yasaları	yasa	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	10	nsubj	_	_
 10	uyarınca	uyar	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	11	nmod	_	_
 11	cereyan	cereyan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-12	eder	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	11	compound:lvc	_	SpaceAfter=No
+12	eder	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	compound:lvc	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-0293
@@ -2333,7 +2333,7 @@
 12	başlayan	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	14	acl	_	_
 13	bir	bir	NUM	ANum	NumType=Card	14	nummod	_	_
 14	cümle	cümle	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	obj	_	_
-15	kuramazsınız	kur	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Tense=Aor	1	conj	_	SpaceAfter=No
+15	kuramazsınız	kur	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	1	conj	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-0297
@@ -2341,7 +2341,7 @@
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	3	obl	_	_
 2	kadar	kadar	ADP	PCDat	_	1	case	_	_
 3	zengin	zengin	ADJ	Adj	_	4	obj	_	_
-4	olursan	ol	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	32	nmod	_	_
+4	olursan	ol	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	32	nmod	_	_
 5	ol	ol	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	4	compound	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	4	punct	_	_
 7	diyor	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
@@ -2370,7 +2370,7 @@
 30	bakıyor	bak	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	27	compound	_	SpaceAfter=No
 31	)	)	PUNCT	Punc	_	13	punct	_	_
 32	sıfırı	sıfır	NUM	NNum	Case=Acc|Number=Sing|NumType=Card|Person=3	7	conj	_	_
-33	tüketirsin	tüket	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	32	compound	_	SpaceAfter=No
+33	tüketirsin	tüket	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	32	compound	_	SpaceAfter=No
 34	.	.	PUNCT	Punc	_	32	punct	_	_
 
 # sent_id = mst-0299
@@ -2679,7 +2679,7 @@
 24	güzelliğini	güzellik	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	26	obj	_	_
 25	bile	bile	ADV	Adverb	_	24	advmod:emph	_	_
 26	fark	fark	NOUN	Noun	Case=Nom|Number=Sing|Person=3	28	nmod	_	_
-27	edemez	et	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Neg|Tense=Aor|VerbForm=Part	26	compound:lvc	_	_
+27	edemez	et	VERB	Verb	Aspect=Hab|Mood=Pot|Polarity=Neg|Tense=Pres|VerbForm=Part	26	compound:lvc	_	_
 28	hale	hal	NOUN	Noun	Case=Dat|Number=Sing|Person=3	13	conj	_	_
 29	gelmiştim	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pqp	28	compound	_	SpaceAfter=No
 30	.	.	PUNCT	Punc	_	28	punct	_	_
@@ -2797,7 +2797,7 @@
 7	hatta	hatta	CCONJ	Conj	_	8	cc	_	_
 8	seslerini	ses	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	1	conj	_	_
 9	bile	bile	ADV	Adverb	_	8	advmod:emph	_	_
-10	değiştirebilirler	değiş	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+10	değiştirebilirler	değiş	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 11	,	,	PUNCT	Punc	_	19	punct	_	_
 12	ama	ama	CCONJ	Conj	_	19	cc	_	_
 13	o	o	DET	Det	_	14	det	_	_
@@ -2865,7 +2865,7 @@
 22	kavramlarla	kavram	NOUN	Noun	Case=Ins|Number=Plur|Person=3	25	obl	_	_
 23	o	o	DET	Det	_	24	det	_	_
 24	ideolojiyi	ideoloji	NOUN	Noun	Case=Acc|Number=Sing|Person=3	25	obj	_	_
-25	etkiler	etkile	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	14	conj	_	SpaceAfter=No
+25	etkiler	etkile	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	14	conj	_	SpaceAfter=No
 26	.	.	PUNCT	Punc	_	25	punct	_	_
 
 # sent_id = mst-0330
@@ -2887,7 +2887,7 @@
 # sent_id = mst-0331
 # text = İşe yarar mı ki...
 1	İşe	iş	NOUN	Noun	Case=Dat|Number=Sing|Person=3	0	root	_	_
-2	yarar	yara	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound	_	_
+2	yarar	yara	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	_
 3	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	1	aux:q	_	_
 4	ki	ki	CCONJ	Conj	_	1	advmod:emph	_	SpaceAfter=No
 5	...	...	PUNCT	Punc	_	1	punct	_	_
@@ -2907,7 +2907,7 @@
 # sent_id = mst-0334
 # text = Akıl alır gibi değil.
 1	Akıl	akıl	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	alır	al	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	1	compound	_	_
+2	alır	al	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	1	compound	_	_
 3	gibi	gibi	ADP	PCNom	_	1	compound	_	_
 4	değil	değil	VERB	Neg	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	1	compound	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	1	punct	_	_
@@ -3196,7 +3196,7 @@
 # sent_id = mst-0364
 # text = Şimdi varırız oraya, dedi Kerem.
 1	Şimdi	şimdi	ADV	Adverb	_	2	advmod	_	_
-2	varırız	var	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	5	obj	_	_
+2	varırız	var	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	5	obj	_	_
 3	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	2	punct	_	_
 5	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
@@ -3238,7 +3238,7 @@
 13	inananlar	inan	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	15	acl	_	_
 14	için	için	ADP	PCNom	_	13	case	_	_
 15	tehlike	tehlike	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-16	yaratır	yarat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	15	compound	_	SpaceAfter=No
+16	yaratır	yarat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	15	compound	_	SpaceAfter=No
 17	:	:	PUNCT	Punc	_	33	punct	_	_
 18	diferansiyel	diferansiyel	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	nmod	_	_
 19-20	eşitliklerinizdeki	_	_	_	_	_	_	_	_
@@ -3257,7 +3257,7 @@
 31	tekillikle	tekillik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	32	nmod	_	_
 32	birlikte	birlik	NOUN	Noun	Case=Loc|Number=Sing|Person=3	33	obl	_	_
 33	ortadan	orta	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	15	conj	_	_
-34	kalkar	kalk	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	33	compound	_	SpaceAfter=No
+34	kalkar	kalk	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	33	compound	_	SpaceAfter=No
 35	.	.	PUNCT	Punc	_	33	punct	_	_
 
 # sent_id = mst-0371
@@ -3402,7 +3402,7 @@
 # text = Golf de oynarlar.
 1	Golf	golf	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 2	de	de	CCONJ	Conj	_	1	advmod:emph	_	_
-3	oynarlar	oyna	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	oynarlar	oyna	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-0385
@@ -3412,7 +3412,7 @@
 3	öyle	öyle	ADJ	Adj	_	2	cc	_	_
 4	oyuncu	oyuncu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
 5	ki	ki	CCONJ	Conj	_	4	mark	_	_
-6	anlatamam	anlat	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+6	anlatamam	anlat	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-0387
@@ -3459,7 +3459,7 @@
 12	yok	yok	ADV	Adverb	_	5	advmod	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	15	punct	_	_
 14	yalnız	yalnız	ADV	Adverb	_	15	advmod	_	_
-15	dinler	dinle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	SpaceAfter=No
+15	dinler	dinle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	conj	_	SpaceAfter=No
 16	...	...	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-0391
@@ -3501,7 +3501,7 @@
 6	ay	ay	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
 7	dır	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	6	cop	_	_
 8	bakıyorlar	bak	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	2	conj	_	_
-9	alışır	alış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	conj	_	_
+9	alışır	alış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	conj	_	_
 10	insan	insan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
 11	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	13	obl	_	_
 12	kadar	kadar	ADP	PCDat	_	11	case	_	_
@@ -3526,7 +3526,7 @@
 # text = Lezzetini de kaybetmez.
 1	Lezzetini	lezzet	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obj	_	_
 2	de	de	CCONJ	Conj	_	1	advmod:emph	_	_
-3	kaybetmez	kaybet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+3	kaybetmez	kaybet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-0398
@@ -3545,11 +3545,11 @@
 12	yarısını	yarı	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	obj	_	_
 13	kesip	kes	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	15	nmod	_	_
 14	size	siz	PRON	Pers	Case=Dat|Number=Plur|Person=2|PronType=Prs	15	obl	_	_
-15	verir	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+15	verir	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 16	(	(	PUNCT	Punc	_	19	punct	_	SpaceAfter=No
 17	Karım	karı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	19	nsubj	_	_
 18	böyle	böyle	ADV	Adverb	_	19	advmod	_	_
-19	yapar	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	15	parataxis	_	SpaceAfter=No
+19	yapar	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	15	parataxis	_	SpaceAfter=No
 20	)	)	PUNCT	Punc	_	19	punct	_	SpaceAfter=No
 21	.	.	PUNCT	Punc	_	19	punct	_	_
 
@@ -3576,7 +3576,7 @@
 18	iş	iş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	nmod:poss	_	_
 19	hayatlarını	hayat	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	21	obj	_	_
 20	pürdikkat	pürdikkat	ADV	Adverb	_	21	advmod	_	_
-21	dinlerler	dinle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+21	dinlerler	dinle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 22	.	.	PUNCT	Punc	_	21	punct	_	_
 
 # sent_id = mst-0402
@@ -3650,7 +3650,7 @@
 6	koyu	koyu	ADJ	Adj	_	8	amod	_	_
 7	gür	gür	ADJ	Adj	_	8	amod	_	_
 8	sakallı	sakallı	ADJ	Adj	_	3	conj	_	_
-9	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+9	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 10	Tatarlar	Tatarlar	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nsubj	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
@@ -3741,7 +3741,7 @@
 # sent_id = mst-0419
 # text = Kimseyle konuşmaz ilk kocası.
 1	Kimseyle	kimse	NOUN	Noun	Case=Ins|Number=Sing|Person=3	2	obl	_	_
-2	konuşmaz	konuş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	_
+2	konuşmaz	konuş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
 3	ilk	ilk	ADJ	Adj	_	4	det	_	_
 4	kocası	koca	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	nsubj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	2	punct	_	_
@@ -3817,7 +3817,7 @@
 17	test	test	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	obj	_	_
 18	edilebileceğini	et	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	17	compound:lvc	_	_
 19	tahmin	tahmin	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-20	edebiliriz	et	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	19	compound:lvc	_	SpaceAfter=No
+20	edebiliriz	et	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	19	compound:lvc	_	SpaceAfter=No
 21	.	.	PUNCT	Punc	_	19	punct	_	_
 
 # sent_id = mst-0430
@@ -4055,7 +4055,7 @@
 # text = Kadın uyuduysa okur, dedi adam.
 1	Kadın	kadın	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	uyuduysa	uyu	VERB	Verb	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	nmod	_	_
-3	okur	oku	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	obj	_	SpaceAfter=No
+3	okur	oku	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	obj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	3	punct	_	_
 5	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 6	adam	adam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	SpaceAfter=No
@@ -4215,7 +4215,7 @@
 10	tanrının	tanrı	NOUN	Noun	Case=Gen|Number=Sing|Person=3	11	nmod:poss	_	_
 11	istemi	istem	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	nmod:poss	_	_
 12	doğrultusunda	doğrultu	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	obl	_	_
-13	gerçekleşir	gerçekleş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	8	conj	_	SpaceAfter=No
+13	gerçekleşir	gerçekleş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	conj	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-0474
@@ -4321,7 +4321,7 @@
 
 # sent_id = mst-0481
 # text = Anlarsın ya...
-1	Anlarsın	anla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Anlarsın	anla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	_
 2	ya	ya	CCONJ	Conj	_	1	advmod:emph	_	SpaceAfter=No
 3	...	...	PUNCT	Punc	_	1	punct	_	_
 
@@ -4507,7 +4507,7 @@
 5	başka	başka	ADJ	Adj	_	7	amod	_	_
 6	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
 7	biçimde	biçim	NOUN	Noun	Case=Loc|Number=Sing|Person=3	8	obl	_	_
-8	bitirirsiniz	bitir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+8	bitirirsiniz	bitir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-0499
@@ -4533,7 +4533,7 @@
 1	Ayla	Ayla	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 2	:	:	PUNCT	Punc	_	6	punct	_	_
 3	Böyle	böyle	ADV	Adverb	_	4	advmod	_	_
-4	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	obj	_	_
+4	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	obj	_	_
 5	mu	mu	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	4	aux:q	_	_
 6	bilmiyorum	bil	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
@@ -4688,7 +4688,7 @@
 10	sürece	süre	NOUN	Noun	Case=Equ|Number=Sing|Person=3	13	obl	_	_
 11	hiçbir	hiçbir	DET	Det	_	13	obj	_	_
 12	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	compound	_	_
-13	yapamam	yap	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	3	conj	_	_
+13	yapamam	yap	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	3	conj	_	_
 14	ki	ki	CCONJ	Conj	_	13	advmod:emph	_	SpaceAfter=No
 15	!	!	PUNCT	Punc	_	13	punct	_	_
 
@@ -4789,7 +4789,7 @@
 2	orayı	ora	PRON	Noun	Case=Acc|Number=Sing|Person=3	5	obj	_	_
 3	bir	bir	ADV	Adverb	_	5	advmod	_	_
 4	daha	daha	ADV	Adverb	_	3	advmod	_	_
-5	bulamazsam	bul	VERB	Verb	Aspect=Imp|Mood=CndPot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+5	bulamazsam	bul	VERB	Verb	Aspect=Hab|Mood=CndPot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 6	?	?	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-0530
@@ -4905,7 +4905,7 @@
 9	,	,	PUNCT	Punc	_	10	punct	_	_
 10	viski	viski	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	conj	_	_
 11	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	12	obj	_	_
-12	bulursam	bul	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	17	obj	_	SpaceAfter=No
+12	bulursam	bul	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	17	obj	_	SpaceAfter=No
 13	;	;	PUNCT	Punc	_	12	punct	_	_
 14	birer	birer	NUM	ANum	NumType=Dist	16	amod	_	_
 15	ikişer	iki	NUM	ANum	NumType=Dist	14	compound:redup	_	_
@@ -5091,7 +5091,7 @@
 2	tanındığı	tanı	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	3	acl	_	_
 3	yerlere	yer	NOUN	Noun	Case=Dat|Number=Plur|Person=3	4	obl	_	_
 4	gitmek	git	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	obj	_	_
-5	ister	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	ister	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-0568
@@ -5144,7 +5144,7 @@
 # sent_id = mst-0572
 # text = Benzetmek gerekirse, Lahana kanlı-canlı, tuttuğunu koparan bir Kuzeyli güzelidir.
 1	Benzetmek	benze	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	14	nmod	_	_
-2	gerekirse	gerek	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound	_	SpaceAfter=No
+2	gerekirse	gerek	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	1	punct	_	_
 4	Lahana	lahana	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	nsubj	_	_
 5	kanlı	kanlı	ADJ	Adj	_	14	amod	_	SpaceAfter=No
@@ -5199,7 +5199,7 @@
 8	ve	ve	CCONJ	Conj	_	12	cc	_	_
 9	değiştirilmesi	değiş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=CauPass	10	nsubj	_	_
 10	teklif	teklif	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nmod	_	_
-11	edilemez	et	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	10	compound:lvc	_	_
+11	edilemez	et	VERB	Verb	Aspect=Hab|Mood=Pot|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	10	compound:lvc	_	_
 12	maddeleri	madde	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	3	conj	_	_
 13	yeni	yeni	ADJ	Adj	_	14	amod	_	_
 14	anayasada	anayasa	NOUN	Noun	Case=Loc|Number=Sing|Person=3	15	nmod	_	_
@@ -5476,7 +5476,7 @@
 # text = Avrupalı Bulgar der ama yanlış.
 1	Avrupalı	Avrupalı	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	Bulgar	Bulgar	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	3	obj	_	_
-3	der	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+3	der	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 4	ama	ama	CCONJ	Conj	_	5	cc	_	_
 5	yanlış	yanlış	ADJ	Adj	_	3	conj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
@@ -5506,7 +5506,7 @@
 6	eninde	en	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
 7	sonunda	sonunda	ADV	Adverb	_	6	advmod	_	_
 8	ölüm	ölü	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	9	nsubj	_	_
-9	girer	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+9	girer	gir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-0627
@@ -5652,9 +5652,9 @@
 22	performans	performans	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	conj	_	_
 23	onlarla	o	PRON	Demons	Case=Ins|Number=Plur|Person=3	24	obl	_	_
 24	tanışanları	tanış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Part	25	ccomp	_	_
-25	şaşırtır	şaşır	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	_
+25	şaşırtır	şaşır	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	_
 26	ve	ve	CCONJ	Conj	_	27	cc	_	_
-27	çarpar	çarp	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	25	conj	_	SpaceAfter=No
+27	çarpar	çarp	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	25	conj	_	SpaceAfter=No
 28	.	.	PUNCT	Punc	_	27	punct	_	_
 
 # sent_id = mst-0641
@@ -5698,7 +5698,7 @@
 # text = Bu gece ulaştırmam gerek...
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	gece	gece	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obl	_	_
-3	ulaştırmam	ulaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor|Voice=Cau	4	nsubj	_	_
+3	ulaştırmam	ulaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres|Voice=Cau	4	nsubj	_	_
 4	gerek	gerek	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	...	...	PUNCT	Punc	_	4	punct	_	_
 
@@ -5799,7 +5799,7 @@
 12	,	,	PUNCT	Punc	_	15	punct	_	_
 13	o	o	DET	Det	_	14	det	_	_
 14	hacmi	hacim	NOUN	Noun	Case=Acc|Number=Sing|Person=3	15	obj	_	_
-15	mekanlaştırmaz	mekanlaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+15	mekanlaştırmaz	mekanlaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	1	conj	_	_
 
 # sent_id = mst-0658
@@ -5941,7 +5941,7 @@
 
 # sent_id = mst-0677
 # text = Yarayabilir.
-1	Yarayabilir	yara	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+1	Yarayabilir	yara	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-0679
@@ -6041,7 +6041,7 @@
 2	kapıları	kapı	NOUN	Noun	Case=Acc|Number=Plur|Person=3	4	obj	_	_
 3	boşuna	boşuna	ADV	Adverb	_	4	advmod	_	_
 4	bulmaya	bul	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	nmod	_	_
-5	çalışırsın	çalış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	7	obj	_	SpaceAfter=No
+5	çalışırsın	çalış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	7	obj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	5	punct	_	_
 7	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
@@ -6095,7 +6095,7 @@
 
 # sent_id = mst-0696
 # text = Sanırım gezmediği ülke, danışmanı olmadığı kimse, bilmediği ilke kalmadı.
-1	Sanırım	san	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Sanırım	san	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 2	gezmediği	gez	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	3	acl	_	_
 3	ülke	ülke	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	7	punct	_	_
@@ -6157,7 +6157,7 @@
 # text = Kavurup leblebi yaparlar.
 1	Kavurup	kavur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	3	nmod	_	_
 2	leblebi	leblebi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
-3	yaparlar	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	yaparlar	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-0704
@@ -6180,7 +6180,7 @@
 14	buzlanmadan	buzlan	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	conj	_	_
 15	dolayı	dolayı	ADP	PCAbl	_	8	case	_	_
 16	düşmüş	düş	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	17	obj	_	_
-17	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	SpaceAfter=No
+17	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	conj	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-0706
@@ -6605,7 +6605,7 @@
 1	Timur	Timur	PROPN	Prop	Case=Nom|Number=Sing|Person=3	13	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	13	punct	_	_
 3	uyuşturucu	uyuşturucu	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	4	obj	_	_
-4	kullanırken	kullan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	13	nmod	_	_
+4	kullanırken	kullan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	13	nmod	_	_
 5	etrafımda	etraf	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	6	obl	_	_
 6	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	acl	_	_
 7	biten	bit	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	compound	_	_
@@ -6849,7 +6849,7 @@
 4-5	Üstündekiler	_	_	_	_	_	_	_	_
 4	Üstünde	üst	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	6	obj	_	_
 5	kiler	ki	ADP	Rel	Case=Nom|Number=Plur|Person=3	4	case	_	_
-6	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+6	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-0782
@@ -6911,7 +6911,7 @@
 12	ürünü	ürün	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	obj	_	_
 13	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	14	acl	_	_
 14	mantığı	mantık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obj	_	_
-15	saymazsak	say	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+15	saymazsak	say	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 16	,	,	PUNCT	Punc	_	23	punct	_	_
 17	iki	iki	NUM	ANum	NumType=Card	18	nummod	_	_
 18-19	önemli	_	_	_	_	_	_	_	_
@@ -7046,7 +7046,7 @@
 # sent_id = mst-0804
 # text = Size kalırsa nal toplayacağız " diye tepki gösterdiler.
 1	Size	siz	PRON	Pers	Case=Dat|Number=Plur|Person=2|PronType=Prs	3	nmod	_	_
-2	kalırsa	kal	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound	_	_
+2	kalırsa	kal	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	_
 3	nal	nal	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
 4	toplayacağız	topla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Fut	3	compound	_	_
 5	"	"	PUNCT	Punc	_	3	punct	_	_
@@ -7086,7 +7086,7 @@
 24	halkta	halk	NOUN	Noun	Case=Loc|Number=Sing|Person=3	25	obl	_	_
 25	bölünmeye	böl	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	26	nmod	_	_
 26	yol	yol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-27	açabilir	aç	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	26	compound	_	SpaceAfter=No
+27	açabilir	aç	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	26	compound	_	SpaceAfter=No
 28	.	.	PUNCT	Punc	_	27	punct	_	_
 
 # sent_id = mst-0807
@@ -7340,7 +7340,7 @@
 # sent_id = mst-0838
 # text = Nasıl olur.
 1	Nasıl	nasıl	ADV	Adverb	_	2	advmod	_	_
-2	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0840
@@ -7492,7 +7492,7 @@
 29	reşit	reşit	ADJ	Adj	_	32	obj	_	_
 30	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	29	compound:lvc	_	_
 31	"	"	PUNCT	Punc	_	29	punct	_	_
-32	diyebiliriz	de	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+32	diyebiliriz	de	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 33	.	.	PUNCT	Punc	_	32	punct	_	_
 
 # sent_id = mst-0854
@@ -7543,7 +7543,7 @@
 2	oğlum	oğul	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	1	conj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	9	punct	_	_
 4	şimdi	şimdi	ADV	Adverb	_	5	advmod	_	_
-5	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	9	obj	_	SpaceAfter=No
+5	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	9	obj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	5	punct	_	_
 7	ayıp	ayıp	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	9	punct	_	_
@@ -7631,18 +7631,18 @@
 15	sevişebilmek	seviş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	17	nmod	_	_
 16	için	için	ADP	PCNom	_	15	case	_	_
 17	yalan	yalan	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	5	conj	_	_
-18	söyleyebilir	söyle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	17	compound	_	SpaceAfter=No
+18	söyleyebilir	söyle	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	17	compound	_	SpaceAfter=No
 19	,	,	PUNCT	Punc	_	23	punct	_	_
 20	ama	ama	CCONJ	Conj	_	23	cc	_	_
 21	seviştikten	seviş	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	23	acl	_	_
 22	sonra	sonra	ADP	PCAbl	_	21	case	_	_
-23	sevebilir	sev	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	SpaceAfter=No
+23	sevebilir	sev	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	conj	_	SpaceAfter=No
 24	,	,	PUNCT	Punc	_	28	punct	_	_
 25	bundan	bu	PRON	Demons	Case=Abl|Number=Sing|Person=3|PronType=Dem	28	obl	_	_
 26	sonra	sonra	ADP	PCAbl	_	25	case	_	_
 27	ise	i	AUX	Conj	_	25	discourse	_	_
 28	yalan	yalan	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	5	conj	_	_
-29	söylemez	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	5	conj	_	SpaceAfter=No
+29	söylemez	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	5	conj	_	SpaceAfter=No
 30	.	.	PUNCT	Punc	_	28	punct	_	_
 
 # sent_id = mst-0867
@@ -7914,7 +7914,7 @@
 4	,	,	PUNCT	Punc	_	3	punct	_	_
 5	sevgilinin	sevgili	ADJ	NAdj	Case=Gen|Number=Sing|Person=3	10	nmod:poss	_	_
 6-7	uyurkenki	_	_	_	_	_	_	_	_
-6	uyurken	uyu	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	10	nmod	_	_
+6	uyurken	uyu	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	10	nmod	_	_
 7	ki	ki	ADP	Rel	_	6	case	_	_
 8	beş	beş	NUM	ANum	NumType=Card	10	nummod	_	_
 9	ayrı	ayrı	ADJ	Adj	_	10	amod	_	_
@@ -8009,7 +8009,7 @@
 
 # sent_id = mst-0899
 # text = Bakarız, dedi kadın, sonra sandalyesini biraz yan çevirdi, çalgıcıları görmek için.
-1	Bakarız	bak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	3	obj	_	SpaceAfter=No
+1	Bakarız	bak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	3	obj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	1	punct	_	_
 3	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 4	kadın	kadın	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	3	nsubj	_	SpaceAfter=No
@@ -8148,7 +8148,7 @@
 1	Artık	artık	ADV	Adverb	_	4	advmod	_	_
 2	hiçbir	hiçbir	DET	Det	_	4	nsubj	_	_
 3	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound	_	_
-4	avutamaz	avut	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	_
+4	avutamaz	avut	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
 5	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	4	obj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	4	punct	_	_
 7	kendimi	kendi	PRON	Reflex	Case=Acc|Number=Sing|Number[psor]=Sing|Person=1|Person[psor]=1|Reflex=Yes	9	obl	_	_
@@ -8173,7 +8173,7 @@
 10	de	de	CCONJ	Conj	_	9	advmod:emph	_	_
 11	uzanarak	uza	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	12	nmod	_	_
 12	analiz	analiz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	obl	_	_
-13	ederken	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	12	compound:lvc	_	_
+13	ederken	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	12	compound:lvc	_	_
 14	dosyamıza	dosya	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	17	obl	_	_
 15	güzel	güzel	ADJ	Adj	_	17	amod	_	_
 16	bir	bir	NUM	ANum	NumType=Card	17	det	_	_
@@ -8364,15 +8364,15 @@
 4	,	,	PUNCT	Punc	_	3	punct	_	_
 5	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 6	Katana	katana	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
-7	duyulur	duy	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	10	acl	_	_
-8	duyulmaz	duy	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	7	compound	_	_
+7	duyulur	duy	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	10	acl	_	_
+8	duyulmaz	duy	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	7	compound	_	_
 9	bir	bir	NUM	ANum	NumType=Card	10	det	_	_
 10	sesle	ses	NOUN	Noun	Case=Ins|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-0938
 # text = Sakinleştirir bu beni yavaş yavaş.
-1	Sakinleştirir	sakinleş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	_
+1	Sakinleştirir	sakinleş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	_
 2	bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	1	nsubj	_	_
 3	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	1	obj	_	_
 4	yavaş	yavaş	ADJ	Adj	_	1	amod	_	_
@@ -8483,7 +8483,7 @@
 1	Bazen	bazen	ADV	Adverb	_	4	advmod	_	_
 2	çok	çok	ADJ	Adj	_	3	amod	_	_
 3	para	para	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
-4	verir	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+4	verir	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 5	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	4	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -8543,7 +8543,7 @@
 
 # sent_id = mst-0957
 # text = İnanır mı.
-1	İnanır	inan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+1	İnanır	inan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 2	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	1	aux:q	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
@@ -8638,18 +8638,18 @@
 # text = O kişi olmazsa yaşayamam; sekssiz yaşayamam; alkolsüz bir hayat düşünemem; başarı için günde on altı saat çalışmam gerekir vb.
 1	O	o	DET	Det	_	2	det	_	_
 2	kişi	kişi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
-3	olmazsa	ol	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	4	nmod	_	_
-4	yaşayamam	yaşa	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+3	olmazsa	ol	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	4	nmod	_	_
+4	yaşayamam	yaşa	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	;	;	PUNCT	Punc	_	8	punct	_	_
 6-7	sekssiz	_	_	_	_	_	_	_	_
 6	seks	seks	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
 7	siz	siz	ADP	Without	_	6	case	_	_
-8	yaşayamam	yaşa	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	4	conj	_	SpaceAfter=No
+8	yaşayamam	yaşa	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	4	conj	_	SpaceAfter=No
 9	;	;	PUNCT	Punc	_	13	punct	_	_
 10	alkolsüz	alkolsüz	ADJ	Adj	_	12	amod	_	_
 11	bir	bir	NUM	ANum	NumType=Card	12	det	_	_
 12	hayat	hayat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obj	_	_
-13	düşünemem	düşün	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	4	conj	_	SpaceAfter=No
+13	düşünemem	düşün	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	4	conj	_	SpaceAfter=No
 14	;	;	PUNCT	Punc	_	22	punct	_	_
 15	başarı	başarı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	obl	_	_
 16	için	için	ADP	PCNom	_	15	case	_	_
@@ -8658,7 +8658,7 @@
 19	altı	altı	NUM	ANum	NumType=Card	18	flat	_	_
 20	saat	saat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	obl	_	_
 21	çalışmam	çalış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	22	nsubj	_	_
-22	gerekir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	4	conj	_	_
+22	gerekir	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	conj	_	_
 23	vb	vb	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	obl	_	SpaceAfter=No
 24	.	.	PUNCT	Punc	_	22	punct	_	_
 
@@ -8783,10 +8783,10 @@
 2	yüzden	yüz	NOUN	Noun	Case=Abl|Number=Sing|Person=3	1	compound	_	_
 3	alışveriş	alışveriş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 4	bilimini	bilim	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
-5	yaratırken	yarat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	8	nmod	_	_
+5	yaratırken	yarat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	8	nmod	_	_
 6	antroplojinin	antropoloji	NOUN	Noun	Case=Gen|Number=Sing|Person=3	7	nmod:poss	_	_
 7	katkısı	katkı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nsubj	_	_
-8	tartışılmaz	tartış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+8	tartışılmaz	tartış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-0979
@@ -8835,7 +8835,7 @@
 
 # sent_id = mst-0985
 # text = Sanırım o zaman da gelmemişti.
-1	Sanırım	san	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Sanırım	san	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 2	o	o	DET	Det	_	5	det	_	_
 3	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound	_	_
 4	da	da	CCONJ	Conj	_	2	advmod:emph	_	_
@@ -8873,7 +8873,7 @@
 14	taksak	tak	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	13	compound	_	_
 15	fena	fena	ADJ	Adj	_	17	amod	_	_
 16	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	15	advmod:emph	_	_
-17	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	18	nmod	_	_
+17	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	nmod	_	_
 18	a	a	INTJ	Interj	_	5	discourse	_	_
 19-20	yatkındı	_	_	_	_	_	_	_	SpaceAfter=No
 19	yatkın	yatkın	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	5	conj	_	_
@@ -8918,7 +8918,7 @@
 4	yüzünden	yüz	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obl	_	_
 5	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	4	advmod:emph	_	_
 6	derviş	derviş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
-7	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+7	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-0993
@@ -9040,7 +9040,7 @@
 2	birdenbire	birdenbire	ADV	Adverb	_	5	advmod	_	_
 3	her	her	DET	Det	_	5	obj	_	_
 4	şeyini	şey	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	fixed	_	_
-5	verir	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+5	verir	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 6	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	5	obl	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
@@ -9115,10 +9115,10 @@
 1	Melek	Melek	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
 2	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	3	nmod	_	_
 3	yardım	yardım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
-4	edersen	et	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	3	compound:lvc	_	_
+4	edersen	et	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	3	compound:lvc	_	_
 5	çocuklarla	çocuk	NOUN	Noun	Case=Ins|Number=Plur|Person=3	6	nmod	_	_
 6	başa	baş	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	obj	_	_
-7	çıkarım	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	6	compound	_	SpaceAfter=No
+7	çıkarım	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	6	compound	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	9	punct	_	_
 9	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 10	üsteleyerek	üstele	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	9	nmod	_	_
@@ -9244,7 +9244,7 @@
 
 # sent_id = mst-1028
 # text = Aydınlatır mısınız? " diye soruyor.
-1	Aydınlatır	aydınlat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	obj	_	_
+1	Aydınlatır	aydınlat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	obj	_	_
 2	mısınız	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	1	aux:q	_	SpaceAfter=No
 3	?	?	PUNCT	Punc	_	1	punct	_	_
 4	"	"	PUNCT	Punc	_	1	punct	_	_
@@ -9404,7 +9404,7 @@
 4	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
 5	gelip	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	_
 6	Kahve'yi	Kahve	PROPN	Prop	Case=Acc|Number=Sing|Person=3	7	obj	_	_
-7	görebilirsin	gör	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	2	conj	_	SpaceAfter=No
+7	görebilirsin	gör	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-1046
@@ -9473,7 +9473,7 @@
 # text = Bozduğunu o düzeltemez artık, lafını ilk defa o gün orada ettim.
 1	Bozduğunu	boz	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	3	obj	_	_
 2	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
-3	düzeltemez	düzel	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Cau	6	obj	_	_
+3	düzeltemez	düzel	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Cau	6	obj	_	_
 4	artık	artık	ADV	Adverb	_	3	advmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	3	punct	_	_
 6	lafını	laf	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
@@ -9489,7 +9489,7 @@
 # text = Bazen çabuk söner böyle şeyler, dedim.
 1	Bazen	bazen	ADV	Adverb	_	3	advmod	_	_
 2	çabuk	çabuk	ADV	Adverb	_	3	advmod	_	_
-3	söner	sön	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+3	söner	sön	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 4	böyle	böyle	ADJ	Adj	_	5	det	_	_
 5	şeyler	şey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	7	obj	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	7	punct	_	_
@@ -9772,10 +9772,10 @@
 # sent_id = mst-1085
 # text = Sarısı olur, beyazı olur.
 1	Sarısı	sarı	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	obj	_	_
-2	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	5	punct	_	_
 4	beyazı	beyaz	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
-5	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	conj	_	SpaceAfter=No
+5	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	conj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1086
@@ -9820,7 +9820,7 @@
 5	,	,	PUNCT	Punc	_	10	punct	_	_
 6	tam	tam	ADV	Adverb	_	8	advmod	_	_
 7	biraz	biraz	ADV	Adverb	_	8	advmod	_	_
-8	açılır	aç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	10	nmod	_	_
+8	açılır	aç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	10	nmod	_	_
 9	gibi	gibi	ADP	PCNom	_	8	case	_	_
 10	oluyor	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	2	conj	_	SpaceAfter=No
 11	,	,	PUNCT	Punc	_	13	punct	_	_
@@ -9904,7 +9904,7 @@
 
 # sent_id = mst-1095
 # text = Anlarız.
-1	Anlarız	anla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+1	Anlarız	anla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-1096
@@ -10087,7 +10087,7 @@
 # text = Bir yerlere yetişirler.
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	yerlere	yer	NOUN	Noun	Case=Dat|Number=Plur|Person=3	3	obl	_	_
-3	yetişirler	yetiş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	yetişirler	yetiş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1119
@@ -10189,7 +10189,7 @@
 6	hareketleri	hareket	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	3	compound	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	8	punct	_	_
 8	çırpınışları	çırpınış	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	3	conj	_	_
-9	görülmez	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	10	obj	_	_
+9	görülmez	gör	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	10	obj	_	_
 10	oluyor	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
@@ -10237,7 +10237,7 @@
 5	DYP'de	DYP	PROPN	Abr	Abbr=Yes|Case=Loc|Number=Sing|Person=3	11	obl	_	_
 6	ise	i	AUX	Conj	_	5	discourse	_	_
 7	gözle	göz	NOUN	Noun	Case=Ins|Number=Sing|Person=3	10	nmod	_	_
-8	görülür	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	7	compound	_	_
+8	görülür	gör	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	7	compound	_	_
 9	bir	bir	NUM	ANum	NumType=Card	10	det	_	_
 10	hareketlilik	hareketlilik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
 11	var	var	ADJ	Adj	_	0	root	_	SpaceAfter=No
@@ -10392,7 +10392,7 @@
 17	Gerçeği	gerçek	ADJ	NAdj	Case=Acc|Number=Sing|Person=3	20	obj	_	_
 18	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	20	obl	_	_
 19	nasıl	nasıl	ADV	Adverb	_	20	advmod	_	_
-20	söyleriz	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	12	conj	_	_
+20	söyleriz	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	12	conj	_	_
 21	bilmiyorum	bil	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Polite=Infm|Tense=Pres	12	conj	_	SpaceAfter=No
 22	.	.	PUNCT	Punc	_	21	punct	_	_
 
@@ -10508,7 +10508,7 @@
 5	böyle	böyle	ADJ	Adj	_	7	amod	_	_
 6	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
 7	vaziyeti	vaziyet	NOUN	Noun	Case=Acc|Number=Sing|Person=3	8	obj	_	_
-8	görürüm	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	11	nmod	_	_
+8	görürüm	gör	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	11	nmod	_	_
 9	diye	diye	ADP	PCNom	_	8	case	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	8	punct	_	_
 11	bilemiyorum	bil	VERB	Verb	Aspect=Prog|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
@@ -10670,7 +10670,7 @@
 # sent_id = mst-1187
 # text = Yaşamı çekilmez hale getiriyorsunuz.
 1	Yaşamı	yaşam	NOUN	Noun	Case=Acc|Number=Sing|Person=3	4	obj	_	_
-2	çekilmez	çek	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	3	acl	_	_
+2	çekilmez	çek	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	3	acl	_	_
 3	hale	hal	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
 4	getiriyorsunuz	getir	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
@@ -10716,7 +10716,7 @@
 5	maddenin	madde	NOUN	Noun	Case=Gen|Number=Sing|Person=3	6	obj	_	_
 6	yoktan	yok	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	8	obj	_	_
 7	varolduğunu	varol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	6	compound	_	_
-8	ispatlarken	ispatla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	19	punct	_	SpaceAfter=No
+8	ispatlarken	ispatla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	19	punct	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	8	conj	_	_
 10	yoktan	yok	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	12	nmod:poss	_	_
 11	varetme	varet	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	10	compound	_	_
@@ -10771,7 +10771,7 @@
 # sent_id = mst-1200
 # text = Tehlikeyi bilirim.
 1	Tehlikeyi	tehlike	NOUN	Noun	Case=Acc|Number=Sing|Person=3	2	obj	_	_
-2	bilirim	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	bilirim	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-1201
@@ -10868,7 +10868,7 @@
 2	"	"	PUNCT	Punc	_	5	punct	_	_
 3	Devletin	devlet	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod	_	_
 4	ırkı	ırk	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	nsubj	_	_
-5	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	7	nmod:poss	_	_
+5	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	7	nmod:poss	_	_
 6	"	"	PUNCT	Punc	_	5	punct	_	_
 7	anlayışı	anlayış	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nmod:poss	_	_
 8	temelinde	temel	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	amod	_	_
@@ -11064,8 +11064,8 @@
 # sent_id = mst-1236
 # text = Günahlar ister istemez biriktiğine göre...
 1	Günahlar	günah	NOUN	Noun	Case=Nom|Number=Plur|Person=3	4	nsubj	_	_
-2	ister	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	4	nmod	_	_
-3	istemez	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	2	compound	_	_
+2	ister	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	nmod	_	_
+3	istemez	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	2	compound	_	_
 4	biriktiğine	birik	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	0	root	_	_
 5	göre	göre	ADP	PCDat	_	4	case	_	SpaceAfter=No
 6	...	...	PUNCT	Punc	_	4	punct	_	_
@@ -11213,7 +11213,7 @@
 # text = O sizi bulur.
 1	O	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	sizi	siz	PRON	Pers	Case=Acc|Number=Plur|Person=2|PronType=Prs	3	obj	_	_
-3	bulur	bul	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	bulur	bul	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1252
@@ -11343,7 +11343,7 @@
 3	üstüne	üst	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	compound	_	_
 4	büyüklerin	büyük	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	5	nmod:poss	_	_
 5	önünde	ön	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	amod	_	_
-6	atılmaz	at	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	1	compound	_	SpaceAfter=No
+6	atılmaz	at	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Pass	1	compound	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	8	punct	_	_
 8	diyor	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
@@ -11498,7 +11498,7 @@
 # Change 2.2/dev: mark 'hangi' as DET
 1	Hangi	hangi	DET	Adj	_	2	det	_	_
 2	aday	aday	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
-3	kazanırsa	kazan	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	8	obj	_	_
+3	kazanırsa	kazan	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	obj	_	_
 4	kazansın	kazan	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	compound	_	_
 5	birlikte	birlikte	ADV	Adverb	_	7	advmod	_	_
 6	mücadeleyi	mücadele	NOUN	Noun	Case=Acc|Number=Sing|Person=3	7	obj	_	_
@@ -11585,7 +11585,7 @@
 3	Erdoğan'ı	Erdoğan	PROPN	Prop	Case=Acc|Number=Sing|Person=3	2	conj	_	_
 4	aynı	aynı	ADJ	Adj	_	8	obj	_	_
 5	kefeye	kefe	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	compound	_	_
-6	koymam	koy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	4	compound	_	_
+6	koymam	koy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	4	compound	_	_
 7	"	"	PUNCT	Punc	_	4	punct	_	_
 8	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
@@ -11804,13 +11804,13 @@
 # text = Ya havayı katılaştırır, seferleri kaldırır, yollarını kaparlarsa.
 1	Ya	ya	CCONJ	Conj	_	3	nmod	_	_
 2	havayı	hava	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	obj	_	_
-3	katılaştırır	katılaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+3	katılaştırır	katılaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	6	punct	_	_
 5	seferleri	sefer	NOUN	Noun	Case=Acc|Number=Plur|Person=3	6	obj	_	_
-6	kaldırır	kal	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	3	conj	_	SpaceAfter=No
+6	kaldırır	kal	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	3	conj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	9	punct	_	_
 8	yollarını	yol	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	9	obj	_	_
-9	kaparlarsa	kapa	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+9	kaparlarsa	kapa	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-1322
@@ -11874,7 +11874,7 @@
 13	veya	veya	CCONJ	Conj	_	14	cc	_	_
 14	varsayımlardan	varsayım	NOUN	Noun	Case=Abl|Number=Plur|Person=3	10	conj	_	_
 15	yola	yol	NOUN	Noun	Case=Dat|Number=Sing|Person=3	0	root	_	_
-16	çıkılır	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	15	compound	_	SpaceAfter=No
+16	çıkılır	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	15	compound	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-1330
@@ -11901,7 +11901,7 @@
 3	geçmiş	geçmiş	ADJ	Adj	_	4	amod	_	_
 4	enflasyona	enflasyon	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
 5	göre	göre	ADP	PCDat	_	4	case	_	_
-6	yapılırsa	yap	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	16	nmod	_	SpaceAfter=No
+6	yapılırsa	yap	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	16	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
 8	yıl	yıl	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nmod:poss	_	_
 9	sonu	son	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	nmod:poss	_	_
@@ -11968,7 +11968,7 @@
 10	peynirlerimizden	peynir	NOUN	Noun	Case=Abl|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=1	13	obl	_	_
 11	futbol	futbol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nmod:poss	_	_
 12	takımı	takım	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	obj	_	_
-13	kurarım	kur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+13	kurarım	kur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-1342
@@ -11993,7 +11993,7 @@
 # text = Cumhurbaşkanı ile sürtüşmeyiz.
 1	Cumhurbaşkanı	cumhurbaşkanı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	nmod	_	_
 2	ile	ile	CCONJ	Conj	_	3	nmod	_	_
-3	sürtüşmeyiz	sürtüş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+3	sürtüşmeyiz	sürtüş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1347
@@ -12097,7 +12097,7 @@
 20	sonra	sonra	ADP	PCAbl	_	19	case	_	_
 21	bir	bir	NUM	ANum	NumType=Card	22	det	_	_
 22	ralli	ralli	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	obj	_	_
-23	yapabilir	yap	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+23	yapabilir	yap	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 24	.	.	PUNCT	Punc	_	23	punct	_	_
 
 # sent_id = mst-1359
@@ -12181,14 +12181,14 @@
 4	genel	genel	ADJ	Adj	_	5	amod	_	_
 5	hatlarıyla	hat	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	_
 6	betimlemek	betimle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	obj	_	_
-7	istersek	iste	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	14	nmod	_	SpaceAfter=No
+7	istersek	iste	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	14	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	şu	şu	DET	Det	_	11	det	_	_
 10	iki	iki	NUM	ANum	NumType=Card	11	nummod	_	_
 11	görüngüyü	görüngü	NOUN	Noun	Case=Acc|Number=Sing|Person=3	13	obj	_	_
 12	temel	temel	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	13	amod	_	_
 13	almamız	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Plur|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	14	nsubj	_	_
-14	gerekir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+14	gerekir	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 15	:	:	PUNCT	Punc	_	16	punct	_	_
 16	Birincisi	bir	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	14	conj	_	SpaceAfter=No
 17	,	,	PUNCT	Punc	_	26	punct	_	_
@@ -12370,7 +12370,7 @@
 # text = Onlardan intikam alırım.
 1	Onlardan	o	PRON	Pers	Case=Abl|Number=Plur|Person=3|PronType=Prs	2	nmod	_	_
 2	intikam	intikam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-3	alırım	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	2	compound	_	SpaceAfter=No
+3	alırım	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	2	compound	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-1392
@@ -12488,8 +12488,8 @@
 3	hazırlayın	hazırla	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	9	obj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	7	punct	_	_
 5	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	_	_
-6	götürür	götür	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	7	acl	_	_
-7	veririm	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+6	götürür	götür	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	7	acl	_	_
+7	veririm	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
@@ -12596,7 +12596,7 @@
 12	ydınız	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Past	11	cop	_	_
 13	,	,	PUNCT	Punc	_	18	punct	_	_
 14	bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	15	obj	_	_
-15	keşfedemezseniz	keşfet	VERB	Verb	Aspect=Imp|Mood=CndPot|Number=Plur|Person=2|Polarity=Neg|Tense=Aor	18	nmod	_	_
+15	keşfedemezseniz	keşfet	VERB	Verb	Aspect=Hab|Mood=CndPot|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	18	nmod	_	_
 16	biraz	biraz	ADV	Adverb	_	17	advmod	_	_
 17	daha	daha	ADV	Adverb	_	18	advmod	_	_
 18	düşmanlaşırlardı	düşmanlaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	5	conj	_	SpaceAfter=No
@@ -12647,7 +12647,7 @@
 # sent_id = mst-1425
 # text = Raporları incelerken gelişmelerini yakından izlediği olayda kimi yetkililerin yaptığı açıklamalar ile raporlarda kimi ifadelerin ortak yönlerini, farklılıklarını karşılaştırmaya başladı.
 1	Raporları	rapor	NOUN	Noun	Case=Acc|Number=Plur|Person=3	2	obj	_	_
-2	incelerken	incele	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	20	nmod	_	_
+2	incelerken	incele	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	20	nmod	_	_
 3	gelişmelerini	geliş	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	obj	_	_
 4	yakından	yakın	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	5	amod	_	_
 5	izlediği	izle	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	6	acl	_	_
@@ -12751,7 +12751,7 @@
 14	o	o	DET	Det	_	17	det	_	_
 15	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	compound	_	_
 16	ayakları	ayak	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	17	nsubj	_	_
-17	kirlenir	kirlen	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	10	conj	_	_
+17	kirlenir	kirlen	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	10	conj	_	_
 18	ve	ve	CCONJ	Conj	_	22	cc	_	_
 19	her	her	DET	Det	_	20	det	_	_
 20	defasında	defa	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	obl	_	_
@@ -12912,7 +12912,7 @@
 9	teyzemden	teyze	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	10	nmod	_	_
 10	rivayet	rivayet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	conj	_	SpaceAfter=No
 11	-	-	PUNCT	Punc	_	10	punct	_	SpaceAfter=No
-12	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+12	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 13	de	de	CCONJ	Conj	_	12	advmod:emph	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	12	punct	_	_
 15	insaf	insaf	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	conj	_	SpaceAfter=No
@@ -13212,7 +13212,7 @@
 3	El	el	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
 4	sallardım	salla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	3	compound	_	_
 5	işine	iş	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	6	obl	_	_
-6	giderken	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	3	nmod	_	_
+6	giderken	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	3	nmod	_	_
 7	balkondan	balkon	NOUN	Noun	Case=Abl|Number=Sing|Person=3	3	nmod	_	SpaceAfter=No
 8	...	...	PUNCT	Punc	_	3	punct	_	_
 
@@ -13240,7 +13240,7 @@
 
 # sent_id = mst-1474
 # text = Bırakamazsınız o parkı.
-1	Bırakamazsınız	bırak	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Tense=Aor	0	root	_	_
+1	Bırakamazsınız	bırak	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	0	root	_	_
 2	o	o	DET	Det	_	3	det	_	_
 3	parkı	park	NOUN	Noun	Case=Acc|Number=Sing|Person=3	1	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	1	punct	_	_
@@ -13406,7 +13406,7 @@
 12	çocuğun	çocuk	NOUN	Noun	Case=Gen|Number=Sing|Person=3	13	nmod:poss	_	_
 13	pantolonuna	pantolon	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obl	_	_
 14	doğru	doğru	ADP	PCDat	_	15	case	_	_
-15	giderken	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	9	nmod	_	SpaceAfter=No
+15	giderken	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	9	nmod	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-1497
@@ -13492,13 +13492,13 @@
 # Change 2.2/dev: merge -CA
 1	Bazen	bazen	ADV	Adverb	_	5	advmod	_	_
 2	şarkı	şarkı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
-3	söylerken	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	2	compound	_	_
+3	söylerken	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	2	compound	_	_
 4	de	de	CCONJ	Conj	_	2	advmod:emph	_	_
-5	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+5	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 6	bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	5	nsubj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	5	punct	_	_
 8	arkadaşlar	arkadaş	NOUN	Noun	Case=Nom|Number=Plur|Person=3	9	nsubj	_	_
-9	bilir	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	_
+9	bilir	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	conj	_	_
 10	(	(	PUNCT	Punc	_	29	punct	_	SpaceAfter=No
 11	arkadaşlar	arkadaş	NOUN	Noun	Case=Nom|Number=Plur|Person=3	25	nsubj	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	18	punct	_	_
@@ -13515,12 +13515,12 @@
 23	eğerek	eğ	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	21	compound	_	_
 24	onaylıyorlar	onayla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	9	parataxis	_	SpaceAfter=No
 25	)	)	PUNCT	Punc	_	24	punct	_	_
-26	okursa	oku	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	29	nmod	_	_
+26	okursa	oku	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	29	nmod	_	_
 27	hüzzam	hüzzam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	29	obj	_	_
-28	okur	oku	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	SpaceAfter=No
+28	okur	oku	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	conj	_	SpaceAfter=No
 29	,	,	PUNCT	Punc	_	32	punct	_	_
 30	herkesi	herkes	NOUN	Noun	Case=Acc|Number=Sing|Person=3	32	obj	_	_
-31	kahırlandırır	kahırlan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	5	conj	_	SpaceAfter=No
+31	kahırlandırır	kahırlan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	5	conj	_	SpaceAfter=No
 32	.	.	PUNCT	Punc	_	31	punct	_	_
 
 # sent_id = mst-1509
@@ -13529,7 +13529,7 @@
 2	boyutu	boyut	NOUN	Noun	Case=Acc|Number=Sing|Person=3	4	obj	_	_
 3	da	da	CCONJ	Conj	_	2	advmod:emph	_	_
 4	ihmal	ihmal	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
-5	edemeyiz	et	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Neg|Tense=Aor	4	compound:lvc	_	_
+5	edemeyiz	et	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Neg|Tense=Pres	4	compound:lvc	_	_
 6	"	"	PUNCT	Punc	_	4	punct	_	_
 7	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
@@ -13682,7 +13682,7 @@
 5	konuda	konu	NOUN	Noun	Case=Loc|Number=Sing|Person=3	8	obl	_	_
 6	deneme	deneme	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
 7	yanılma	yanıl	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	compound	_	_
-8	oynanabilir	oyna	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	_
+8	oynanabilir	oyna	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	_
 9	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	8	nmod	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	8	punct	_	_
 11	Selma'cım	Selma'cı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	14	obj	_	SpaceAfter=No
@@ -13720,7 +13720,7 @@
 
 # sent_id = mst-1526
 # text = Anlar mıyız.
-1	Anlar	anla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Anlar	anla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 2	mıyız	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Tense=Pres	1	aux:q	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
@@ -13753,9 +13753,9 @@
 10	gelip	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	9	compound:redup	_	_
 11	karıştırdığın	karış	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Cau	3	acl	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	11	punct	_	_
-13	bilmem	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	15	obj	_	_
+13	bilmem	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	15	obj	_	_
 14	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	13	aux:q	_	_
-15	sanırsın	san	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+15	sanırsın	san	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 16	,	,	PUNCT	Punc	_	21	punct	_	_
 17	hah	hah	INTJ	Interj	_	1	discourse	_	_
 18	işte	işte	ADV	Adverb	_	19	advmod	_	_
@@ -14106,7 +14106,7 @@
 3	,	,	PUNCT	Punc	_	6	punct	_	_
 4	onların	on	NUM	NNum	Case=Nom|Number=Plur|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=2	5	nmod:poss	_	_
 5	haklılığını	haklılık	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obj	_	_
-6	değiştirebilir	değiş	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	_
+6	değiştirebilir	değiş	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	_
 7	ki	ki	CCONJ	Conj	_	6	advmod:emph	_	SpaceAfter=No
 8	!	!	PUNCT	Punc	_	6	punct	_	SpaceAfter=No
 9	..	..	PUNCT	Punc	_	6	punct	_	_
@@ -14178,12 +14178,12 @@
 8	;	;	PUNCT	Punc	_	11	punct	_	_
 9	can	can	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
 10	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	9	advmod:emph	_	_
-11	dayanır	dayan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+11	dayanır	dayan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	11	punct	_	_
 13	diye	diye	ADP	PCNom	_	3	case	_	_
 14	söylendi	söyle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	0	root	_	_
 15	saatine	saat	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	16	obl	_	_
-16	bakarken	bak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	14	nmod	_	SpaceAfter=No
+16	bakarken	bak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-1583
@@ -14206,7 +14206,7 @@
 # text = Başka güne alırız doğum günümü.
 1	Başka	başka	ADJ	Adj	_	2	amod	_	_
 2	güne	gün	NOUN	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
-3	alırız	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+3	alırız	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 4	doğum	doğum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 5	günümü	gün	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	4	compound	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -14358,7 +14358,7 @@
 6	yapmayı	yap	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	obj	_	_
 7	çok	çok	ADV	Adverb	_	8	advmod	_	_
 8	iyi	iyi	ADJ	Adj	_	9	amod	_	_
-9	bilir	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+9	bilir	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 10	;	;	PUNCT	Punc	_	9	punct	_	_
 11	eroin	eroin	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nmod:poss	_	_
 12	tacirleri	tacir	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
@@ -14372,7 +14372,7 @@
 3	bölüşülmesi	bölüş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	4	nmod:poss	_	_
 4	kuralını	kural	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obj	_	_
 5	da	da	CCONJ	Conj	_	4	advmod:emph	_	_
-6	sanırım	san	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	9	nmod	_	_
+6	sanırım	san	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	9	nmod	_	_
 7	Atila	Atila	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
 8	Sav	Sav	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	flat	_	_
 9	önermişti	öner	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
@@ -14550,7 +14550,7 @@
 1	Müşteri	müşteri	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 2	kelepiri	kelepir	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
 3	de	de	CCONJ	Conj	_	2	advmod:emph	_	_
-4	sever	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	sever	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-1625
@@ -15389,7 +15389,7 @@
 
 # sent_id = mst-1719
 # text = Çeker.
-1	Çeker	çek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+1	Çeker	çek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-1720
@@ -15553,7 +15553,7 @@
 # text = Beni yapayalnız bırakmaz.
 1	Beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	3	obj	_	_
 2	yapayalnız	yapayalnız	ADJ	Adj	_	3	amod	_	_
-3	bırakmaz	bırak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+3	bırakmaz	bırak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1739
@@ -15755,7 +15755,7 @@
 # sent_id = mst-1758
 # text = Ağbime güvenirim.
 1	Ağbime	ağbi	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	obl	_	_
-2	güvenirim	güven	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	güvenirim	güven	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-1760
@@ -15977,7 +15977,7 @@
 22	rahatsız	rahatsız	ADJ	Adj	_	24	amod	_	_
 23	edici	et	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	22	compound:lvc	_	_
 24	hizmeti	hizmet	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	conj	_	_
-25	sevmez	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+25	sevmez	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 26	.	.	PUNCT	Punc	_	25	punct	_	_
 
 # sent_id = mst-1785
@@ -16008,7 +16008,7 @@
 1	Ya	ya	CCONJ	Conj	_	0	root	_	_
 2	okula	okul	NOUN	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
 3	geç	geç	ADV	Adverb	_	1	conj	_	_
-4	kalırsak	kal	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+4	kalırsak	kal	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1787
@@ -16096,7 +16096,7 @@
 4	intihar	intihar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
 5	edip	et	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	4	compound:lvc	_	_
 6	çok	çok	ADV	Adverb	_	7	advmod	_	_
-7	yaşarlar	yaşa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+7	yaşarlar	yaşa	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-1796
@@ -16170,14 +16170,14 @@
 3	masaya	masa	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
 4	oturunca	otur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	2	conj	_	_
 5	kravatını	kravat	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obj	_	_
-6	çözer	çöz	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	çözer	çöz	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	13	punct	_	_
 8	ince	ince	ADJ	Adj	_	9	amod	_	_
 9	ucunu	uç	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	obj	_	_
 10	elinin	el	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	nmod:poss	_	_
 11	sol	sol	ADJ	Adj	_	12	amod	_	_
 12	bileğine	bilek	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	obl	_	_
-13	bağlar	bağla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+13	bağlar	bağla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	21	punct	_	_
 15	kalın	kalın	ADJ	Adj	_	16	amod	_	_
 16	ucunu	uç	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	obj	_	_
@@ -16203,7 +16203,7 @@
 1	Yeşil	yeşil	ADJ	Adj	_	2	amod	_	_
 2	fasulye	fasulye	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
 3	diyip	de	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	4	nmod	_	_
-4	geçemezsiniz	geç	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	geçemezsiniz	geç	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-1810
@@ -16252,7 +16252,7 @@
 2	bir	bir	NUM	ANum	NumType=Card	3	det	_	_
 3	düğün	düğün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 4	fotoğrafı	fotoğraf	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nsubj	_	_
-5	durur	dur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	durur	dur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1814
@@ -16349,7 +16349,7 @@
 5	ya	ya	CCONJ	Conj	_	4	cc	_	_
 6	aynen	aynen	ADV	Adverb	_	8	advmod	_	_
 7	öyle	öyle	ADV	Adverb	_	8	advmod	_	_
-8	yaparım	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+8	yaparım	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-1827
@@ -16392,7 +16392,7 @@
 1	Eğer	eğer	CCONJ	Conj	_	4	nmod	_	_
 2	ilk	ilk	ADJ	Adj	_	3	amod	_	_
 3	anda	an	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
-4	şarlamazsanız	şarla	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Neg|Tense=Aor	10	nmod	_	SpaceAfter=No
+4	şarlamazsanız	şarla	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	10	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	4	punct	_	_
 6	size	siz	PRON	Pers	Case=Dat|Number=Plur|Person=2|PronType=Prs	10	obl	_	_
 7	ciddi	ciddi	ADJ	Adj	_	10	amod	_	_
@@ -16454,7 +16454,7 @@
 # sent_id = mst-1838
 # text = Sen içebilirsin.
 1	Sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	2	nsubj	_	_
-2	içebilirsin	iç	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	içebilirsin	iç	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-1839
@@ -16476,7 +16476,7 @@
 15	kuramın	kuram	NOUN	Noun	Case=Gen|Number=Sing|Person=3	16	nmod:poss	_	_
 16	çöktüğüne	çök	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	17	acl	_	_
 17	işaret	işaret	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
-18	eder	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	17	compound:lvc	_	SpaceAfter=No
+18	eder	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	17	compound:lvc	_	SpaceAfter=No
 19	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-1841
@@ -16688,7 +16688,7 @@
 8	duygusunun	duygu	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	nmod:poss	_	_
 9	temelinde	temel	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	amod	_	_
 10	bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	11	obj	_	_
-11	yatar	yat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+11	yatar	yat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-1864
@@ -16761,7 +16761,7 @@
 # sent_id = mst-1871
 # text = Birbirimizi biliriz.
 1	Birbirimizi	birbiri	PRON	Quant	Case=Acc|Number=Plur|Number[psor]=Plur|Person=1|Person[psor]=1|PronType=Ind	2	obj	_	_
-2	biliriz	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	biliriz	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-1873
@@ -16811,13 +16811,13 @@
 # sent_id = mst-1879
 # text = içine alır, besler, büyütür, korur.
 1	içine	iç	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	amod	_	_
-2	alır	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	alır	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	4	cc	_	_
-4	besler	besle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	conj	_	SpaceAfter=No
+4	besler	besle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	conj	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	6	cc	_	_
-6	büyütür	büyü	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	2	conj	_	SpaceAfter=No
+6	büyütür	büyü	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	2	conj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	8	cc	_	_
-8	korur	koru	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	conj	_	SpaceAfter=No
+8	korur	koru	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	conj	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	cc	_	_
 
 # sent_id = mst-1881
@@ -17012,7 +17012,7 @@
 19	ek	ek	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	20	amod	_	_
 20	finansman	finansman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	nmod:poss	_	_
 21	ihtiyacı	ihtiyaç	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	24	nmod:poss	_	_
-22	doğar	doğ	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	21	compound	_	_
+22	doğar	doğ	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	21	compound	_	_
 23	"	"	PUNCT	Punc	_	21	punct	_	_
 24	sözlerini	söz	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	25	obj	_	_
 25	eleştirdi	eleştir	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -17068,7 +17068,7 @@
 2	kuramın	kuram	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
 3	doğurganlığı	doğurganlık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
 4	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
-5	yatar	yat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	yatar	yat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1912
@@ -17094,7 +17094,7 @@
 # Fixed 2.2/dev: original sentence ID: 00099161401/2
 1	Casino	casino	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obl	_	_
 2	Venüs'e	Venüs	PROPN	Prop	Case=Dat|Number=Sing|Person=3	1	flat	_	_
-3	girerken	i	AUX	Zero	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	17	advcl	_	_
+3	girerken	i	AUX	Zero	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	17	advcl	_	_
 4	o	o	DET	Det	_	5	det	_	_
 5-6	kilitli	_	_	_	_	_	_	_	_
 5	kilit	kilit	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
@@ -17111,7 +17111,7 @@
 14	bir	bir	NUM	ANum	NumType=Card	15	det	_	_
 15	an	an	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nmod	_	_
 16	heyecandan	heyecan	NOUN	Noun	Case=Abl|Number=Sing|Person=3	17	nmod	_	_
-17	cızlar	cızla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+17	cızlar	cızla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-1915
@@ -17142,7 +17142,7 @@
 1	Ama	ama	CCONJ	Conj	_	0	root	_	_
 2	çoğunun	çok	ADJ	NAdj	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	nmod:poss	_	_
 3	teorileri	teori	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	6	obj	_	_
-4	tartışılır	tartış	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	5	acl	_	_
+4	tartışılır	tartış	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	5	acl	_	_
 5	olmaktan	ol	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	nmod	_	_
 6	çıkmıştı	çık	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	1	conj	_	SpaceAfter=No
 7	...	...	PUNCT	Punc	_	6	punct	_	_
@@ -17324,7 +17324,7 @@
 
 # sent_id = mst-1948
 # text = Olur, alayım.
-1	Olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+1	Olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	3	punct	_	_
 3	alayım	al	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -17508,7 +17508,7 @@
 17	bir	bir	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	19	nummod	_	_
 18	tane	tane	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	compound	_	_
 19	kraliçe	kraliçe	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nsubj	_	_
-20	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+20	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 21	.	.	PUNCT	Punc	_	20	punct	_	_
 22	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 23	.	.	PUNCT	Punc	_	22	punct	_	_
@@ -17675,7 +17675,7 @@
 13	roman	roman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	compound	_	_
 14	kahramanının	kahraman	ADJ	NAdj	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	nmod:poss	_	_
 15	çizilmesi	çiz	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	16	obj	_	_
-16	gerekmez	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	8	conj	_	_
+16	gerekmez	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	8	conj	_	_
 17	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	16	aux:q	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	16	punct	_	_
 
@@ -17700,10 +17700,10 @@
 17	birtakım	birtakım	ADJ	Adj	_	18	det	_	_
 18	konularını	konu	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=2	20	obj	_	_
 19	seninle	sen	PRON	Pers	Case=Ins|Number=Sing|Person=2|PronType=Prs	20	obl	_	_
-20	konuşurlar	konuş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+20	konuşurlar	konuş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 21	,	,	PUNCT	Punc	_	23	punct	_	_
 22	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	23	obl	_	_
-23	danışırlar	danış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+23	danışırlar	danış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 24	,	,	PUNCT	Punc	_	29	punct	_	_
 25	senin	sen	PRON	Pers	Case=Gen|Number=Sing|Person=2|PronType=Prs	26	obl	_	_
 26	söyleyeceklerine	söyle	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	27	acl	_	_
@@ -17780,7 +17780,7 @@
 15	desem	de	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	16	nmod	_	_
 16	boş	boş	ADJ	Adj	_	5	conj	_	SpaceAfter=No
 17	,	,	PUNCT	Punc	_	20	punct	_	_
-18	inanılmaz	inan	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	19	acl	_	_
+18	inanılmaz	inan	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	19	acl	_	_
 19	derecede	derece	NOUN	Noun	Case=Loc|Number=Sing|Person=3	20	obl	_	_
 20	bunaldım	bunal	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	5	conj	_	SpaceAfter=No
 21	.	.	PUNCT	Punc	_	20	punct	_	_
@@ -17914,7 +17914,7 @@
 2	ilk	ilk	ADV	Adverb	_	3	advmod	_	_
 3	başta	başta	ADV	Adverb	_	5	advmod	_	_
 4	konuşmaya	konuş	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	nmod	_	_
-5	başlar	başla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+5	başlar	başla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 6	benimle	ben	PRON	Pers	Case=Ins|Number=Sing|Person=1|PronType=Prs	5	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
@@ -17953,7 +17953,7 @@
 31	alanlarında	alan	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	32	nmod	_	_
 32	elde	el	NOUN	Noun	Case=Loc|Number=Sing|Person=3	35	nmod	_	_
 33	ettiği	et	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	32	compound:lvc	_	_
-34	tartışılmaz	tartış	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	35	acl	_	_
+34	tartışılmaz	tartış	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	35	acl	_	_
 35	başarılarla	başarı	NOUN	Noun	Case=Ins|Number=Plur|Person=3	48	obl	_	SpaceAfter=No
 36	,	,	PUNCT	Punc	_	48	punct	_	_
 37	materyalizme	materyalizm	NOUN	Noun	Case=Dat|Number=Sing|Person=3	48	obl	_	SpaceAfter=No
@@ -18242,7 +18242,7 @@
 16	geometri	geometri	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nmod:poss	_	_
 17	problemini	problem	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	obj	_	_
 18	çözmeye	çöz	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	19	nmod	_	_
-19	çalışırken	çalış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	29	nmod	_	SpaceAfter=No
+19	çalışırken	çalış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	29	nmod	_	SpaceAfter=No
 20	,	,	PUNCT	Punc	_	19	punct	_	_
 21	Siraküza'yı	Siraküza	PROPN	Prop	Case=Acc|Number=Sing|Person=3	22	obj	_	_
 22	işgal	işgal	NOUN	Noun	Case=Nom|Number=Sing|Person=3	27	nmod	_	_
@@ -18428,7 +18428,7 @@
 # sent_id = mst-2041
 # text = Öyle geçer yaşam.
 1	Öyle	öyle	ADV	Adverb	_	2	advmod	_	_
-2	geçer	geç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+2	geçer	geç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 3	yaşam	yaşam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -18513,7 +18513,7 @@
 
 # sent_id = mst-2052
 # text = Bıktırırlar insanı.
-1	Bıktırırlar	bık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	_
+1	Bıktırırlar	bık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	_
 2	insanı	insan	NOUN	Noun	Case=Acc|Number=Sing|Person=3	1	obj	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
@@ -18689,7 +18689,7 @@
 17	bir	bir	NUM	ANum	NumType=Card	18	det	_	_
 18	nicelik	nicelik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	nsubj	_	_
 19	yüklenmesiyle	yükle	VERB	Verb	Aspect=Perf|Case=Ins|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	11	conj	_	_
-20	gerçekleştirilir	gerçekleş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=CauPass	0	root	_	SpaceAfter=No
+20	gerçekleştirilir	gerçekleş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=CauPass	0	root	_	SpaceAfter=No
 21	.	.	PUNCT	Punc	_	20	punct	_	_
 
 # sent_id = mst-2070
@@ -18886,7 +18886,7 @@
 
 # sent_id = mst-2090
 # text = İstersen biraz daha kalsın, biraz daha annesi baksın ona.
-1	İstersen	iste	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	4	nmod	_	_
+1	İstersen	iste	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	4	nmod	_	_
 2	biraz	biraz	ADV	Adverb	_	4	advmod	_	_
 3	daha	daha	ADV	Adverb	_	2	advmod:emph	_	_
 4	kalsın	kal	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
@@ -19006,7 +19006,7 @@
 4	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
 5	ekleyeyim	ekle	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	:	:	PUNCT	Punc	_	7	punct	_	_
-7	Yiyebilir	ye	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	_
+7	Yiyebilir	ye	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	conj	_	_
 8	miyim	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	7	aux:q	_	SpaceAfter=No
 9	?	?	PUNCT	Punc	_	10	punct	_	_
 10	diye	diye	ADP	PCNom	_	5	conj	_	_
@@ -19113,7 +19113,7 @@
 # text = Bununla neden sözedilir?
 1	Bununla	bu	PRON	Demons	Case=Ins|Number=Sing|Person=3|PronType=Dem	3	obl	_	_
 2	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	3	obl	_	_
-3	sözedilir	sözet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+3	sözedilir	sözet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 4	?	?	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-2121
@@ -19155,7 +19155,7 @@
 
 # sent_id = mst-2125
 # text = Ürkerim o an ondan.
-1	Ürkerim	ürk	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Ürkerim	ürk	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 2	o	o	DET	Det	_	3	det	_	_
 3	an	an	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	obl	_	_
 4	ondan	o	PRON	Pers	Case=Abl|Number=Sing|Person=3|PronType=Prs	1	obl	_	SpaceAfter=No
@@ -19225,7 +19225,7 @@
 # text = Rakı soframızın vazgeçilmez bir üyesi daha.
 1	Rakı	rakı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
 2	soframızın	sofra	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	5	nmod:poss	_	_
-3	vazgeçilmez	vazgeç	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	0	root	_	_
+3	vazgeçilmez	vazgeç	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	0	root	_	_
 4	bir	bir	NUM	ANum	NumType=Card	5	det	_	_
 5	üyesi	üye	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nmod	_	_
 6	daha	daha	ADV	Adverb	_	3	conj	_	SpaceAfter=No
@@ -19354,7 +19354,7 @@
 38	böyle	böyle	ADV	Adverb	_	40	advmod	_	_
 39	bir	bir	NUM	ANum	NumType=Card	40	det	_	_
 40	soru	soru	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	conj	_	_
-41	sorar	sor	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	40	compound	_	SpaceAfter=No
+41	sorar	sor	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	40	compound	_	SpaceAfter=No
 42	,	,	PUNCT	Punc	_	40	punct	_	_
 43	demek	de	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	44	obj	_	_
 44	istedi	iste	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	4	conj	_	SpaceAfter=No
@@ -19363,8 +19363,8 @@
 # sent_id = mst-2146
 # text = Beni görür görmez kendini yere atıp göbeğini bir açışı var ki sevdirmek için özellikle şişiriyor sanırsın.
 1	Beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	_	_
-2	görür	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	nmod	_	_
-3	görmez	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	2	compound	_	_
+2	görür	gör	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	nmod	_	_
+3	görmez	gör	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	2	compound	_	_
 4	kendini	kendi	PRON	Reflex	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	6	obj	_	_
 5	yere	yer	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
 6	atıp	at	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	9	nmod	_	_
@@ -19377,7 +19377,7 @@
 13	için	için	ADP	PCNom	_	12	case	_	_
 14	özellikle	özellikle	ADV	Adverb	_	15	advmod	_	_
 15	şişiriyor	şişir	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	_
-16	sanırsın	san	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	15	nmod	_	SpaceAfter=No
+16	sanırsın	san	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	15	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-2147
@@ -19459,7 +19459,7 @@
 3	,	,	PUNCT	Punc	_	6	punct	_	_
 4	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	_
 5	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	6	obj	_	_
-6	yapabilirim	yap	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	2	conj	_	_
+6	yapabilirim	yap	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	2	conj	_	_
 7	bu	bu	DET	Det	_	8	det	_	_
 8	tarihten	tarih	NOUN	Noun	Case=Abl|Number=Sing|Person=3	6	obl	_	_
 9	sonra	sonra	ADP	PCAbl	_	8	case	_	SpaceAfter=No
@@ -19569,7 +19569,7 @@
 6	bir	bir	NUM	ANum	NumType=Card	8	det	_	_
 7	üretici	üre	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	8	acl	_	_
 8	güce	güç	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	9	amod	_	_
-9	dönüşür	dönüş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+9	dönüşür	dönüş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2167
@@ -19656,8 +19656,8 @@
 4	var	var	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	11	ccomp	_	_
 5	dır	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	4	cop	_	_
 6	,	,	PUNCT	Punc	_	11	punct	_	_
-7	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	11	obj	_	_
-8	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	compound	_	_
+7	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	11	obj	_	_
+8	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	compound	_	_
 9	mu	mu	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	7	aux:q	_	SpaceAfter=No
 10	?	?	PUNCT	Punc	_	7	punct	_	_
 11	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -19680,7 +19680,7 @@
 3	düzülen	düz	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	5	acl	_	_
 4	her	her	DET	Det	_	5	det	_	_
 5	ev	ev	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
-6	bozulur	boz	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+6	bozulur	boz	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-2177
@@ -20071,7 +20071,7 @@
 6	,	,	PUNCT	Punc	_	9	punct	_	_
 7	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	9	obl	_	_
 8	da	da	CCONJ	Conj	_	7	advmod:emph	_	_
-9	alırlar	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	_
+9	alırlar	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	5	conj	_	_
 10	göreceksin	gör	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Fut	5	conj	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
@@ -20110,7 +20110,7 @@
 4	birisi	biri	PRON	Quant	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	5	nsubj	_	_
 5	oturmuşsa	otur	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	7	punct	_	_
-7	kıskanırım	kıskan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	5	conj	_	SpaceAfter=No
+7	kıskanırım	kıskan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	5	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-2216
@@ -20307,7 +20307,7 @@
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	hem	hem	ADV	Adverb	_	7	advmod	_	_
 10	yine	yine	ADV	Adverb	_	11	advmod	_	_
-11	görüşürüz	görüş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	12	obj	_	_
+11	görüşürüz	görüş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	12	obj	_	_
 12	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
@@ -20378,7 +20378,7 @@
 4	dı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	3	cop	_	_
 5	,	,	PUNCT	Punc	_	7	punct	_	_
 6	sevgiden	sevgi	NOUN	Noun	Case=Abl|Number=Sing|Person=3	7	obl	_	_
-7	korkmaz	kork	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	3	conj	_	SpaceAfter=No
+7	korkmaz	kork	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	3	conj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	15	punct	_	_
 9	aksine	aksine	ADV	Adverb	_	15	advmod	_	_
 10	sevdikçe	sev	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	15	nmod	_	_
@@ -20431,13 +20431,13 @@
 # text = Konuşmayı biraz uzatır, işlerin yoğunluğundan filan söz edersiniz.
 1	Konuşmayı	konuş	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	3	obj	_	_
 2	biraz	biraz	ADV	Adverb	_	3	advmod	_	_
-3	uzatır	uza	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+3	uzatır	uza	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	8	punct	_	_
 5	işlerin	iş	NOUN	Noun	Case=Gen|Number=Plur|Person=3	6	nmod:poss	_	_
 6	yoğunluğundan	yoğunluk	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nmod	_	_
 7	filan	filan	ADJ	Adj	_	8	amod	_	_
 8	söz	söz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	conj	_	_
-9	edersiniz	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	8	compound:lvc	_	SpaceAfter=No
+9	edersiniz	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	8	compound:lvc	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-2255
@@ -20446,7 +20446,7 @@
 2	soğanla	soğan	NOUN	Noun	Case=Ins|Number=Sing|Person=3	5	obl	_	_
 3	tencere	tencere	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 4	içine	iç	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	amod	_	_
-5	kapatılmaz	kapa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=CauPass	0	root	_	SpaceAfter=No
+5	kapatılmaz	kapa	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=CauPass	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-2256
@@ -20519,21 +20519,21 @@
 4	insanı	insan	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 5	yım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	4	cop	_	_
 6	,	,	PUNCT	Punc	_	7	punct	_	_
-7	söylerim	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	4	conj	_	SpaceAfter=No
+7	söylerim	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	4	conj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	11	punct	_	_
 9	söylediğimin	söyle	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	10	nmod:poss	_	_
 10	arkasından	arka	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	amod	_	_
-11	giderim	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	4	conj	_	_
+11	giderim	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	4	conj	_	_
 12	ve	ve	CCONJ	Conj	_	20	cc	_	_
 13	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	15	nmod	_	_
 14	neye	ne	PRON	Ques	Case=Dat|Number=Sing|Person=3	15	nmod	_	_
 15	mal	mal	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	obl	_	_
-16	olursa	ol	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	15	compound:lvc	_	_
+16	olursa	ol	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	15	compound:lvc	_	_
 17	olsun	ol	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	20	nmod	_	_
 18	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	_	_
 19	bununla	bu	PRON	Demons	Case=Ins|Number=Sing|Person=3|PronType=Dem	20	nmod	_	_
 20	iftihar	iftihar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	conj	_	_
-21	ederim	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	20	compound:lvc	_	SpaceAfter=No
+21	ederim	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	20	compound:lvc	_	SpaceAfter=No
 22	.	.	PUNCT	Punc	_	20	punct	_	_
 
 # sent_id = mst-2268
@@ -20563,7 +20563,7 @@
 7	dizgede	dizge	NOUN	Noun	Case=Loc|Number=Sing|Person=3	10	obl	_	_
 8	evren	evren	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
 9	açık	açık	ADV	Adverb	_	10	advmod	_	_
-10	sanılır	san	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+10	sanılır	san	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-2272
@@ -20607,8 +20607,8 @@
 # sent_id = mst-2276
 # text = Ben götürür veririm.
 1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
-2	götürür	götür	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	3	acl	_	_
-3	veririm	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	götürür	götür	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	acl	_	_
+3	veririm	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-2277
@@ -20951,7 +20951,7 @@
 4	sayıcılarında	sayıcı	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	7	obl	_	_
 5	click	click	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 6	sesi	ses	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obj	_	_
-7	üretirler	üre	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+7	üretirler	üre	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-2322
@@ -21075,7 +21075,7 @@
 5	gibi	gibi	ADP	PCNom	_	3	case	_	_
 6	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
 7	yolculuğa	yolculuk	NOUN	Noun	Case=Dat|Number=Sing|Person=3	8	obl	_	_
-8	çıkarken	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	14	nmod	_	SpaceAfter=No
+8	çıkarken	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	14	nmod	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10-11	çevresindeki	_	_	_	_	_	_	_	_
 10	çevresinde	çevre	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	nmod	_	_
@@ -21187,7 +21187,7 @@
 # sent_id = mst-2349
 # text = Beni bulamazlar.
 1	Beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	_	_
-2	bulamazlar	bul	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+2	bulamazlar	bul	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-2350
@@ -21236,7 +21236,7 @@
 2	gideyim	git	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	6	punct	_	_
 4	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	5	obj	_	_
-5	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	nmod	_	_
+5	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	nmod	_	_
 6	bırakın	bırak	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	2	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
@@ -21391,7 +21391,7 @@
 5	almak	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nmod	_	_
 6	için	için	ADP	PCNom	_	5	case	_	_
 7	Diyarbakır'a	Diyarbakır	PROPN	Prop	Case=Dat|Number=Sing|Person=3	8	obl	_	_
-8	giderken	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	19	nmod	_	SpaceAfter=No
+8	giderken	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	19	nmod	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10	anne	anne	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nmod	_	_
 11	İlkin	İlkin	PROPN	Prop	Case=Nom|Number=Sing|Person=3	18	nsubj	_	_
@@ -21503,7 +21503,7 @@
 1	-	-	PUNCT	Punc	_	4	punct	_	SpaceAfter=No
 2	Yazdığın	yaz	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	3	nmod:poss	_	_
 3	kadarını	kadar	ADP	PCDat	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
-4	okurum	oku	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	okurum	oku	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2389
@@ -21593,7 +21593,7 @@
 31	sıcaklık	sıcaklık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	32	nmod:poss	_	_
 32	gradyentinden	gradyent	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	25	conj	_	_
 33	hesaplandığını	hesapla	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	34	obj	_	_
-34	söyler	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	9	conj	_	SpaceAfter=No
+34	söyler	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	conj	_	SpaceAfter=No
 35	.	.	PUNCT	Punc	_	34	punct	_	_
 
 # sent_id = mst-2397
@@ -21651,7 +21651,7 @@
 1	Çoğulu	çoğul	ADJ	NAdj	Case=Acc|Number=Sing|Person=3	3	obj	_	_
 2	çoğul	çoğul	ADJ	Adj	_	3	obj	_	_
 3	yapmayı	yap	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	obj	_	_
-4	anlamam	anla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	anlamam	anla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2403
@@ -21706,7 +21706,7 @@
 1	O	o	DET	Det	_	4	nsubj	_	_
 2	üç	üç	NUM	ANum	NumType=Card	3	nummod	_	_
 3	geceyi	gece	NOUN	Noun	Case=Acc|Number=Sing|Person=3	4	obj	_	_
-4	unutamaz	unut	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	unutamaz	unut	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2413
@@ -21731,7 +21731,7 @@
 18	takdir	takdir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	obj	_	_
 19	ettiğimi	et	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	18	compound:lvc	_	_
 20	bilmenizi	bil	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	21	obj	_	_
-21	isterim	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	23	obj	_	_
+21	isterim	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	23	obj	_	_
 22	"	"	PUNCT	Punc	_	21	punct	_	_
 23	diyor	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 24	.	.	PUNCT	Punc	_	23	punct	_	_
@@ -21777,7 +21777,7 @@
 1	Yaşamın	yaşam	NOUN	Noun	Case=Gen|Number=Sing|Person=3	2	nmod:poss	_	_
 2	ruhunu	ruh	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
 3	duygularla	duygu	NOUN	Noun	Case=Ins|Number=Plur|Person=3	4	obj	_	_
-4	yakalarız	yakala	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	yakalarız	yakala	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2419
@@ -22075,7 +22075,7 @@
 4	etmek	et	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	3	compound:lvc	_	_
 5	konusunda	konu	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obl	_	_
 6	titiz	titiz	ADJ	Adj	_	7	amod	_	_
-7	davranırsanız	davran	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+7	davranırsanız	davran	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	14	punct	_	_
 9-11	karlılığınız	_	_	_	_	_	_	_	_
 9	kar	kar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	obj	_	_
@@ -22083,7 +22083,7 @@
 11	lığınız	lik	ADP	Ness	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	9	case	_	_
 12	garanti	garanti	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
 13	altına	alt	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	amod	_	_
-14	girer	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	conj	_	SpaceAfter=No
+14	girer	gir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	conj	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-2460
@@ -22101,7 +22101,7 @@
 11	tarzı	tarz	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	conj	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	13	punct	_	_
 13	evi	ev	NOUN	Noun	Case=Acc|Number=Sing|Person=3	8	conj	_	_
-14	biçimlendirir	biçimlen	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	6	conj	_	SpaceAfter=No
+14	biçimlendirir	biçimlen	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	6	conj	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-2463
@@ -22310,7 +22310,7 @@
 # sent_id = mst-2485
 # text = Yaşıtım sayılır.
 1	Yaşıtım	yaşıt	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	obj	_	_
-2	sayılır	say	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+2	sayılır	say	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-2486
@@ -22443,11 +22443,11 @@
 21	,	,	PUNCT	Punc	_	27	punct	_	_
 22	"	"	PUNCT	Punc	_	27	punct	_	_
 23	Saddam	Saddam	PROPN	Prop	Case=Nom|Number=Sing|Person=3	24	nsubj	_	_
-24	giderse	git	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	27	nmod	_	_
+24	giderse	git	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	27	nmod	_	_
 25	savaş	savaş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	26	nmod:poss	_	_
 26	şartları	şart	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	27	obj	_	_
 27	ortadan	orta	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	20	conj	_	_
-28	kalkar	kalk	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	27	compound	_	_
+28	kalkar	kalk	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	27	compound	_	_
 29	"	"	PUNCT	Punc	_	27	punct	_	_
 30	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 31	.	.	PUNCT	Punc	_	30	punct	_	_
@@ -22484,7 +22484,7 @@
 7	dalı	dal	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	compound	_	_
 8	daha	daha	ADV	Adverb	_	6	advmod:emph	_	_
 9	fazla	fazla	ADV	Adverb	_	10	advmod	_	_
-10	ilerleyemez	ilerle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+10	ilerleyemez	ilerle	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 11	;	;	PUNCT	Punc	_	14	punct	_	_
 12	son	son	ADJ	Adj	_	13	amod	_	_
 13	bilgiye	bilgi	NOUN	Noun	Case=Dat|Number=Sing|Person=3	14	obl	_	_
@@ -22803,10 +22803,10 @@
 2	yerinden	yer	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 3	bıçak	bıçak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
 4	gibi	gibi	ADP	PCNom	_	3	case	_	_
-5	girer	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	girer	gir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	8	punct	_	_
 7	kesip	kes	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	8	nmod	_	_
-8	atar	at	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	SpaceAfter=No
+8	atar	at	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	conj	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-2542
@@ -22853,7 +22853,7 @@
 2	;	;	PUNCT	Punc	_	4	punct	_	_
 3	gidip	git	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	4	nmod	_	_
 4	günah	günah	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
-5	çıkarsam	çık	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	4	compound	_	SpaceAfter=No
+5	çıkarsam	çık	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	4	compound	_	SpaceAfter=No
 6	-	-	PUNCT	Punc	_	7	punct	_	SpaceAfter=No
 7	bakın	bakı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	1	conj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	15	punct	_	_
@@ -22866,14 +22866,14 @@
 15	aslında	aslında	ADV	Adverb	_	1	advmod	_	SpaceAfter=No
 16	-	-	PUNCT	Punc	_	15	punct	_	SpaceAfter=No
 17	,	,	PUNCT	Punc	_	15	punct	_	_
-18	rahatlamaz	rahatla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	14	conj	_	_
+18	rahatlamaz	rahatla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	14	conj	_	_
 19	mıyım	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	18	aux:q	_	SpaceAfter=No
 20	?	?	PUNCT	Punc	_	24	punct	_	_
 21	Sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	23	obl	_	_
 22	normal	normal	ADJ	Adj	_	23	amod	_	_
-23	davranır	davran	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	24	acl	_	_
+23	davranır	davran	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	24	acl	_	_
 24	hale	hal	NOUN	Noun	Case=Dat|Number=Sing|Person=3	14	conj	_	_
-25	gelmez	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	14	conj	_	_
+25	gelmez	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	14	conj	_	_
 26	miyim	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	24	aux:q	_	SpaceAfter=No
 27	?	?	PUNCT	Punc	_	28	punct	_	_
 28	Belki	belki	ADV	Adverb	_	14	advmod	_	SpaceAfter=No
@@ -22965,7 +22965,7 @@
 2	,	,	PUNCT	Punc	_	1	punct	_	_
 3	dediler	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	3	punct	_	_
-5	yeter	yet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	nmod	_	_
+5	yeter	yet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	nmod	_	_
 6	ki	ki	CCONJ	Conj	_	9	nmod	_	_
 7	cezan	ceza	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	9	nsubj	_	_
 8	büyük	büyük	ADJ	Adj	_	9	obj	_	_
@@ -22982,8 +22982,8 @@
 # text = Bu fotoğrafı çektirir çektirmez İstanbul'a göçmeye karar vermişler, ama olmamış.
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	fotoğrafı	fotoğraf	NOUN	Noun	Case=Acc|Number=Sing|Person=3	7	nmod	_	_
-3	çektirir	çek	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Cau	2	compound	_	_
-4	çektirmez	çek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Cau	2	compound	_	_
+3	çektirir	çek	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	2	compound	_	_
+4	çektirmez	çek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Cau	2	compound	_	_
 5	İstanbul'a	İstanbul	PROPN	Prop	Case=Dat|Number=Sing|Person=3	6	obl	_	_
 6	göçmeye	göç	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	nmod	_	_
 7	karar	karar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
@@ -23006,7 +23006,7 @@
 9	cebine	cep	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	_
 10	akşam	akşam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obl	_	_
 11	abime	abi	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	12	obl	_	_
-12	verirsin	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+12	verirsin	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-2558
@@ -23022,7 +23022,7 @@
 # text = Yanlış düşünüyor olabilirim; ama böyle bir saplantım var.
 1	Yanlış	yanlış	ADJ	Adj	_	2	amod	_	_
 2	düşünüyor	düşün	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	3	obj	_	_
-3	olabilirim	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	olabilirim	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	;	;	PUNCT	Punc	_	3	punct	_	_
 5	ama	ama	CCONJ	Conj	_	3	conj	_	_
 6	böyle	böyle	ADV	Adverb	_	8	advmod	_	_
@@ -23037,7 +23037,7 @@
 2	sorsan	sor	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	5	nmod	_	_
 3	hiç	hiç	ADV	Adverb	_	4	advmod	_	_
 4	özlemediğini	özle	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	5	obj	_	_
-5	söyler	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	söyler	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	;	;	PUNCT	Punc	_	5	punct	_	_
 7	ama	ama	CCONJ	Conj	_	5	conj	_	_
 8	bence	ben	PRON	Pers	Case=Equ|Number=Sing|Person=1|PronType=Prs	11	obl	_	_
@@ -23050,7 +23050,7 @@
 # text = İyice kollarız, dedi Katana, yoksa dalarız.
 # Change 2.2/dev: merge -CA
 1	İyice	İyice	ADV	Adverb	_	2	advmod	_	_
-2	kollarız	kolla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	4	obj	_	SpaceAfter=No
+2	kollarız	kolla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	4	obj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	9	punct	_	_
 4	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 5	Katana	katana	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	SpaceAfter=No
@@ -23058,7 +23058,7 @@
 7-8	yoksa	_	_	_	_	_	_	_	_
 7	yok	yok	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	9	cc	_	_
 8	sa	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	7	cop	_	_
-9	dalarız	dala	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	2	conj	_	SpaceAfter=No
+9	dalarız	dala	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	2	conj	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2565
@@ -23196,7 +23196,7 @@
 2	tazminat	tazminat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nmod:poss	_	_
 3	davası	dava	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
 4	açmak	aç	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	obj	_	_
-5	istersem	iste	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	8	nmod	_	_
+5	istersem	iste	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	8	nmod	_	_
 6	bu	bu	DET	Det	_	7	det	_	_
 7	davayı	dava	NOUN	Noun	Case=Acc|Number=Sing|Person=3	8	obj	_	_
 8	alabileceklerini	al	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Pot|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	39	obj	_	SpaceAfter=No
@@ -23325,7 +23325,7 @@
 6	yerinde	yer	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obl	_	_
 7	olmayı	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	obj	_	_
 8	hayal	hayal	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-9	edersiniz	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	8	compound:lvc	_	SpaceAfter=No
+9	edersiniz	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	8	compound:lvc	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-2586
@@ -23373,12 +23373,12 @@
 1	Hem	hem	CCONJ	Conj	_	9	nmod	_	_
 2	ismi	isim	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
 3	kolay	kolay	ADJ	Adj	_	4	amod	_	_
-4	olursa	ol	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	9	nmod	_	_
+4	olursa	ol	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	nmod	_	_
 5	köpeğin	köpek	NOUN	Noun	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
 6	öğrenmesi	öğren	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	nsubj	_	_
 7	de	de	CCONJ	Conj	_	6	advmod:emph	_	_
 8	kolay	kolay	ADJ	Adj	_	9	amod	_	_
-9	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+9	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2591
@@ -23416,7 +23416,7 @@
 
 # sent_id = mst-2595
 # text = Sinirlendirir.
-1	Sinirlendirir	Sinirlen	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+1	Sinirlendirir	Sinirlen	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-2596
@@ -23452,19 +23452,19 @@
 
 # sent_id = mst-2598
 # text = Kalmayız, dedi, koşa koşa gideriz, erikleri de senin heybene doldururuz.
-1	Kalmayız	kal	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Neg|Tense=Aor	3	obj	_	SpaceAfter=No
+1	Kalmayız	kal	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Neg|Tense=Pres	3	obj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	1	punct	_	_
 3	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	7	punct	_	_
 5	koşa	koşa	ADJ	Adj	_	7	amod	_	_
 6	koşa	koş	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	compound:redup	_	_
-7	gideriz	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+7	gideriz	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	13	punct	_	_
 9	erikleri	erik	NOUN	Noun	Case=Acc|Number=Plur|Person=3	13	obj	_	_
 10	de	de	CCONJ	Conj	_	9	advmod:emph	_	_
 11	senin	sen	PRON	Pers	Case=Gen|Number=Sing|Person=2|PronType=Prs	12	nmod:poss	_	_
 12	heybene	heybe	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	13	obl	_	_
-13	doldururuz	dol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor|Voice=Cau	3	conj	_	SpaceAfter=No
+13	doldururuz	dol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres|Voice=Cau	3	conj	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-2600
@@ -23515,7 +23515,7 @@
 # sent_id = mst-2603
 # text = Kim bilir belki bir gün, mezara girmeden ya da hapse düşmeden önce arar ve katılır.
 1	Kim	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	bilir	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound	_	_
+2	bilir	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	_
 3	belki	belki	ADV	Adverb	_	16	advmod	_	_
 4	bir	bir	NUM	ANum	NumType=Card	16	nummod	_	_
 5	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	compound	_	SpaceAfter=No
@@ -23527,9 +23527,9 @@
 11	hapse	hapis	NOUN	Noun	Case=Dat|Number=Sing|Person=3	7	conj	_	_
 12	düşmeden	düş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	11	compound	_	_
 13	önce	önce	ADP	PCAbl	_	7	case	_	_
-14	arar	ara	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	_
+14	arar	ara	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	_
 15	ve	ve	CCONJ	Conj	_	16	cc	_	_
-16	katılır	kat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	1	conj	_	SpaceAfter=No
+16	katılır	kat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	1	conj	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-2606
@@ -23574,7 +23574,7 @@
 # text = ' Cumhuriyet'ten sapmayız Verheugen.
 1	'	'	PUNCT	Punc	_	3	punct	_	_
 2	Cumhuriyet'ten	Cumhuriyet	PROPN	Prop	Case=Abl|Number=Sing|Person=3	3	obl	_	_
-3	sapmayız	sap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Neg|Tense=Aor	0	root	_	_
+3	sapmayız	sap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Neg|Tense=Pres	0	root	_	_
 4	Verheugen	Verheugen	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	dep	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -23640,7 +23640,7 @@
 26	evlerin	ev	NOUN	Noun	Case=Gen|Number=Plur|Person=3	27	nmod:poss	_	_
 27	farklılığı	farklılık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	28	nsubj	_	_
 28	ortadan	orta	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	0	root	_	_
-29	kalkabilir	kalk	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	28	compound	_	SpaceAfter=No
+29	kalkabilir	kalk	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	28	compound	_	SpaceAfter=No
 30	.	.	PUNCT	Punc	_	28	punct	_	_
 
 # sent_id = mst-2619
@@ -23675,7 +23675,7 @@
 
 # sent_id = mst-2621
 # text = Güvenemem ona, anlıyor musun beni? Hızlı araba kullanmayı, geceyi, içkiyi ve kadınları seven, arada kadife gibi yumuşayıveren, bazen sessiz ve suskun...
-1	Güvenemem	güven	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	_
+1	Güvenemem	güven	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	_
 2	ona	o	PRON	Demons	Case=Dat|Number=Sing|Person=3|PronType=Dem	1	obl	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	1	punct	_	_
 4	anlıyor	anla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	_
@@ -23846,7 +23846,7 @@
 5	seslere	ses	NOUN	Noun	Case=Dat|Number=Plur|Person=3	6	obl	_	_
 6	kattığı	kat	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	7	acl	_	_
 7	tonlamalar	tonla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nsubj	_	_
-8	değişmez	değiş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+8	değişmez	değiş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	16	punct	_	_
 10	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	13	obl	_	_
 11	kadar	kadar	ADP	PCDat	_	10	case	_	_
@@ -23854,7 +23854,7 @@
 13	isteseler	iste	VERB	Verb	Aspect=Perf|Mood=Des|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	16	nmod	_	_
 14	de	de	CCONJ	Conj	_	13	mark	_	_
 15	bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	16	obj	_	_
-16	beceremezler	becer	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=Aor	8	conj	_	SpaceAfter=No
+16	beceremezler	becer	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	8	conj	_	SpaceAfter=No
 17	,	,	PUNCT	Punc	_	26	punct	_	_
 18	bir	bir	NUM	ANum	NumType=Card	19	det	_	_
 19	köpekten	köpek	NOUN	Noun	Case=Abl|Number=Sing|Person=3	21	obl	_	_
@@ -23921,7 +23921,7 @@
 # text = Başka ne olabilir ki!
 1	Başka	başka	ADJ	Adj	_	2	amod	_	_
 2	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	3	obj	_	_
-3	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+3	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 4	ki	ki	CCONJ	Conj	_	3	advmod:emph	_	SpaceAfter=No
 5	!	!	PUNCT	Punc	_	3	punct	_	_
 
@@ -23974,7 +23974,7 @@
 19	depreşti	depreş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
 20	,	,	PUNCT	Punc	_	22	punct	_	_
 21	ölçüye	ölçü	NOUN	Noun	Case=Dat|Number=Sing|Person=3	22	obl	_	_
-22	sığmaz	sığ	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	1	conj	_	_
+22	sığmaz	sığ	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	1	conj	_	_
 23	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	22	compound:lvc	_	_
 24	içki	içki	NOUN	Noun	Case=Nom|Number=Sing|Person=3	25	nmod:poss	_	_
 25	bağımlılığım	bağımlılık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	22	nsubj	_	SpaceAfter=No
@@ -24062,7 +24062,7 @@
 # text = Beni köşeye sıkıştırırlarsa çıkaracaktım ortaya.
 1	Beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	_	_
 2	köşeye	köşe	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
-3	sıkıştırırlarsa	sıkış	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	2	compound	_	_
+3	sıkıştırırlarsa	sıkış	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	2	compound	_	_
 4	çıkaracaktım	çıkar	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Fut,Past	0	root	_	_
 5	ortaya	orta	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	4	compound	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	4	punct	_	_
@@ -24116,7 +24116,7 @@
 2	uyuşturucularla	uyuşturucu	ADJ	NAdj	Case=Ins|Number=Plur|Person=3	5	amod	_	_
 3	adım	adım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
 4	adım	adım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	compound:redup	_	_
-5	öldürürken	öl	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv|Voice=Cau	6	nmod	_	_
+5	öldürürken	öl	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	6	nmod	_	_
 6	bile	bile	ADV	Adverb	_	8	advmod	_	_
 7	ölmekten	öl	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nmod	_	_
 8	korkuyordum	kork	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
@@ -24177,7 +24177,7 @@
 2	sonra	sonra	ADP	PCAbl	_	1	case	_	_
 3	kanallar	kanal	NOUN	Noun	Case=Nom|Number=Plur|Person=3	4	nmod:poss	_	_
 4	kıyısında	kıyı	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
-5	dolaşırken	dolaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	11	nmod	_	SpaceAfter=No
+5	dolaşırken	dolaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	11	nmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	5	punct	_	_
 7	sanki	sanki	ADV	Adverb	_	11	advmod	_	_
 8	uzun	uzun	ADJ	Adj	_	9	amod	_	_
@@ -24248,7 +24248,7 @@
 6	geyikleri	geyik	NOUN	Noun	Case=Acc|Number=Plur|Person=3	8	obj	_	_
 7	kızaklarından	kızak	NOUN	Noun	Case=Abl|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	8	obl	_	_
 8	çözmeye	çöz	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	9	nmod	_	_
-9	başlarken	başla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	13	nmod	_	_
+9	başlarken	başla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	13	nmod	_	_
 10	yolcular	yolcu	NOUN	Noun	Case=Nom|Number=Plur|Person=3	13	nsubj	_	_
 11	hızla	hız	NOUN	Noun	Case=Ins|Number=Sing|Person=3	13	obl	_	_
 12	içeri	içeri	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
@@ -24268,7 +24268,7 @@
 5	hayatımızla	hayat	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	7	obl	_	_
 6	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	5	nmod	_	_
 7	var	var	ADJ	Adj	_	0	root	_	_
-8	oluruz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	7	compound:lvc	_	SpaceAfter=No
+8	oluruz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	7	compound:lvc	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-2681
@@ -24457,7 +24457,7 @@
 6	karışıklıklara	karışıklık	NOUN	Noun	Case=Dat|Number=Plur|Person=3	8	nmod	_	_
 7	da	da	CCONJ	Conj	_	6	nmod	_	_
 8	neden	neden	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-9	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	8	compound:lvc	_	SpaceAfter=No
+9	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	compound:lvc	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-2705
@@ -24479,7 +24479,7 @@
 6	kendinizi	kendi	PRON	Reflex	Case=Acc|Number=Plur|Number[psor]=Plur|Person=2|Person[psor]=2|Reflex=Yes	9	obj	_	_
 7	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	8	nmod	_	_
 8	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
-9	atarsınız	at	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+9	atarsınız	at	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2708
@@ -24718,21 +24718,21 @@
 16	üzerimden	üzer	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	19	obl	_	_
 17	bir	bir	NUM	ANum	NumType=Card	18	det	_	_
 18	yük	yük	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	nsubj	_	_
-19	kalkar	kalk	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	4	conj	_	SpaceAfter=No
+19	kalkar	kalk	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	conj	_	SpaceAfter=No
 20	,	,	PUNCT	Punc	_	22	punct	_	_
 21	gerilimim	gerilim	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	22	nsubj	_	_
-22	azalır	azal	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	4	conj	_	SpaceAfter=No
+22	azalır	azal	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	conj	_	SpaceAfter=No
 23	,	,	PUNCT	Punc	_	28	punct	_	_
 24	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	28	obl	_	_
 25	daha	daha	ADV	Adverb	_	26	advmod	_	_
 26-27	hoşgörülü	_	_	_	_	_	_	_	_
 26	hoşgörü	hoşgörü	NOUN	Noun	Case=Nom|Number=Sing|Person=3	28	obl	_	_
 27	lü	li	ADP	With	_	26	case	_	_
-28	yaklaşabilirim	yaklaş	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	4	conj	_	SpaceAfter=No
+28	yaklaşabilirim	yaklaş	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	4	conj	_	SpaceAfter=No
 29	,	,	PUNCT	Punc	_	32	punct	_	_
 30	daha	daha	ADV	Adverb	_	31	advmod	_	_
 31	bağışlayıcı	bağışlayıcı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	32	obl	_	_
-32	olabilirim	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	4	conj	_	SpaceAfter=No
+32	olabilirim	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	4	conj	_	SpaceAfter=No
 33	.	.	PUNCT	Punc	_	32	punct	_	_
 
 # sent_id = mst-2732
@@ -24840,7 +24840,7 @@
 1	Kim	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
 2	dertli	dertli	ADJ	Adj	_	0	root	_	_
 3	onda	o	PRON	Pers	Case=Loc|Number=Sing|Person=3|PronType=Prs	4	obl	_	_
-4	alır	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	conj	_	_
+4	alır	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	conj	_	_
 5	soluğu	soluk	ADJ	NAdj	Case=Acc|Number=Sing|Person=3	4	compound	_	SpaceAfter=No
 6	...	...	PUNCT	Punc	_	4	punct	_	_
 
@@ -25158,7 +25158,7 @@
 # text = Ne kadar zorlarsam zorlayayım, her biri cılız birer siluet olarak gözlerimin önünden geçip kayboluyor.
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	3	obl	_	_
 2	kadar	kadar	ADP	PCNom	_	1	case	_	_
-3	zorlarsam	zorla	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	15	nmod	_	_
+3	zorlarsam	zorla	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	15	nmod	_	_
 4	zorlayayım	zorla	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	compound	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	3	punct	_	_
 6	her	her	DET	Det	_	15	nsubj	_	_
@@ -25470,7 +25470,7 @@
 19	yuz	yuz	NUM	ANum	NumType=Card	18	flat	_	_
 20	reel	reel	ADJ	Adj	_	21	amod	_	_
 21	getiri	getiri	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	obj	_	_
-22	sağlayabilir	sağla	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+22	sağlayabilir	sağla	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 23	.	.	PUNCT	Punc	_	22	punct	_	_
 
 # sent_id = mst-2815
@@ -25532,10 +25532,10 @@
 # text = -Artık olmaz, onu kıramam.
 1	-	-	PUNCT	Punc	_	0	root	_	SpaceAfter=No
 2	Artık	artık	ADV	Adverb	_	3	advmod	_	_
-3	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	1	conj	_	SpaceAfter=No
+3	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	1	conj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	6	punct	_	_
 5	onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	6	obj	_	_
-6	kıramam	kır	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	3	conj	_	SpaceAfter=No
+6	kıramam	kır	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	3	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-2825
@@ -25723,7 +25723,7 @@
 1	Acı	acı	ADJ	Adj	_	0	root	_	_
 2	patlıcanı	patlıcan	NOUN	Noun	Case=Acc|Number=Sing|Person=3	1	compound	_	_
 3	kırağı	kırağı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
-4	çalmaz	çal	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	1	compound	_	SpaceAfter=No
+4	çalmaz	çal	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	1	compound	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-2848
@@ -25747,7 +25747,7 @@
 4	birbirleriyle	birbiri	PRON	Quant	Case=Ins|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	5	nmod	_	_
 5	dayanışma	dayanışma	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obl	_	_
 6	içinde	iç	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	amod	_	_
-7	olurlar	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+7	olurlar	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-2852
@@ -25812,7 +25812,7 @@
 3	eritme	eri	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	4	nmod:poss	_	_
 4	peynirleri	peynir	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	1	conj	_	_
 5	rakıya	rakı	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
-6	yakışmaz	yakış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+6	yakışmaz	yakış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-2858
@@ -25826,7 +25826,7 @@
 # sent_id = mst-2859
 # text = İthal ederler.
 1	İthal	ithal	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	ederler	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	1	compound:lvc	_	SpaceAfter=No
+2	ederler	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	1	compound:lvc	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-2860
@@ -25851,7 +25851,7 @@
 1	Sağlık	sağlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	açısından	açı	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obl	_	_
 3	iyi	iyi	ADJ	Adj	_	4	amod	_	_
-4	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2863
@@ -26012,7 +26012,7 @@
 10	bir	bir	NUM	ANum	NumType=Card	11	det	_	_
 11	model	model	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obj	_	_
 12	aramak	ara	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	13	nsubj	_	_
-13	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+13	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-2883
@@ -26079,7 +26079,7 @@
 7	ama	ama	CCONJ	Conj	_	20	cc	_	_
 8	şu	şu	DET	Det	_	9	det	_	_
 9	dünyada	dünya	NOUN	Noun	Case=Loc|Number=Sing|Person=3	10	obl	_	_
-10	yaşarken	yaşa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	20	nmod	_	_
+10	yaşarken	yaşa	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	20	nmod	_	_
 11	daha	daha	ADV	Adverb	_	12	advmod	_	_
 12	komplekssiz	komplekssiz	ADJ	Adj	_	20	amod	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	15	punct	_	_
@@ -26204,7 +26204,7 @@
 
 # sent_id = mst-2906
 # text = İsterseniz yanına dilimlenmiş hıyar.
-1	İsterseniz	iste	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	_
+1	İsterseniz	iste	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	_
 2	yanına	yan	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	amod	_	_
 3	dilimlenmiş	dilimle	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	4	acl	_	_
 4	hıyar	hıyar	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	obj	_	SpaceAfter=No
@@ -26254,7 +26254,7 @@
 # sent_id = mst-2914
 # text = Ne kaybedersin.
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	2	obj	_	_
-2	kaybedersin	kaybet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	kaybedersin	kaybet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-2915
@@ -26404,7 +26404,7 @@
 6	bütün	bütün	ADJ	Adj	_	7	det	_	_
 7	hayranlığına	hayranlık	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	conj	_	_
 8	rağmen	rağmen	ADP	PCDat	_	3	case	_	_
-9	inanılmaz	inan	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	10	acl	_	_
+9	inanılmaz	inan	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	10	acl	_	_
 10	derecede	derece	NOUN	Noun	Case=Loc|Number=Sing|Person=3	11	obl	_	_
 11	sadık	sadık	ADJ	Adj	_	13	amod	_	_
 12	bir	bir	NUM	ANum	NumType=Card	13	det	_	_
@@ -26426,7 +26426,7 @@
 27	,	,	PUNCT	Punc	_	29	punct	_	_
 28	küçük	küçük	ADJ	Adj	_	29	amod	_	_
 29	kırıştırmalardan	kırış	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	26	conj	_	_
-30	hoşlanmaz	hoşlan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	13	conj	_	SpaceAfter=No
+30	hoşlanmaz	hoşlan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	13	conj	_	SpaceAfter=No
 31	,	,	PUNCT	Punc	_	36	punct	_	_
 32	kendini	kendi	PRON	Reflex	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	36	obj	_	_
 33	tümüyle	tümüyle	ADV	Adverb	_	34	advmod	_	_
@@ -26457,7 +26457,7 @@
 10	,	,	PUNCT	Punc	_	15	punct	_	_
 11	tetiği	tetik	ADJ	NAdj	Case=Acc|Number=Sing|Person=3	15	amod	_	_
 12	tam	tam	ADV	Adverb	_	11	advmod	_	_
-13	çekerken	çek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	11	compound	_	_
+13	çekerken	çek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	11	compound	_	_
 14	neler	ne	PRON	Ques	Case=Nom|Number=Plur|Person=3	15	obj	_	_
 15	hissettiğini	hisset	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	17	obj	_	_
 16	anlamaya	anla	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	17	nmod	_	_
@@ -26545,7 +26545,7 @@
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	hanımefendi	hanımefendi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 3	sakız	sakız	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-4	çiğnemez	çiğne	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	3	compound	_	SpaceAfter=No
+4	çiğnemez	çiğne	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	3	compound	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	7	punct	_	_
 6	deyip	dey	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	_
 7	kesip	kes	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	3	conj	_	_
@@ -26582,7 +26582,7 @@
 7	kişi	kişi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
 8	olunca	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	10	nmod	_	_
 9	onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	1	conj	_	_
-10	döveriz	döv	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+10	döveriz	döv	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-2953
@@ -26697,9 +26697,9 @@
 # sent_id = mst-2966
 # text = Merak eder, açar.
 1	Merak	merak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	eder	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound:lvc	_	SpaceAfter=No
+2	eder	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound:lvc	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	4	punct	_	_
-4	açar	aç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+4	açar	aç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2967
@@ -26845,10 +26845,10 @@
 2	geceler	gece	NOUN	Noun	Case=Nom|Number=Plur|Person=3	5	obl	_	_
 3	kulağımı	kulak	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	5	obj	_	_
 4	kapısına	kapı	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
-5	dayar	daya	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	11	nmod	_	SpaceAfter=No
+5	dayar	daya	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	nmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	12	punct	_	_
 7	dayak	dayak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
-8	yerken	ye	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	7	compound	_	_
+8	yerken	ye	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	compound	_	_
 9	attığı	at	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	11	obj	_	_
 10	çığlıkları	çığlık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	9	compound	_	_
 11	dinlerdim	dinle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -26963,7 +26963,7 @@
 26	ortaya	orta	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	28	amod	_	_
 27	çıkmasına	çık	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	26	compound	_	_
 28	neden	neden	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-29	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	28	compound:lvc	_	SpaceAfter=No
+29	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	28	compound:lvc	_	SpaceAfter=No
 30	.	.	PUNCT	Punc	_	28	punct	_	_
 
 # sent_id = mst-2994
@@ -27031,7 +27031,7 @@
 24	"	"	PUNCT	Punc	_	25	punct	_	_
 25	Yanlışlara	yanlış	ADJ	NAdj	Case=Dat|Number=Plur|Person=3	29	nmod:poss	_	_
 26	Ortak	ortak	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	25	compound	_	_
-27	Olmam	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	25	compound	_	_
+27	Olmam	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	25	compound	_	_
 28	"	"	PUNCT	Punc	_	25	punct	_	_
 29	başlığıyla	başlık	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	30	obl	_	_
 30	yayımlanan	yayımla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	31	acl	_	_
@@ -27049,7 +27049,7 @@
 # text = Aman vız gelir!
 1	Aman	aman	INTJ	Interj	_	2	discourse	_	_
 2	vız	vız	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-3	gelir	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	compound	_	SpaceAfter=No
+3	gelir	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	compound	_	SpaceAfter=No
 4	!	!	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-3005
@@ -27100,11 +27100,11 @@
 16	da	da	CCONJ	Conj	_	12	compound	_	_
 17	bir	bir	NUM	ANum	NumType=Card	18	det	_	_
 18	bozlağa	bozlak	NOUN	Noun	Case=Dat|Number=Sing|Person=3	12	conj	_	_
-19	geçer	geç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+19	geçer	geç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 20	,	,	PUNCT	Punc	_	33	punct	_	_
 21	balıkçılar	balıkçı	NOUN	Noun	Case=Nom|Number=Plur|Person=3	23	nsubj	_	_
 22	oturmayacak	otur	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Fut|VerbForm=Part	23	obj	_	_
-23	olurlarsa	ol	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	33	nmod	_	SpaceAfter=No
+23	olurlarsa	ol	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	33	nmod	_	SpaceAfter=No
 24	,	,	PUNCT	Punc	_	23	punct	_	_
 25	kaş	kaş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	33	obl	_	_
 26	göz	göz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	25	compound	_	_
@@ -27158,7 +27158,7 @@
 1	Onun	o	PRON	Pers	Case=Gen|Number=Sing|Person=3|PronType=Prs	2	nmod:poss	_	_
 2	yüzünün	yüz	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	nmod:poss	_	_
 3	yarısı	yarı	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
-4	gülerken	gül	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	6	nmod	_	_
+4	gülerken	gül	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
 5	yarısı	yarı	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	amod	_	_
 6	ağlardı	ağla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
@@ -27188,7 +27188,7 @@
 # sent_id = mst-3021
 # text = Güneş batarken ve eylül rüzgarları kuruyan otların üstünde belli belirsiz gezinirken buluşmalıydınız.
 1	Güneş	Güneş	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
-2	batarken	bat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	12	nmod	_	_
+2	batarken	bat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	12	nmod	_	_
 3	ve	ve	CCONJ	Conj	_	2	cc	_	_
 4	eylül	eylül	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
 5	rüzgarları	rüzgar	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	8	obl	_	_
@@ -27197,7 +27197,7 @@
 8	üstünde	üst	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	amod	_	_
 9	belli	belli	ADJ	Adj	_	11	amod	_	_
 10	belirsiz	belirsiz	ADJ	Adj	_	9	compound:redup	_	_
-11	gezinirken	gezin	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	12	nmod	_	_
+11	gezinirken	gezin	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	12	nmod	_	_
 12	buluşmalıydınız	buluş	VERB	Verb	Aspect=Perf|Mood=Nec|Number=Plur|Person=2|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
@@ -27333,7 +27333,7 @@
 5	domates	domates	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 6	ismini	isim	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obj	_	_
 7	hak	hak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	conj	_	_
-8	eder	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	compound:lvc	_	SpaceAfter=No
+8	eder	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	compound:lvc	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-3040
@@ -27396,7 +27396,7 @@
 11	istemek	iste	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	13	obj	_	_
 12	egolarına	ego	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	13	obj	_	_
 13	ters	ters	ADJ	Adj	_	0	root	_	_
-14	düşer	düş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	13	compound	_	SpaceAfter=No
+14	düşer	düş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	13	compound	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-3051
@@ -27461,7 +27461,7 @@
 # text = Bir sır verir gibi isteksizce Üç, demişti.
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	sır	sır	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
-3	verir	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	2	compound	_	_
+3	verir	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	2	compound	_	_
 4	gibi	gibi	ADP	PCNom	_	2	case	_	_
 5	isteksizce	isteksizce	ADV	Adverb	_	8	advmod	_	_
 6	Üç	üç	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	8	obj	_	SpaceAfter=No
@@ -27532,7 +27532,7 @@
 # text = Birlikten kuvvet doğar.
 1	Birlikten	birlik	NOUN	Noun	Case=Abl|Number=Sing|Person=3	0	root	_	_
 2	kuvvet	kuvvet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
-3	doğar	doğ	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound	_	SpaceAfter=No
+3	doğar	doğ	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-3070
@@ -27546,7 +27546,7 @@
 1	Yo	yo	INTJ	Interj	_	4	discourse	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	3	punct	_	_
 3	yo	yo	INTJ	Interj	_	4	discourse	_	_
-4	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-3073
@@ -27613,7 +27613,7 @@
 # sent_id = mst-3084
 # text = Kabul eder.
 1	Kabul	kabul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	eder	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound:lvc	_	SpaceAfter=No
+2	eder	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound:lvc	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-3085
@@ -27880,13 +27880,13 @@
 3	kadar	kadar	ADP	PCDat	_	2	case	_	_
 4	da	da	CCONJ	Conj	_	2	advmod:emph	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	14	punct	_	_
-6	umarım	um	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	11	nmod	_	_
+6	umarım	um	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	11	nmod	_	_
 7	ki	ki	CCONJ	Conj	_	6	mark	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	6	punct	_	_
 9	Ana'dan	Ana	PROPN	Prop	Case=Abl|Number=Sing|Person=3	11	nmod	_	_
 10	bir	bir	NUM	ANum	NumType=Card	11	det	_	_
 11	haber	haber	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	obj	_	_
-12	alırım	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	11	compound	_	SpaceAfter=No
+12	alırım	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	11	compound	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	14	punct	_	_
 14	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
@@ -27905,7 +27905,7 @@
 # text = Son köşeyi dönerken, bembeyaz elbisesi içinde, kucağında yastığı, kaldırımda cansız yatan Hülya'nın üzerine kapanmaya hazırdım.
 1	Son	son	ADJ	Adj	_	2	amod	_	_
 2	köşeyi	köşe	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	obj	_	_
-3	dönerken	dön	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	18	nmod	_	SpaceAfter=No
+3	dönerken	dön	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	18	nmod	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	3	punct	_	_
 5	bembeyaz	bembeyaz	ADJ	Adj	_	6	amod	_	_
 6	elbisesi	elbise	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nmod:poss	_	_
@@ -27982,7 +27982,7 @@
 31	,	,	PUNCT	Punc	_	33	punct	_	_
 32	acaba	acaba	ADV	Adverb	_	33	advmod	_	_
 33	altından	alt	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	24	conj	_	_
-34	kalkılabilinir	kalk	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	24	conj	_	_
+34	kalkılabilinir	kalk	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	24	conj	_	_
 35	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	33	aux:q	_	SpaceAfter=No
 36	?	?	PUNCT	Punc	_	33	punct	_	_
 
@@ -27993,7 +27993,7 @@
 3	bir	bir	NUM	ANum	NumType=Card	6	nummod	_	_
 4	kez	kez	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	compound	_	_
 5	anımsamaya	anımsa	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	nmod	_	_
-6	başlarsa	başla	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	14	nmod	_	_
+6	başlarsa	başla	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	14	nmod	_	_
 7	gizlediklerini	gizle	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	5	obj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	7	punct	_	_
 9	beyninin	beyin	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nmod:poss	_	_
@@ -28001,7 +28001,7 @@
 11	giren	gir	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	12	acl	_	_
 12	kurt	kurt	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	nsubj	_	_
 13	onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	14	obj	_	_
-14	kemirir	kemir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+14	kemirir	kemir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 15	,	,	PUNCT	Punc	_	34	punct	_	_
 16	yeni	yeni	ADJ	Adj	_	17	amod	_	_
 17	korkular	korku	NOUN	Noun	Case=Nom|Number=Plur|Person=3	34	obj	_	SpaceAfter=No
@@ -28022,7 +28022,7 @@
 31	günahlar	günah	NOUN	Noun	Case=Nom|Number=Plur|Person=3	17	conj	_	SpaceAfter=No
 32	,	,	PUNCT	Punc	_	33	punct	_	_
 33	suçlar	suç	NOUN	Noun	Case=Nom|Number=Plur|Person=3	17	conj	_	_
-34	yaratır	yarat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	14	conj	_	SpaceAfter=No
+34	yaratır	yarat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	14	conj	_	SpaceAfter=No
 35	.	.	PUNCT	Punc	_	34	punct	_	_
 
 # sent_id = mst-3122
@@ -28032,7 +28032,7 @@
 3	bak	bak	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	_
 4	nasıl	nasıl	ADV	Adverb	_	5	advmod	_	_
 5	üstüne	üst	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	conj	_	_
-6	titrer	titre	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	compound	_	SpaceAfter=No
+6	titrer	titre	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	compound	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	8	punct	_	_
 8	çekip	çek	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	3	conj	_	_
 9	çevirirdi	çevir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	8	compound	_	_
@@ -28100,7 +28100,7 @@
 2	arkamda	arka	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	5	amod	_	_
 3	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
 4	iz	iz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
-5	kalırsa	kal	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	22	nmod	_	SpaceAfter=No
+5	kalırsa	kal	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	22	nmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	16	punct	_	_
 7	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	_	_
 8	siyasette	siyaset	NOUN	Noun	Case=Loc|Number=Sing|Person=3	16	obl	_	_
@@ -28112,7 +28112,7 @@
 13	,	,	PUNCT	Punc	_	14	punct	_	_
 14	cesur	cesur	ADJ	Adj	_	9	conj	_	_
 15	işler	iş	NOUN	Noun	Case=Nom|Number=Plur|Person=3	16	obj	_	_
-16	yaparsam	yap	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	5	conj	_	_
+16	yaparsam	yap	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	5	conj	_	_
 17-18	benim	_	_	_	_	_	_	_	_
 17	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	obl	_	_
 18	im	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	17	cop	_	_
@@ -28142,9 +28142,9 @@
 14	kadar	kadar	ADP	PCNom	_	13	case	_	_
 15	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	4	conj	_	SpaceAfter=No
 16	,	,	PUNCT	Punc	_	17	punct	_	_
-17	yaparsam	yap	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	4	conj	_	_
+17	yaparsam	yap	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	4	conj	_	_
 18	küstahlık	küstahlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	obj	_	_
-19	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	4	conj	_	SpaceAfter=No
+19	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	conj	_	SpaceAfter=No
 20	.	.	PUNCT	Punc	_	19	punct	_	_
 
 # sent_id = mst-3132
@@ -28253,8 +28253,8 @@
 10	uyum	uyum	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obj	_	_
 11	sağlamak	sağla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	15	nmod	_	_
 12	için	için	ADP	PCNom	_	11	case	_	_
-13	ister	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	15	nmod	_	_
-14	istemez	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	13	compound	_	_
+13	ister	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	15	nmod	_	_
+14	istemez	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	13	compound	_	_
 15	içtiği	iç	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	18	acl	_	_
 16	iki	iki	NUM	ANum	NumType=Card	17	nummod	_	_
 17	kadeh	kadeh	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nmod	_	_
@@ -28428,7 +28428,7 @@
 13	,	,	PUNCT	Punc	_	16	punct	_	_
 14	Ayşe	Ayşe	PROPN	Prop	Case=Nom|Number=Sing|Person=3	16	nsubj	_	_
 15	kadın	kadın	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	14	amod	_	_
-16	giriverir	gir	VERB	Verb	Aspect=Rapid|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+16	giriverir	gir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 17	sahneye	sahne	NOUN	Noun	Case=Dat|Number=Sing|Person=3	16	obl	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	16	punct	_	_
 
@@ -28439,7 +28439,7 @@
 3	annem	anne	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	6	nsubj	_	_
 4	buna	bu	PRON	Demons	Case=Dat|Number=Sing|Person=3|PronType=Dem	6	obl	_	_
 5	sürpriz	sürpriz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obj	_	_
-6	diyebilir	de	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+6	diyebilir	de	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 7	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	6	aux:q	_	SpaceAfter=No
 8	?	?	PUNCT	Punc	_	6	punct	_	_
 
@@ -28453,7 +28453,7 @@
 6	ki	ki	CCONJ	Conj	_	5	mark	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	5	punct	_	_
 8	annemle	anne	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	9	obl	_	_
-9	konuşurken	konuş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	10	nmod	_	_
+9	konuşurken	konuş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	10	nmod	_	_
 10	kapıldığım	kap	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	11	acl	_	_
 11	korkular	korku	NOUN	Noun	Case=Nom|Number=Plur|Person=3	13	nsubj	_	_
 12	yeniden	yeniden	ADV	Adverb	_	13	advmod	_	_
@@ -28543,11 +28543,11 @@
 9	bir	bir	NUM	ANum	NumType=Card	16	nummod	_	_
 10	kenara	kenar	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	9	compound	_	_
 11	bırakıp	bırak	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	9	compound	_	_
-12	sinirlenmez	sinirlen	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	9	conj	_	SpaceAfter=No
+12	sinirlenmez	sinirlen	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	9	conj	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	15	punct	_	_
 14	sıkıldıklarını	sıkıl	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	15	obj	_	_
 15	belli	belli	ADJ	Adj	_	12	conj	_	_
-16	etmezler	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+16	etmezler	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-3172
@@ -28591,7 +28591,7 @@
 # text = Hem deney olur benim için.
 1	Hem	hem	CCONJ	Conj	_	0	root	_	_
 2	deney	deney	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
-3	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	_
+3	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	_
 4	benim	ben	PRON	Pers	Case=Gen|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 5	için	için	ADP	PCNom	_	4	case	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -28640,7 +28640,7 @@
 3	için	için	ADP	PCNom	_	2	case	_	_
 4	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	2	aux:q	_	_
 5	böyle	böyle	ADV	Adverb	_	6	advmod	_	_
-6	yapılır	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	7	obj	_	_
+6	yapılır	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	7	obj	_	_
 7	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
@@ -28648,7 +28648,7 @@
 # text = Bana da düşmez.
 1	Bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	3	obl	_	_
 2	da	da	CCONJ	Conj	_	1	advmod:emph	_	_
-3	düşmez	düş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+3	düşmez	düş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3185
@@ -28717,7 +28717,7 @@
 1	Şimşek	şimşek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obl	_	_
 2	gibi	gibi	ADP	PCNom	_	1	compound	_	_
 3	atağa	atak	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	0	root	_	_
-4	kalkar	kalk	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	3	compound	_	SpaceAfter=No
+4	kalkar	kalk	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	compound	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3193
@@ -28913,7 +28913,7 @@
 2	onlar	o	PRON	Pers	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	_	_
 3	doğuştan	doğuş	NOUN	Noun	Case=Abl|Number=Sing|Person=3	5	obl	_	_
 4	anne	anne	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
-5	olurlar	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	12	nmod	_	_
+5	olurlar	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	12	nmod	_	_
 6	da	da	CCONJ	Conj	_	5	nmod	_	_
 7	erkekler	erkek	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	12	nsubj	_	_
 8	baba	baba	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
@@ -28921,7 +28921,7 @@
 10	ancak	ancak	ADV	Adverb	_	11	advmod:emph	_	_
 11	öğrenerek	öğren	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	12	nmod	_	_
 12	elde	el	NOUN	Noun	Case=Loc|Number=Sing|Person=3	0	root	_	_
-13	edebilirler	et	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	12	compound:lvc	_	SpaceAfter=No
+13	edebilirler	et	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	12	compound:lvc	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-3217
@@ -29042,7 +29042,7 @@
 14	"	"	PUNCT	Punc	_	17	punct	_	_
 15	Pazar	Pazar	PROPN	Prop	Case=Nom|Number=Sing|Person=3	17	nsubj	_	_
 16	herkese	herkes	NOUN	Noun	Case=Dat|Number=Sing|Person=3	17	obl	_	_
-17	yeter	yet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	19	obj	_	_
+17	yeter	yet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	19	obj	_	_
 18	"	"	PUNCT	Punc	_	17	punct	_	_
 19	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 20	.	.	PUNCT	Punc	_	19	punct	_	_
@@ -29130,7 +29130,7 @@
 18	bir	bir	NUM	ANum	NumType=Card	20	det	_	_
 19	kitap	kitap	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nmod:poss	_	_
 20	konusu	konu	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	obj	_	_
-21	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+21	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 22	.	.	PUNCT	Punc	_	21	punct	_	_
 
 # sent_id = mst-3240
@@ -29248,7 +29248,7 @@
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10	Çorumlu	Çorumlu	PROPN	Prop	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
 11	Çorumluya	Çorumluya	PROPN	Prop	Case=Dat|Number=Sing|Person=3	12	obl	_	_
-12	yapmaz	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	4	conj	_	SpaceAfter=No
+12	yapmaz	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	4	conj	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-3254
@@ -29390,7 +29390,7 @@
 # text = Yahu nasıl yaptırırız zorla?.
 1	Yahu	yahu	INTJ	Interj	_	3	discourse	_	_
 2	nasıl	nasıl	ADV	Adverb	_	3	advmod	_	_
-3	yaptırırız	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	_
+3	yaptırırız	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	_
 4	zorla	zor	ADJ	NAdj	Case=Ins|Number=Sing|Person=3	3	amod	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	3	punct	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -29444,7 +29444,7 @@
 12	Afrika	Afrika	PROPN	Prop	Case=Nom|Number=Sing|Person=3	11	flat	_	_
 13	ülkelerini	ülke	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	15	obj	_	_
 14	öncelikle	öncelik	NOUN	Noun	Case=Ins|Number=Sing|Person=3	15	obl	_	_
-15	etkiler	etkile	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+15	etkiler	etkile	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-3272
@@ -29493,7 +29493,7 @@
 2	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
 3	dır	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	2	cop	_	_
 4	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	2	aux:q	_	_
-5	gidersiniz	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	_
+5	gidersiniz	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	_
 6	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
@@ -29617,7 +29617,7 @@
 3	canım	can	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	4	nmod	_	_
 4	annem	anne	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	1	conj	_	SpaceAfter=No
 5	)	)	PUNCT	Punc	_	4	punct	_	_
-6	sever	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+6	sever	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 7	onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	6	obj	_	SpaceAfter=No
 8	..	..	PUNCT	Punc	_	6	punct	_	_
 
@@ -29788,7 +29788,7 @@
 3	bir	bir	NUM	ANum	NumType=Card	5	nummod	_	_
 4	küçük	küçük	ADJ	Adj	_	5	amod	_	_
 5	kaza	kaza	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
-6	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	15	punct	_	_
 8-9	çantanızdaki	_	_	_	_	_	_	_	_
 8	çantanızda	çanta	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	11	nmod	_	_
@@ -29798,7 +29798,7 @@
 12	belki	belki	ADV	Adverb	_	15	advmod	_	_
 13	de	de	CCONJ	Conj	_	12	advmod:emph	_	_
 14	hayatınızı	hayat	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=2	15	obj	_	_
-15	kurtarır	kurtar	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	SpaceAfter=No
+15	kurtarır	kurtar	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-3306
@@ -30002,7 +30002,7 @@
 4	bir	bir	NUM	ANum	NumType=Card	5	det	_	_
 5	nesne	nesne	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
 6	gibi	gibi	ADP	PCNom	_	5	case	_	_
-7	bakabiliriz	bak	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+7	bakabiliriz	bak	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 8	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	7	obl	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	7	punct	_	_
 10	öznel	öznel	ADJ	Adj	_	12	amod	_	_
@@ -30196,7 +30196,7 @@
 # text = Annem dünyada evlenmez.
 1	Annem	anne	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	3	nsubj	_	_
 2	dünyada	dünya	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
-3	evlenmez	evlen	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+3	evlenmez	evlen	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3353
@@ -30587,7 +30587,7 @@
 2	sa	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	1	cop	_	_
 3	,	,	PUNCT	Punc	_	14	punct	_	_
 4	çalıp	çal	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	5	nmod	_	_
-5	söylerken	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	9	nmod	_	_
+5	söylerken	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	9	nmod	_	_
 6	göz	göz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
 7	ucuyla	uç	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	compound	_	_
 8	kendilerini	kendi	PRON	Reflex	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|Reflex=Yes	9	obj	_	_
@@ -30620,7 +30620,7 @@
 2	hiçbir	hiçbir	DET	Det	_	3	det	_	_
 3	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obl	_	_
 4	emin	emin	ADJ	Adj	_	1	conj	_	_
-5	olamazsın	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Tense=Aor	4	compound:lvc	_	SpaceAfter=No
+5	olamazsın	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	4	compound:lvc	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-3406
@@ -30634,7 +30634,7 @@
 7	gençlerin	genç	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	8	nmod:poss	_	_
 8	selamlarına	selam	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	9	nmod	_	_
 9	karşılık	karşılık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	conj	_	_
-10	verilir	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	9	compound	_	SpaceAfter=No
+10	verilir	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	9	compound	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-3408
@@ -30803,7 +30803,7 @@
 5	ve	ve	CCONJ	Conj	_	6	cc	_	_
 6	sarmısaktan	sarmısak	NOUN	Noun	Case=Abl|Number=Sing|Person=3	4	conj	_	_
 7	takviye	takviye	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8	alır	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+8	alır	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-3433
@@ -30827,7 +30827,7 @@
 
 # sent_id = mst-3436
 # text = İnanır.
-1	İnanır	inan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+1	İnanır	inan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-3438
@@ -30919,7 +30919,7 @@
 3	ana	ana	ADJ	Adj	_	4	amod	_	_
 4	yemek	yemek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
 5	garnisine	garni	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	conj	_	_
-6	gelir	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	gelir	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3448
@@ -31046,7 +31046,7 @@
 15-16	ücretsiz	_	_	_	_	_	_	_	_
 15	ücret	ücret	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	obl	_	_
 16	siz	siz	ADP	Without	_	15	case	_	_
-17	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	19	obj	_	_
+17	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	19	obj	_	_
 18	"	"	PUNCT	Punc	_	17	punct	_	_
 19	diyen	de	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	20	acl	_	_
 20	Demiray	Demiray	PROPN	Prop	Case=Nom|Number=Sing|Person=3	28	nsubj	_	SpaceAfter=No
@@ -31064,7 +31064,7 @@
 # text = Boşalmasını sabırsızlıkla beklerim.
 1	Boşalmasını	boşal	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	3	obj	_	_
 2	sabırsızlıkla	sabırsızlık	NOUN	Noun	Case=Ins|Number=Sing|Person=3	3	obl	_	_
-3	beklerim	bekle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	beklerim	bekle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3462
@@ -31108,7 +31108,7 @@
 1	Hepinizi	hep	PRON	Quant	Case=Acc|Number=Plur|Number[psor]=Plur|Person=2|Person[psor]=2|PronType=Ind	4	obj	_	_
 2	tek	tek	ADJ	Adj	_	4	amod	_	_
 3	basıma	bas	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	compound	_	_
-4	haklarım	hakla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	5	obj	_	_
+4	haklarım	hakla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	5	obj	_	_
 5	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
@@ -31283,7 +31283,7 @@
 6	bilimsel	bilimsel	ADJ	Adj	_	7	amod	_	_
 7	bilgiler	bilgi	NOUN	Noun	Case=Nom|Number=Plur|Person=3	8	nmod:poss	_	_
 8	temelinde	temel	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	amod	_	_
-9	üretilebilir	üre	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=CauPass	10	nmod	_	_
+9	üretilebilir	üre	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=CauPass	10	nmod	_	_
 10	hale	hale	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 11	gelmiştir	gel	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Gen|Number=Sing|Person=3|Polarity=Pos|Tense=Past	10	compound	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	10	punct	_	_
@@ -31302,7 +31302,7 @@
 2	şöyle	şöyle	ADV	Adverb	_	4	advmod	_	_
 3	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
 4	soru	soru	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	nsubj	_	_
-5	gelebilir	gel	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound	_	SpaceAfter=No
+5	gelebilir	gel	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-3484
@@ -31312,8 +31312,8 @@
 
 # sent_id = mst-3485
 # text = Olur olur...
-1	Olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
-2	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound:redup	_	SpaceAfter=No
+1	Olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
+2	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound:redup	_	SpaceAfter=No
 3	...	...	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-3486
@@ -31369,14 +31369,14 @@
 6	aksiyomlar	aksiyom	NOUN	Noun	Case=Nom|Number=Plur|Person=3	9	nsubj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	8	punct	_	_
 8	türetimler	türetim	NOUN	Noun	Case=Nom|Number=Plur|Person=3	6	conj	_	_
-9	girmez	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+9	girmez	gir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 10	;	;	PUNCT	Punc	_	16	punct	_	_
 11	ondan	o	PRON	Demons	Case=Abl|Number=Sing|Person=3|PronType=Dem	16	obl	_	_
 12	yeni	yeni	ADJ	Adj	_	13	amod	_	_
 13	bilgiler	bilgi	NOUN	Noun	Case=Nom|Number=Plur|Person=3	16	nsubj	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	15	punct	_	_
 15	öngörüler	öngörü	NOUN	Noun	Case=Nom|Number=Plur|Person=3	13	conj	_	_
-16	çıkmaz	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	9	conj	_	SpaceAfter=No
+16	çıkmaz	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	9	conj	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-3492
@@ -31488,7 +31488,7 @@
 2	ikimiz	iki	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Plur|NumType=Card|Person=3|Person[psor]=1	9	nsubj	_	_
 3	yan	yan	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	9	nmod	_	_
 4	yana	yan	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	3	compound:redup	_	_
-5	koşar	koş	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	6	acl	_	_
+5	koşar	koş	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	acl	_	_
 6	adım	adım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
 7	gecenin	gece	NOUN	Noun	Case=Gen|Number=Sing|Person=3	8	nmod:poss	_	_
 8	içinde	iç	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	amod	_	_
@@ -31498,12 +31498,12 @@
 # sent_id = mst-3512
 # text = Beni tanır, gelip karşısına oturduğumu hisseder.
 1	Beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	_	_
-2	tanır	tanı	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	tanır	tanı	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	7	punct	_	_
 4	gelip	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
 5	karşısına	karşı	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	amod	_	_
 6	oturduğumu	otur	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	7	obj	_	_
-7	hisseder	hisset	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	conj	_	SpaceAfter=No
+7	hisseder	hisset	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-3513
@@ -31521,7 +31521,7 @@
 1	Her	her	DET	Det	_	4	nsubj	_	_
 2	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
 3	onunla	o	PRON	Pers	Case=Ins|Number=Sing|Person=3|PronType=Prs	4	obl	_	_
-4	başlar	başla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	başlar	başla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-3515
@@ -31685,7 +31685,7 @@
 1	Gençliğinde	gençlik	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	obl	_	_
 2	yazdıklarını	yaz	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	3	obj	_	_
 3	tercih	tercih	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-4	ederim	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	3	compound:lvc	_	SpaceAfter=No
+4	ederim	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	compound:lvc	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3537
@@ -31715,7 +31715,7 @@
 # sent_id = mst-3540
 # text = Bunları söylerken iki adımda Ömür Uzatma Kıraathanesi'nin kapısına varmıştı.
 1	Bunları	bu	PRON	Demons	Case=Acc|Number=Plur|Person=3|PronType=Dem	2	obj	_	_
-2	söylerken	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	9	nmod	_	_
+2	söylerken	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	9	nmod	_	_
 3	iki	iki	NUM	ANum	NumType=Card	4	nummod	_	_
 4	adımda	adım	NOUN	Noun	Case=Loc|Number=Sing|Person=3	9	obl	_	_
 5	Ömür	ömür	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod:poss	_	_
@@ -31966,7 +31966,7 @@
 13	ve	ve	CCONJ	Conj	_	14	cc	_	_
 14	bıçakla	bıçak	NOUN	Noun	Case=Ins|Number=Sing|Person=3	12	conj	_	_
 15	tencereye	tencere	NOUN	Noun	Case=Dat|Number=Sing|Person=3	16	obl	_	_
-16	girebilir	gir	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part	17	acl	_	_
+16	girebilir	gir	VERB	Verb	Aspect=Hab|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Part	17	acl	_	_
 17	parçalara	parça	NOUN	Noun	Case=Dat|Number=Plur|Person=3	18	obl	_	_
 18	ayırıyor	ayır	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 19	.	.	PUNCT	Punc	_	18	punct	_	_
@@ -31990,7 +31990,7 @@
 6	yerlerde	yer	NOUN	Noun	Case=Loc|Number=Plur|Person=3	7	obl	_	_
 7	dolaşıp	dolaş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	0	root	_	_
 8	çevreye	çevre	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
-9	bakınır	bakın	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	conj	_	SpaceAfter=No
+9	bakınır	bakın	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	conj	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	15	punct	_	_
 11	cinayet	cinayet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nmod:poss	_	_
 12	anını	an	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	obj	_	_
@@ -32097,7 +32097,7 @@
 12	vade	vade	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	nmod	_	_
 13	li	li	ADP	With	_	12	case	_	_
 14	portföy	portföy	NOUN	Noun	Case=Nom|Number=Sing|Person=3	15	obj	_	_
-15	oluşturabilir	oluş	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+15	oluşturabilir	oluş	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-3589
@@ -32164,7 +32164,7 @@
 8	türlü	türlü	ADJ	Adj	_	7	compound	_	_
 9	evleşememesine	evleş	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Pot|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Pres|VerbForm=Vnoun	10	nmod	_	_
 10	neden	neden	ADV	Adverb	_	1	conj	_	_
-11	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	10	conj	_	SpaceAfter=No
+11	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	10	conj	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-3598
@@ -32557,7 +32557,7 @@
 3	tenis	tenis	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod	_	_
 4	raketi	raket	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nsubj	_	_
 5	ilgisini	ilgi	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obj	_	_
-6	çeker	çek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	compound	_	_
+6	çeker	çek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	compound	_	_
 7	sanıyorum	san	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
@@ -32568,7 +32568,7 @@
 3	bulunduğu	bulun	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	4	nmod	_	_
 4	yerde	yer	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
 5	özgürlük	özgürlük	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obj	_	_
-6	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+6	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3638
@@ -32626,7 +32626,7 @@
 5	üzerinden	üzer	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nmod	_	_
 6	Türkiye'ye	Türkiye	PROPN	Prop	Case=Dat|Number=Sing|Person=3	7	nmod	_	_
 7	baskı	baskı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-8	yapar	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	compound:lvc	_	SpaceAfter=No
+8	yapar	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	compound:lvc	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-3646
@@ -32654,7 +32654,7 @@
 21	bir	bir	NUM	ANum	NumType=Card	22	det	_	_
 22	dönüşüme	dönüşüm	NOUN	Noun	Case=Dat|Number=Sing|Person=3	23	nmod	_	_
 23	yol	yol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-24	açar	aç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	23	compound	_	SpaceAfter=No
+24	açar	aç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	23	compound	_	SpaceAfter=No
 25	.	.	PUNCT	Punc	_	23	punct	_	_
 
 # sent_id = mst-3648
@@ -32663,7 +32663,7 @@
 2	cenazelerinin	cenaze	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	4	nmod:poss	_	_
 3	alanda	alan	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 4	bekletileceği	bekle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=CauPass	5	obj	_	_
-5	öğrenilirken	öğren	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv|Voice=Pass	44	nmod	_	SpaceAfter=No
+5	öğrenilirken	öğren	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	44	nmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	5	punct	_	_
 7	yolcular	yolcu	NOUN	Noun	Case=Nom|Number=Plur|Person=3	10	nmod	_	_
 8	Kurmay	kurmay	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod	_	_
@@ -32861,7 +32861,7 @@
 # sent_id = mst-3666
 # text = Salondan çıkarken herkesin yüzünün güldüğünü fark ettim.
 1	Salondan	salon	NOUN	Noun	Case=Abl|Number=Sing|Person=3	2	obl	_	_
-2	çıkarken	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	6	nmod	_	_
+2	çıkarken	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
 3	herkesin	herkes	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod	_	_
 4	yüzünün	yüz	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nmod:poss	_	_
 5	güldüğünü	gül	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	6	obj	_	_
@@ -32892,7 +32892,7 @@
 4	takılan	tak	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	3	compound	_	_
 5	soruları	soru	NOUN	Noun	Case=Acc|Number=Plur|Person=3	17	obj	_	_
 6	da	da	CCONJ	Conj	_	5	advmod:emph	_	_
-7	anlatır	anlat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	17	nmod	_	_
+7	anlatır	anlat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	17	nmod	_	_
 8	gibi	gibi	ADP	PCNom	_	7	case	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	7	punct	_	_
 10	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	17	obl	_	_
@@ -32962,7 +32962,7 @@
 1	-	-	PUNCT	Punc	_	0	root	_	SpaceAfter=No
 2	Yeniden	yeniden	ADV	Adverb	_	5	advmod	_	_
 3-4	deneyebiliriz	_	_	_	_	_	_	_	SpaceAfter=No
-3	deneyebilir	dene	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part	6	ccomp	_	_
+3	deneyebilir	dene	VERB	Verb	Aspect=Hab|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Part	6	ccomp	_	_
 4	iz	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Tense=Pres	3	cop	_	_
 5	,	,	PUNCT	Punc	_	6	punct	_	_
 6	dedim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
@@ -33067,7 +33067,7 @@
 3	daha	daha	ADV	Adverb	_	4	advmod	_	_
 4	mümkün	mümkün	ADJ	Adj	_	5	amod	_	_
 5	hale	hal	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
-6	getiririz	getir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	10	nmod	_	_
+6	getiririz	getir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	10	nmod	_	_
 7	diye	diye	ADP	PCNom	_	6	case	_	_
 8-9	düşünürken	_	_	_	_	_	_	_	_
 8	düşünür	düşünür	NOUN	Noun	Case=Nom|Number=Sing|Person=3	36	obl	_	_
@@ -33094,7 +33094,7 @@
 29	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	30	obl	_	_
 30	getirtmek	getirt	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	32	nsubj	_	_
 31	mümkün	mümkün	ADJ	Adj	_	32	obj	_	_
-32	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	35	nmod	_	_
+32	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	35	nmod	_	_
 33	gibi	gibi	ADP	PCNom	_	32	case	_	_
 34	bir	bir	NUM	ANum	NumType=Card	35	det	_	_
 35	fikir	fikir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	36	nsubj	_	_
@@ -33245,7 +33245,7 @@
 16	uçağı	uçak	NOUN	Noun	Case=Acc|Number=Sing|Person=3	17	obj	_	_
 17	düzeltme	düzel	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	18	nmod:poss	_	_
 18	manevrası	manevra	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	obj	_	_
-19	yaparken	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	32	nmod	_	_
+19	yaparken	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	32	nmod	_	_
 20	sol	sol	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	22	amod	_	_
 21	ana	ana	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	22	amod	_	_
 22	iniş	iniş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	23	nmod:poss	_	_
@@ -33295,7 +33295,7 @@
 9	,	,	PUNCT	Punc	_	2	punct	_	_
 10	ciddiyet	ciddiyet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	conj	_	SpaceAfter=No
 11	;	;	PUNCT	Punc	_	13	punct	_	_
-12	güvenilir	güven	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	13	acl	_	_
+12	güvenilir	güven	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	13	acl	_	_
 13	olmak	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	2	conj	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	19	punct	_	_
 15	ama	ama	CCONJ	Conj	_	19	cc	_	_
@@ -33425,7 +33425,7 @@
 # sent_id = mst-3711
 # text = Benimle gelir misiniz Jul?
 1	Benimle	ben	PRON	Pers	Case=Ins|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
-2	gelir	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+2	gelir	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 3	misiniz	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Tense=Pres	2	aux:q	_	_
 4	Jul	jul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	conj	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	4	punct	_	_
@@ -33484,7 +33484,7 @@
 8	gamma	gamma	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nmod:poss	_	_
 9	fotonu	foto	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	11	obj	_	_
 10	da	da	CCONJ	Conj	_	9	advmod:emph	_	_
-11	üretebilirsiniz	üre	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=2|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	SpaceAfter=No
+11	üretebilirsiniz	üre	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=2|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-3717
@@ -33554,7 +33554,7 @@
 # text = Bakın bu olabilir, dedi acıyla.
 1	Bakın	bak	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	5	obj	_	_
 2	bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	3	nsubj	_	_
-3	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+3	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	3	punct	_	_
 5	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 6	acıyla	acı	ADJ	NAdj	Case=Ins|Number=Sing|Person=3	5	amod	_	SpaceAfter=No
@@ -33568,7 +33568,7 @@
 3	rakı	rakı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 4	sofrası	sofra	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nsubj	_	_
 5	da	da	CCONJ	Conj	_	4	advmod:emph	_	_
-6	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+6	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3727
@@ -33606,7 +33606,7 @@
 1	Güneş	güneş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 2	ağaçların	ağaç	NOUN	Noun	Case=Gen|Number=Plur|Person=3	3	nmod:poss	_	_
 3	arkasına	arka	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	amod	_	_
-4	inerken	in	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	6	nmod	_	_
+4	inerken	in	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
 5	kasabaya	kasaba	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
 6	yollandı	yolla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	0	root	_	_
 7	kamyon	kamyon	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	SpaceAfter=No
@@ -33633,7 +33633,7 @@
 17	teypte	teyp	NOUN	Noun	Case=Loc|Number=Sing|Person=3	18	obl	_	_
 18	böyle	böyle	ADV	Adverb	_	13	advmod	_	SpaceAfter=No
 19	,	,	PUNCT	Punc	_	22	punct	_	_
-20	isterseniz	iste	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	22	nmod	_	_
+20	isterseniz	iste	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	22	nmod	_	_
 21	deşifresini	deşifre	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	22	obj	_	_
 22	okuyayım	oku	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	13	conj	_	SpaceAfter=No
 23	,	,	PUNCT	Punc	_	22	punct	_	_
@@ -33684,7 +33684,7 @@
 4	daha	daha	ADV	Adverb	_	5	advmod	_	_
 5	az	az	ADJ	Adj	_	6	amod	_	_
 6	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-7	harcarlar	harca	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	6	compound	_	SpaceAfter=No
+7	harcarlar	harca	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	6	compound	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3740
@@ -33750,7 +33750,7 @@
 # Change 2.2/dev: merge Kavrulmamış + ı
 1	Kavrulmamışı	kavrul	VERB	Verb	Aspect=Perf|Case=Acc|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Past|VerbForm=Part	3	ccomp	_	_
 2	da	da	CCONJ	Conj	_	1	advmod:emph	_	_
-3	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+3	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3750
@@ -33786,7 +33786,7 @@
 # sent_id = mst-3753
 # text = Bana hissettirir bunu.
 1	Bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	2	obl	_	_
-2	hissettirir	hisset	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	0	root	_	_
+2	hissettirir	hisset	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	_
 3	bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -33823,7 +33823,7 @@
 7	sadece	sadece	ADV	Adverb	_	6	advmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	6	punct	_	_
 9	dışarı	dışarı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obl	_	_
-10	çıkarken	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	9	compound	_	SpaceAfter=No
+10	çıkarken	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	9	compound	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3757
@@ -33954,13 +33954,13 @@
 1	Mersedes	Mersedes	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	obj	_	_
 2	buldum	bul	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	4	nmod	_	_
 3	mu	mu	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	2	aux:q	_	_
-4	bırakmam	bırak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	_
+4	bırakmam	bırak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	_
 5	abi	abi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	conj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-3772
 # text = Olur, dedi Jul.
-1	Olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	3	obj	_	SpaceAfter=No
+1	Olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	obj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	1	punct	_	_
 3	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 4	Jul	jul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	SpaceAfter=No
@@ -33982,7 +33982,7 @@
 1	Bak	bak	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	5	nmod	_	_
 2	ondan	o	PRON	Pers	Case=Abl|Number=Sing|Person=3|PronType=Prs	5	obl	_	_
 3-4	yakınırım	_	_	_	_	_	_	_	_
-3	yakınır	yakın	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	0	root	_	_
+3	yakınır	yakın	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	0	root	_	_
 4	ım	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	3	cop	_	_
 5	ama	ama	CCONJ	Conj	_	8	cc	_	_
 6	belki	belki	ADV	Adverb	_	8	advmod	_	_
@@ -34011,11 +34011,11 @@
 15	teybe	teyp	NOUN	Noun	Case=Dat|Number=Sing|Person=3	16	obl	_	_
 16	koyduğu	koy	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	17	acl	_	_
 17	şarkıları	şarkı	NOUN	Noun	Case=Acc|Number=Plur|Person=3	18	obj	_	_
-18	keser	kes	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+18	keser	kes	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 19	,	,	PUNCT	Punc	_	21	punct	_	_
 20	bağlamasını	bağlama	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	obj	_	_
 21	eline	el	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	conj	_	_
-22	alır	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	21	compound	_	SpaceAfter=No
+22	alır	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	21	compound	_	SpaceAfter=No
 23	;	;	PUNCT	Punc	_	42	punct	_	_
 24	küçük	küçük	ADJ	Adj	_	26	amod	_	_
 25	bir	bir	NUM	ANum	NumType=Card	26	det	_	_
@@ -34035,7 +34035,7 @@
 37	yükseltiye	yükselti	NOUN	Noun	Case=Dat|Number=Sing|Person=3	40	obl	_	_
 38	bir	bir	NUM	ANum	NumType=Card	39	det	_	_
 39	tabure	tabure	NOUN	Noun	Case=Nom|Number=Sing|Person=3	40	obj	_	_
-40	koyar	koy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	42	nmod	_	SpaceAfter=No
+40	koyar	koy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	42	nmod	_	SpaceAfter=No
 41	,	,	PUNCT	Punc	_	40	punct	_	_
 42	otururdu	otur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	18	conj	_	SpaceAfter=No
 43	.	.	PUNCT	Punc	_	42	punct	_	_
@@ -34321,7 +34321,7 @@
 # sent_id = mst-3808
 # text = Ben ürkerim zamandan.
 1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
-2	ürkerim	ürk	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+2	ürkerim	ürk	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 3	zamandan	zaman	NOUN	Noun	Case=Abl|Number=Sing|Person=3	2	obl	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -34336,7 +34336,7 @@
 # text = Nereye gitmiş olabilir Osman.
 1	Nereye	nere	PRON	Ques	Case=Dat|Number=Sing|Person=3	2	obl	_	_
 2	gitmiş	git	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	obj	_	_
-3	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+3	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 4	Osman	Osman	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nsubj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -34427,7 +34427,7 @@
 1	Güzel	güzel	ADJ	Adj	_	3	amod	_	_
 2	rakı	rakı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	compound	_	_
 3	mezeleri	meze	NOUN	Noun	Case=Acc|Number=Plur|Person=3	4	obj	_	_
-4	verir	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+4	verir	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 5	patlıcan	patlıcan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -34459,7 +34459,7 @@
 # text = Başka ne yapabilirim ki.
 1	Başka	başka	ADJ	Adj	_	3	amod	_	_
 2	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	3	obj	_	_
-3	yapabilirim	yap	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+3	yapabilirim	yap	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 4	ki	ki	CCONJ	Conj	_	3	advmod:emph	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -34592,7 +34592,7 @@
 5	daha	daha	ADV	Adverb	_	3	advmod:emph	_	_
 6	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	7	obj	_	_
 7	yapacağını	yap	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	8	obj	_	_
-8	bilmez	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	9	acl	_	_
+8	bilmez	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	9	acl	_	_
 9	halde	hal	NOUN	Noun	Case=Loc|Number=Sing|Person=3	10	obl	_	_
 10	ortada	orta	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	12	amod	_	_
 11	dolaşmaya	dolaş	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	10	compound	_	_
@@ -34657,8 +34657,8 @@
 9	koymak	koy	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	compound	_	_
 10	olmadığını	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	12	obj	_	_
 11	da	da	CCONJ	Conj	_	10	advmod:emph	_	_
-12	yazarsanız	yaz	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	13	nmod	_	_
-13	sevinirim	sevin	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	15	obj	_	_
+12	yazarsanız	yaz	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	13	nmod	_	_
+13	sevinirim	sevin	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	15	obj	_	_
 14	"	"	PUNCT	Punc	_	13	punct	_	_
 15	karşılığını	karşılık	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 16	verdi	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	15	compound	_	SpaceAfter=No
@@ -34687,7 +34687,7 @@
 3	önem	önem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
 4	li	li	ADP	With	_	3	case	_	_
 5	açıklamalar	açıkla	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	12	nmod	_	_
-6	yaparken	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	5	compound:lvc	_	SpaceAfter=No
+6	yaparken	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	5	compound:lvc	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	5	punct	_	_
 8	babayla	baba	NOUN	Noun	Case=Ins|Number=Sing|Person=3	12	nsubj	_	_
 9	oğlu	oğul	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	conj	_	_
@@ -34745,7 +34745,7 @@
 4	günden	gün	NOUN	Noun	Case=Abl|Number=Sing|Person=3	5	obl	_	_
 5	başlamış	başla	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	7	obj	_	_
 6	da	da	CCONJ	Conj	_	5	advmod:emph	_	_
-7	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+7	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 8	...	...	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-3854
@@ -34849,7 +34849,7 @@
 
 # sent_id = mst-3866
 # text = Bulabilirler onu.
-1	Bulabilirler	bul	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Bulabilirler	bul	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 2	onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	1	obj	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
@@ -35042,7 +35042,7 @@
 3	,	,	PUNCT	Punc	_	2	punct	_	_
 4	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	_
 5	evden	ev	NOUN	Noun	Case=Abl|Number=Sing|Person=3	6	obl	_	_
-6	kaçarım	kaç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	8	obj	_	SpaceAfter=No
+6	kaçarım	kaç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	8	obj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
 8	demek	de	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	2	conj	_	SpaceAfter=No
 9	?	?	PUNCT	Punc	_	8	punct	_	_
@@ -35141,7 +35141,7 @@
 3	de	de	CCONJ	Conj	_	2	advmod:emph	_	_
 4	yazdıklarımı	yaz	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	6	obj	_	_
 5	sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	6	obl	_	_
-6	gösteririm	göster	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+6	gösteririm	göster	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3891
@@ -35151,7 +35151,7 @@
 3	gene	gene	ADV	Adverb	_	5	advmod	_	_
 4	parkın	park	NOUN	Noun	Case=Gen|Number=Sing|Person=3	5	nmod:poss	_	_
 5	içine	iç	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obj	_	_
-6	çeker	çek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	compound	_	_
+6	çeker	çek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	compound	_	_
 7	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 8	Şakir	Şakir	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	nsubj	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	7	punct	_	_
@@ -35225,7 +35225,7 @@
 # text = Doğrular neyi çözer? Hiçbir şeyi.
 1	Doğrular	doğru	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	3	nsubj	_	_
 2	neyi	ne	PRON	Ques	Case=Acc|Number=Sing|Person=3	4	obj	_	_
-3	çözer	çöz	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	çözer	çöz	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	?	?	PUNCT	Punc	_	3	punct	_	_
 5	Hiçbir	hiçbir	DET	Det	_	3	obj	_	_
 6	şeyi	şey	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	compound	_	SpaceAfter=No
@@ -35326,7 +35326,7 @@
 
 # sent_id = mst-3910
 # text = İstersen önce oraya gidelim.
-1	İstersen	iste	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	4	nmod	_	_
+1	İstersen	iste	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	4	nmod	_	_
 2	önce	önce	ADV	Adverb	_	4	advmod	_	_
 3	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
 4	gidelim	git	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
@@ -35339,7 +35339,7 @@
 3	Atila	Atila	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	obj	_	_
 4	Ağbiyi	ağbi	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	compound	_	_
 5	çok	çok	ADV	Adverb	_	6	advmod	_	_
-6	severiz	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	severiz	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3912
@@ -35397,7 +35397,7 @@
 2	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
 3	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
 4	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	5	obj	_	_
-5	yaparım	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	yaparım	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	?	?	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-3922
@@ -35497,7 +35497,7 @@
 6	kadar	kadar	ADP	PCDat	_	5	case	_	_
 7	uzak	uzak	ADJ	Adj	_	8	obj	_	_
 8	olduğu	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	10	nsubj	_	_
-9	sanılırsa	san	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	10	nmod	_	_
+9	sanılırsa	san	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	10	nmod	_	_
 10	sanılsın	san	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	18	nmod	_	_
 11	bu	bu	DET	Det	_	12	det	_	_
 12	oda	oda	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nsubj	_	_
@@ -35505,7 +35505,7 @@
 14	süre	süre	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	obl	_	_
 15	sonra	sonra	ADP	PCAbl	_	14	case	_	_
 16	tezgahı	tezgah	NOUN	Noun	Case=Acc|Number=Sing|Person=3	17	obj	_	_
-17	aratır	ara	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Cau	18	acl	_	_
+17	aratır	ara	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	18	acl	_	_
 18	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 19	.	.	PUNCT	Punc	_	18	punct	_	_
 
@@ -35513,7 +35513,7 @@
 # text = Müşteri neyi sever?.
 1	Müşteri	müşteri	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	neyi	ne	PRON	Ques	Case=Acc|Number=Sing|Person=3	3	obj	_	_
-3	sever	sev	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	sever	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	?	?	PUNCT	Punc	_	3	punct	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -35574,7 +35574,7 @@
 2	,	,	PUNCT	Punc	_	12	punct	_	_
 3	bilginin	bilgi	NOUN	Noun	Case=Gen|Number=Sing|Person=3	7	obj	_	_
 4	üretimde	üretim	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
-5	kullanılabilir	kullan	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	6	acl	_	_
+5	kullanılabilir	kullan	VERB	Verb	Aspect=Hab|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	6	acl	_	_
 6	hale	hal	NOUN	Noun	Case=Dat|Number=Sing|Person=3	7	obl	_	_
 7	getirilmesi	getir	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	8	nmod:poss	_	_
 8	amacıyla	amaç	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obl	_	_
@@ -35618,7 +35618,7 @@
 5	algılar	algı	NOUN	Noun	Case=Nom|Number=Plur|Person=3	6	nmod:poss	_	_
 6	bütünü	bütün	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	amod	_	_
 7	olarak	olarak	ADP	PCNom	_	6	case	_	_
-8	betimler	betimle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+8	betimler	betimle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-3949
@@ -35725,7 +35725,7 @@
 2	ışıksız	ışıksız	ADJ	Adj	_	3	nmod:poss	_	_
 3	pencerelerine	pencere	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	10	obl	_	_
 4	uzaktan	uzak	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	5	amod	_	_
-5	bakarken	bak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	10	nmod	_	_
+5	bakarken	bak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	10	nmod	_	_
 6	kalbim	kalbi	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	10	nsubj	_	_
 7	böyle	böyle	ADV	Adverb	_	10	advmod	_	_
 8	küt	küt	ADJ	Adj	_	10	amod	_	_
@@ -35767,7 +35767,7 @@
 6	Sibirya'nın	Sibirya	PROPN	Prop	Case=Gen|Number=Sing|Person=3	10	nmod:poss	_	_
 7	bu	bu	DET	Det	_	10	det	_	_
 8	insan	insan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
-9	yaşamaz	yaşa	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	10	acl	_	_
+9	yaşamaz	yaşa	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	10	acl	_	_
 10	taygasında	tayga	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	26	nmod	_	_
 11	kızağın	kızak	NOUN	Noun	Case=Gen|Number=Sing|Person=3	12	nmod:poss	_	_
 12	kırılması	kır	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	26	nmod	_	SpaceAfter=No
@@ -35802,7 +35802,7 @@
 # text = Senaryolar çıkışı zorlayabilir.
 1	Senaryolar	senaryo	NOUN	Noun	Case=Nom|Number=Plur|Person=3	3	nsubj	_	_
 2	çıkışı	çıkış	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	obj	_	_
-3	zorlayabilir	zorla	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	zorlayabilir	zorla	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3974
@@ -35880,7 +35880,7 @@
 # sent_id = mst-3982
 # text = Çıkmak istemez.
 1	Çıkmak	çık	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	2	obj	_	_
-2	istemez	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+2	istemez	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-3983
@@ -35919,7 +35919,7 @@
 3	geliştirmiş	geliş	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Cau	4	obj	_	_
 4	olduğu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	7	acl	_	_
 5-6	yanlışlanabilirlik	_	_	_	_	_	_	_	_
-5	yanlışlanabilir	yanlışla	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	7	acl	_	_
+5	yanlışlanabilir	yanlışla	VERB	Verb	Aspect=Hab|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	7	acl	_	_
 6	lik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	5	case	_	_
 7	ilkesi	ilke	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	nsubj	_	_
 8	materyalist	materyalist	ADJ	Adj	_	9	amod	_	_
@@ -36039,11 +36039,11 @@
 11	barındıran	barın	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Cau	12	acl	_	_
 12	önermelerden	öner	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	13	nmod	_	_
 13	yola	yol	NOUN	Noun	Case=Dat|Number=Sing|Person=3	1	conj	_	_
-14	çıkılır	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	13	compound	_	SpaceAfter=No
+14	çıkılır	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	13	compound	_	SpaceAfter=No
 15	;	;	PUNCT	Punc	_	18	punct	_	_
 16	bunlara	bu	PRON	Demons	Case=Dat|Number=Plur|Person=3|PronType=Dem	18	obl	_	_
 17	aksiyom	aksiyom	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	obj	_	_
-18	denir	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	13	conj	_	SpaceAfter=No
+18	denir	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	13	conj	_	SpaceAfter=No
 19	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-4004
@@ -36088,7 +36088,7 @@
 20	bu	bu	DET	Det	_	21	det	_	_
 21	açıdan	açı	NOUN	Noun	Case=Abl|Number=Sing|Person=3	23	obl	_	_
 22	tipik	tipik	ADJ	Adj	_	23	amod	_	_
-23	sayılabilir	say	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+23	sayılabilir	say	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 24	.	.	PUNCT	Punc	_	23	punct	_	_
 
 # sent_id = mst-4010
@@ -36104,14 +36104,14 @@
 9	kullanmak	kullan	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	12	nsubj	_	_
 10	bir	bir	NUM	ANum	NumType=Card	11	nummod	_	_
 11	çözüm	çözüm	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	obj	_	_
-12	olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+12	olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-4012
 # text = Çocuklar izin verirse.
 1	Çocuklar	çocuk	NOUN	Noun	Case=Nom|Number=Plur|Person=3	2	nsubj	_	_
 2	izin	izin	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-3	verirse	ver	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	compound	_	SpaceAfter=No
+3	verirse	ver	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	compound	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-4013
@@ -36144,9 +36144,9 @@
 
 # sent_id = mst-4017
 # text = Olmaz, olmaz! dedi.
-1	Olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	5	obj	_	SpaceAfter=No
+1	Olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	5	obj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	3	punct	_	_
-3	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	1	conj	_	SpaceAfter=No
+3	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	1	conj	_	SpaceAfter=No
 4	!	!	PUNCT	Punc	_	3	punct	_	_
 5	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
@@ -36159,7 +36159,7 @@
 4	kırk	kırk	NUM	ANum	NumType=Card	5	nummod	_	_
 5	kere	kere	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obl	_	_
 6-7	söylenirse	_	_	_	_	_	_	_	_
-6	söylenir	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	8	acl	_	_
+6	söylenir	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	8	acl	_	_
 7	se	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	6	cop	_	_
 8	olurmuş	ol	VERB	Verb	Aspect=Hab|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
@@ -36607,8 +36607,8 @@
 7	doğru	doğru	ADP	PCDat	_	6	case	_	_
 8	sabırsızca	sabırsızca	ADV	Adverb	_	9	advmod	_	_
 9	hareket	hareket	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obj	_	_
-10	ederken	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	9	compound:lvc	_	_
-11	görürsünüz	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+10	ederken	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	9	compound:lvc	_	_
+11	görürsünüz	gör	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-4073
@@ -36634,7 +36634,7 @@
 1	Şehvet	şehvet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 2	ve	ve	CCONJ	Conj	_	3	cc	_	_
 3	arzu	arzu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
-4	yaşanırken	yaşa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv|Voice=Pass	10	nmod	_	SpaceAfter=No
+4	yaşanırken	yaşa	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	10	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	4	punct	_	_
 6	eski	eski	ADJ	Adj	_	8	amod	_	_
 7	bir	bir	NUM	ANum	NumType=Card	8	det	_	_
@@ -36766,7 +36766,7 @@
 1	Kargadan	karga	NOUN	Noun	Case=Abl|Number=Sing|Person=3	0	root	_	_
 2	korkan	kork	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	1	compound	_	_
 3	darı	darı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
-4	ekmez	ek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	1	compound	_	SpaceAfter=No
+4	ekmez	ek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	1	compound	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-4099
@@ -36918,11 +36918,11 @@
 10	çok	çok	ADP	PCAbl	_	11	advmod:emph	_	_
 11	girift	girift	ADJ	Adj	_	15	amod	_	_
 12	ve	ve	CCONJ	Conj	_	13	cc	_	_
-13	ayrılmaz	ayrıl	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	11	conj	_	_
+13	ayrılmaz	ayrıl	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	11	conj	_	_
 14	bir	bir	NUM	ANum	NumType=Card	15	det	_	_
 15	bağlantının	bağlantı	NOUN	Noun	Case=Gen|Number=Sing|Person=3	16	nsubj	_	_
 16	olduğunu	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	17	obj	_	_
-17	gösterir	göster	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+17	gösterir	göster	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 18	.	.	PUNCT	Punc	_	17	punct	_	_
 
 # sent_id = mst-4122
@@ -37050,7 +37050,7 @@
 12	ki	ki	ADP	Rel	_	11	case	_	_
 13	duygusal	duygusal	ADJ	Adj	_	14	amod	_	_
 14	boşluğu	boşluk	NOUN	Noun	Case=Acc|Number=Sing|Person=3	15	obj	_	_
-15	sezebilir	sez	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	_
+15	sezebilir	sez	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	_
 16	ve	ve	CCONJ	Conj	_	28	cc	_	_
 17	pek	pek	ADV	Adverb	_	18	advmod	_	_
 18	çok	çok	ADJ	Adj	_	19	det	_	_
@@ -37063,7 +37063,7 @@
 25	parıltılarından	parıltı	NOUN	Noun	Case=Abl|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	26	obl	_	_
 26	etkilenmeden	etkile	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv|Voice=Pass	28	nmod	_	_
 27	tanısını	tanı	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	28	obj	_	_
-28	koyabilir	koy	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	15	conj	_	SpaceAfter=No
+28	koyabilir	koy	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	15	conj	_	SpaceAfter=No
 29	.	.	PUNCT	Punc	_	28	punct	_	_
 
 # sent_id = mst-4136
@@ -37078,7 +37078,7 @@
 8	piyasaları	piyasa	NOUN	Noun	Case=Acc|Number=Plur|Person=3	10	obj	_	_
 9	olumlu	olumlu	ADJ	Adj	_	10	obj	_	_
 10	etkileyeceği	etkile	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	11	nsubj	_	_
-11	düşünülebilir	düşün	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+11	düşünülebilir	düşün	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-4138
@@ -37122,7 +37122,7 @@
 5	nasıl	nasıl	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	8	ccomp	_	_
 6	dır	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	5	cop	_	_
 7	,	,	PUNCT	Punc	_	8	punct	_	_
-8	bilirsiniz	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	10	obj	_	SpaceAfter=No
+8	bilirsiniz	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	10	obj	_	SpaceAfter=No
 9	...	...	PUNCT	Punc	_	8	punct	_	_
 10	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
@@ -37132,8 +37132,8 @@
 1	Adam	adam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
 2	kızın	kız	ADJ	NAdj	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
 3	annesini	anne	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
-4	görür	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	8	nmod	_	_
-5	görmez	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	4	compound	_	_
+4	görür	gör	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	_
+5	görmez	gör	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	4	compound	_	_
 6	kadının	kadın	ADJ	NAdj	Case=Gen|Number=Sing|Person=3	7	nmod:poss	_	_
 7	güzelliğine	güzellik	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	_
 8	vurulmuş	vurul	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -37265,7 +37265,7 @@
 # sent_id = mst-4158
 # text = yalnız dinler.
 1	yalnız	yalnız	ADV	Adverb	_	2	advmod	_	_
-2	dinler	dinle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	dinler	dinle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-4159
@@ -37306,7 +37306,7 @@
 # text = Kadınlar ne ister?.
 1	Kadınlar	kadın	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	3	nsubj	_	_
 2	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	3	obj	_	_
-3	ister	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	ister	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	?	?	PUNCT	Punc	_	3	punct	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -37496,7 +37496,7 @@
 5	yeniden	yeniden	ADV	Adverb	_	6	advmod	_	_
 6	ortaya	orta	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	8	nsubj	_	_
 7	dökülmesi	dök	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	6	compound	_	_
-8	gerekmez	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	9	nmod	_	_
+8	gerekmez	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	9	nmod	_	_
 9	şeklinde	şekil	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	conj	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
@@ -37556,7 +37556,7 @@
 2	olmamdan	ol	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	nmod	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	6	punct	_	_
 4	onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	6	obj	_	_
-5	taparcasına	tap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	6	nmod	_	_
+5	taparcasına	tap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
 6	sevmemden	sev	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	2	conj	_	_
 7	sıkıldı	sıkıl	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
@@ -37615,7 +37615,7 @@
 
 # sent_id = mst-4202
 # text = Olabilir...
-1	Olabilir	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+1	Olabilir	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 2	...	...	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-4203
@@ -37968,7 +37968,7 @@
 # text = Bu kadar yeter, dedi, inin de gidelim artık.
 1	Bu	bu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	3	nsubj	_	_
 2	kadar	kadar	ADP	PCDat	_	1	case	_	_
-3	yeter	yet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	obj	_	SpaceAfter=No
+3	yeter	yet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	obj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	9	punct	_	_
 5	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	5	punct	_	_
@@ -38295,7 +38295,7 @@
 22	kez	kez	NOUN	Noun	Case=Nom|Number=Sing|Person=3	26	obl	_	_
 23	asansörle	asansör	NOUN	Noun	Case=Ins|Number=Sing|Person=3	25	obl	_	_
 24	eve	ev	NOUN	Noun	Case=Dat|Number=Sing|Person=3	25	obl	_	_
-25	çıkarken	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	26	nmod	_	_
+25	çıkarken	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	26	nmod	_	_
 26	görmüştüm	gör	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pqp	9	conj	_	SpaceAfter=No
 27	,	,	PUNCT	Punc	_	33	punct	_	_
 28	somurtkan	somurtkan	ADJ	Adj	_	29	amod	_	_
@@ -38305,7 +38305,7 @@
 32	gözleri	göz	NOUN	Noun	Case=Acc|Number=Plur|Person=3	29	conj	_	_
 33	vardı	var	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	9	conj	_	SpaceAfter=No
 34	,	,	PUNCT	Punc	_	38	punct	_	_
-35	konuşurken	konuş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	38	nmod	_	_
+35	konuşurken	konuş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	38	nmod	_	_
 36	hep	hep	ADV	Adverb	_	37	advmod	_	_
 37	yere	yer	NOUN	Noun	Case=Dat|Number=Sing|Person=3	38	obl	_	_
 38	bakıyor	bak	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	9	conj	_	_
@@ -38350,7 +38350,7 @@
 # text = Yanlışlanabilirlik ilkesi ne yazık ki çoğu zaman yanlış yorumlanmaktadır.
 # Fixed 2.2/dev: original sentence ID: 00044121454/1
 1-2	Yanlışlanabilirlik	_	_	_	_	_	_	_	_
-1	Yanlışlanabilir	yanlışla	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	3	nmod:poss	_	_
+1	Yanlışlanabilir	yanlışla	VERB	Verb	Aspect=Hab|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	3	nmod:poss	_	_
 2	lik	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	1	case	_	_
 3	ilkesi	ilke	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	nsubj	_	_
 4	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	5	nmod	_	_
@@ -38504,7 +38504,7 @@
 11	olanları	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	12	obj	_	_
 12	anlatmıştı	anla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp|Voice=Cau	0	root	_	_
 13	yola	yol	NOUN	Noun	Case=Dat|Number=Sing|Person=3	14	obl	_	_
-14	çıkarlarken	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	12	nmod	_	SpaceAfter=No
+14	çıkarlarken	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	12	nmod	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-4286
@@ -38749,7 +38749,7 @@
 7	olmayacağından	ol	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Fut|VerbForm=Part	16	acl	_	_
 8	bu	bu	DET	Det	_	9	det	_	_
 9	kurala	kural	NOUN	Noun	Case=Dat|Number=Sing|Person=3	10	obl	_	_
-10	uymam	uy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	16	nsubj	_	_
+10	uymam	uy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	16	nsubj	_	_
 11	köpeğimin	köpek	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	13	nmod:poss	_	_
 12	de	de	CCONJ	Conj	_	11	advmod:emph	_	_
 13	iyiliği	iyilik	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	16	obj	_	_
@@ -38804,7 +38804,7 @@
 # text = Öyle mi dersiniz.
 1	Öyle	öyle	ADV	Adverb	_	3	advmod	_	_
 2	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	1	aux:q	_	_
-3	dersiniz	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	dersiniz	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-4319
@@ -38873,7 +38873,7 @@
 2	kadar	kadar	ADP	PCDat	_	1	case	_	_
 3	çabuk	çabuk	ADV	Adverb	_	5	advmod	_	_
 4	da	da	CCONJ	Conj	_	3	advmod:emph	_	_
-5	bulamaz	bul	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	_
+5	bulamaz	bul	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
 6	değil	değil	VERB	Neg	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	5	cop	_	_
 7	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	5	aux:q	_	SpaceAfter=No
 8	?	?	PUNCT	Punc	_	5	punct	_	_
@@ -38898,7 +38898,7 @@
 4	unutmalarını	unut	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	obj	_	_
 5	hoş	hoş	ADJ	Adj	_	7	obj	_	_
 6	görmek	gör	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	compound	_	_
-7	gerekir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+7	gerekir	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	10	punct	_	_
 9	kolay	kolay	ADJ	Adj	_	10	amod	_	_
 10	olmuyor	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Polite=Infm|Tense=Pres	7	conj	_	_
@@ -39234,7 +39234,7 @@
 12	partilerin	parti	NOUN	Noun	Case=Gen|Number=Plur|Person=3	13	nmod:poss	_	_
 13	binaları	bina	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	15	nsubj	_	_
 14	sessizliğe	sessizlik	NOUN	Noun	Case=Dat|Number=Sing|Person=3	15	obl	_	_
-15	gömülürken	göm	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv|Voice=Pass	23	nmod	_	SpaceAfter=No
+15	gömülürken	göm	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	23	nmod	_	SpaceAfter=No
 16	,	,	PUNCT	Punc	_	15	punct	_	_
 17	partililer	partili	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	23	nsubj	_	_
 18	de	de	CCONJ	Conj	_	17	advmod:emph	_	_
@@ -39275,7 +39275,7 @@
 # text = O kendi götüremez miymiş.
 1	O	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	kendi	kendi	PRON	Reflex	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	1	conj	_	_
-3	götüremez	götür	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	_
+3	götüremez	götür	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
 4	miymiş	mi	AUX	Ques	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Tense=Past	3	aux:q	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -39308,7 +39308,7 @@
 9	felsefi	felsefi	ADJ	Adj	_	10	amod	_	_
 10	anlamda	anlam	NOUN	Noun	Case=Loc|Number=Sing|Person=3	12	obl	_	_
 11	kapalılığı	kapalılık	NOUN	Noun	Case=Acc|Number=Sing|Person=3	12	obj	_	_
-12	anlatır	anlat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+12	anlatır	anlat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-4376
@@ -39394,7 +39394,7 @@
 14	en	en	ADV	Adverb	_	15	advmod	_	_
 15	canlı	canlı	ADJ	Adj	_	16	amod	_	_
 16	yerini	yer	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	obj	_	_
-17	seçer	seç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+17	seçer	seç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 18	,	,	PUNCT	Punc	_	21	punct	_	_
 19	kahvelerin	kahve	NOUN	Noun	Case=Gen|Number=Plur|Person=3	21	nmod:poss	_	_
 20	de	de	CCONJ	Conj	_	19	advmod:emph	_	_
@@ -39433,7 +39433,7 @@
 5	da	da	CCONJ	Conj	_	4	advmod:emph	_	_
 6	Türkler	Türk	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	7	nmod:poss	_	_
 7	tarafından	taraf	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	_
-8	yapılır	yap	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+8	yapılır	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-4390
@@ -39457,7 +39457,7 @@
 1	Hep	hep	ADV	Adverb	_	4	advmod	_	_
 2	uzaktan	uzak	ADJ	NAdj	Case=Abl|Number=Sing|Person=3	3	amod	_	_
 3	uzağa	uzak	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	4	amod	_	_
-4	kuşatmazlar	kuşat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Aor	0	root	_	_
+4	kuşatmazlar	kuşat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
 5	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	4	aux:q	_	_
 6	birbirlerini	birbiri	PRON	Quant	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	4	obj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	4	punct	_	_
@@ -39466,7 +39466,7 @@
 10	giren	gir	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	9	compound	_	_
 11	anaların	ana	ADJ	NAdj	Case=Gen|Number=Plur|Person=3	12	nmod:poss	_	_
 12	yatıştırmalarıyla	yatış	VERB	Verb	Aspect=Perf|Case=Ins|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	13	nmod	_	_
-13	sakinleşmez	sakinleş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	4	conj	_	_
+13	sakinleşmez	sakinleş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	4	conj	_	_
 14	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	13	aux:q	_	_
 15	ortalık	ortalık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nsubj	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	13	punct	_	_
@@ -39474,17 +39474,17 @@
 # sent_id = mst-4394
 # text = Hala okuyabilir, anlattığı aşklara katılabilir, maceralarında uzun yolculuklara çıkabilirdik.
 1	Hala	hala	ADV	Adverb	_	2	advmod	_	_
-2	okuyabilir	oku	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	11	cop	_	SpaceAfter=No
+2	okuyabilir	oku	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	11	cop	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	6	punct	_	_
 4	anlattığı	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	5	acl	_	_
 5	aşklara	aşk	NOUN	Noun	Case=Dat|Number=Plur|Person=3	6	obl	_	_
-6	katılabilir	kat	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	2	conj	_	SpaceAfter=No
+6	katılabilir	kat	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	2	conj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	13	punct	_	_
 8	maceralarında	macera	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	11	obl	_	_
 9	uzun	uzun	ADJ	Adj	_	10	amod	_	_
 10	yolculuklara	yolculuk	NOUN	Noun	Case=Dat|Number=Plur|Person=3	11	obl	_	_
 11-12	çıkabilirdik	_	_	_	_	_	_	_	SpaceAfter=No
-11	çıkabilir	çık	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part	0	root	_	_
+11	çıkabilir	çık	VERB	Verb	Aspect=Hab|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Part	0	root	_	_
 12	dik	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Tense=Past	2	conj	_	_
 13	.	.	PUNCT	Punc	_	11	punct	_	_
 
@@ -39523,7 +39523,7 @@
 # text = Aklığından ötürü alır bu adı.
 1	Aklığından	aklık	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obl	_	_
 2	ötürü	ötürü	ADP	PCAbl	_	1	case	_	_
-3	alır	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+3	alır	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 4	bu	bu	DET	Det	_	5	det	_	_
 5	adı	ad	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	obj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -39542,7 +39542,7 @@
 2	tartışmadan	tartış	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	4	nmod	_	_
 3	önce	önce	ADP	PCAbl	_	2	case	_	_
 4	düşünmek	düşün	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	obj	_	_
-5	isterim	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+5	isterim	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 6	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
@@ -39583,7 +39583,7 @@
 1	Zeynep	Zeynep	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 2	:	:	PUNCT	Punc	_	9	punct	_	_
 3	Yemin	yemin	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	nmod	_	_
-4	ederim	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	3	compound:lvc	_	_
+4	ederim	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	compound:lvc	_	_
 5	ki	ki	CCONJ	Conj	_	3	mark	_	_
 6	kimseye	kimse	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
 7	bir	bir	NUM	ANum	NumType=Card	9	obj	_	_
@@ -39726,7 +39726,7 @@
 # sent_id = mst-4422
 # text = Ya reddedilirsem! korkusu var ya.
 1	Ya	ya	CCONJ	Conj	_	2	nmod	_	_
-2	reddedilirsem	reddet	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Aor|Voice=Pass	4	nmod:poss	_	SpaceAfter=No
+2	reddedilirsem	reddet	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=1|Polarity=Pos|Tense=Pres|Voice=Pass	4	nmod:poss	_	SpaceAfter=No
 3	!	!	PUNCT	Punc	_	2	punct	_	_
 4	korkusu	korku	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nsubj	_	_
 5	var	var	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	_
@@ -39892,7 +39892,7 @@
 2	kocası	koca	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nsubj	_	_
 3	havuzun	havuz	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
 4	başında	baş	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
-5	durur	dur	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+5	durur	dur	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 6	her	her	DET	Det	_	5	det	_	_
 7	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	compound	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	5	punct	_	_
@@ -39913,7 +39913,7 @@
 1	Anne	anne	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	15	punct	_	_
 3	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	15	obl	_	_
-4	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	3	compound	_	SpaceAfter=No
+4	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	compound	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	8	punct	_	_
 6	ses	ses	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
 7	çıkartmadan	çıkar	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv|Voice=Cau	8	nmod	_	_
@@ -39921,7 +39921,7 @@
 9	,	,	PUNCT	Punc	_	12	punct	_	_
 10	içine	iç	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	amod	_	_
 11	kazağımı	kazağı	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	12	obj	_	_
-12	tıkarım	tık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+12	tıkarım	tık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	12	punct	_	_
 14	diye	diye	ADP	PCNom	_	3	case	_	_
 15	yalvardı	yalvar	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	1	conj	_	_
@@ -39962,7 +39962,7 @@
 5	Kutan	Kutan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	flat	_	_
 6	ise	i	AUX	Conj	_	4	discourse	_	_
 7	iktidara	iktidar	NOUN	Noun	Case=Dat|Number=Sing|Person=3	8	obl	_	_
-8	gelirlerse	gel	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	18	nmod	_	_
+8	gelirlerse	gel	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	18	nmod	_	_
 9	ilk	ilk	ADJ	Adj	_	10	amod	_	_
 10	yapacakları	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part	11	acl	_	_
 11	icraatın	icraat	NOUN	Noun	Case=Gen|Number=Sing|Person=3	18	nmod:poss	_	_
@@ -40013,7 +40013,7 @@
 18	kaç	kaç	NUM	Adj	NumType=Card	19	nummod	_	_
 19	tanker	tanker	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nmod	_	_
 20	şarap	şarap	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	obj	_	_
-21	içmem	iç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	22	nsubj	_	_
+21	içmem	iç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	22	nsubj	_	_
 22	gerekecek	gerek	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	1	conj	_	SpaceAfter=No
 23	.	.	PUNCT	Punc	_	22	punct	_	_
 
@@ -40052,7 +40052,7 @@
 6	örtüp	ört	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	8	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
 8	geri	geri	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	17	amod	_	_
-9	çekilirken	çek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv|Voice=Pass	8	compound	_	_
+9	çekilirken	çek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	8	compound	_	_
 10	ayağının	ayak	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	11	nmod:poss	_	_
 11-12	altındaki	_	_	_	_	_	_	_	_
 11	altında	altı	NUM	NNum	Case=Loc|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=2	13	nummod	_	_
@@ -40148,7 +40148,7 @@
 7	o	o	DET	Det	_	8	det	_	_
 8	parkta	park	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	nmod	_	_
 9	geçirmeye	geçir	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	compound	_	_
-10	başlarsınız	başla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+10	başlarsınız	başla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-4466
@@ -40408,7 +40408,7 @@
 # sent_id = mst-4497
 # text = Kapı aralanır gibi oluyor, büyük bir gürültü ile yeniden çarpıp kapanıyordu.
 1	Kapı	kapı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
-2	aralanır	arala	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	4	nmod	_	_
+2	aralanır	arala	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	4	nmod	_	_
 3	gibi	gibi	ADP	PCNom	_	2	case	_	_
 4	oluyor	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	12	punct	_	_
@@ -40504,7 +40504,7 @@
 3	pilotların	pilot	NOUN	Noun	Case=Gen|Number=Plur|Person=3	4	nmod:poss	_	_
 4	üzerine	üzer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 5	atılıp	at	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	0	root	_	_
-6	kapatılır	kapa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=CauPass	5	conj	_	SpaceAfter=No
+6	kapatılır	kapa	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=CauPass	5	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-4508
@@ -40599,7 +40599,7 @@
 5	"	"	PUNCT	Punc	_	8	punct	_	_
 6	Yanlışlara	yanlış	ADJ	NAdj	Case=Dat|Number=Plur|Person=3	8	amod	_	_
 7	ortak	ortak	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8	olmam	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	10	nmod	_	_
+8	olmam	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	10	nmod	_	_
 9	"	"	PUNCT	Punc	_	8	punct	_	_
 10-11	haberindeki	_	_	_	_	_	_	_	_
 10	haberinde	haber	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	nmod	_	_
@@ -40687,7 +40687,7 @@
 13	,	,	PUNCT	Punc	_	16	punct	_	_
 14	kimi	kimi	DET	Det	_	15	det	_	_
 15	intiharlar	intihar	NOUN	Noun	Case=Nom|Number=Plur|Person=3	16	nsubj	_	_
-16	işlenebilir	işle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	1	conj	_	SpaceAfter=No
+16	işlenebilir	işle	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	1	conj	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-4526
@@ -40825,7 +40825,7 @@
 3	sıra	sıra	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound:redup	_	_
 4	nazikçe	nazikçe	ADV	Adverb	_	6	advmod	_	_
 5	boğazlar	boğaz	NOUN	Noun	Case=Nom|Number=Plur|Person=3	6	nsubj	_	_
-6	temizlenir	temizle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+6	temizlenir	temizle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
 8	dudakların	dudak	NOUN	Noun	Case=Gen|Number=Plur|Person=3	9	nmod:poss	_	_
 9	üzerlerinde	üzer	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	10	obl	_	_
@@ -40837,7 +40837,7 @@
 15	özen	özen	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	obl	_	_
 16	gösterilerek	göster	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	15	compound	_	_
 17	hafifçe	hafifçe	ADV	Adverb	_	18	advmod	_	_
-18	siliniverir	sil	VERB	Verb	Aspect=Rapid|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	6	conj	_	SpaceAfter=No
+18	siliniverir	sil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	6	conj	_	SpaceAfter=No
 19	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-4543
@@ -40902,7 +40902,7 @@
 8	öncü	öncü	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod	_	_
 9	bir	bir	NUM	ANum	NumType=Card	10	det	_	_
 10	rol	rol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	obj	_	_
-11	oynarken	oyna	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	19	punct	_	SpaceAfter=No
+11	oynarken	oyna	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	19	punct	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	11	conj	_	_
 13	bugün	bugün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	obl	_	_
 14	artçı	artçı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nmod	_	_
@@ -41245,7 +41245,7 @@
 # text = Çay yapıp içersin.
 1	Çay	çay	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	obj	_	_
 2	yapıp	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	0	root	_	_
-3	içersin	iç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	2	conj	_	SpaceAfter=No
+3	içersin	iç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	2	conj	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-4590
@@ -41270,7 +41270,7 @@
 2	yaşamdan	yaşam	NOUN	Noun	Case=Abl|Number=Sing|Person=3	5	obl	_	_
 3	duygularımızla	duygu	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=1	5	obl	_	_
 4	zevk	zevk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
-5	alırız	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+5	alırız	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4594
@@ -41419,12 +41419,12 @@
 16	olması	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	17	nmod:poss	_	_
 17	ilkesini	ilke	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	obj	_	_
 18	beraberinde	beraber	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	amod	_	_
-19	getirir	getir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+19	getirir	getir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 20	.	.	PUNCT	Punc	_	19	punct	_	_
 
 # sent_id = mst-4615
 # text = Anlar gibiyim.
-1	Anlar	anla	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	4	obj	_	_
+1	Anlar	anla	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	obj	_	_
 2-3	gibiyim	_	_	_	_	_	_	_	SpaceAfter=No
 2	gibi	gibi	ADP	PCNom	_	0	root	_	_
 3	yim	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Tense=Pres	2	cop	_	_
@@ -41618,7 +41618,7 @@
 
 # sent_id = mst-4645
 # text = Dilerim, dedi.
-1	Dilerim	dile	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	3	obj	_	SpaceAfter=No
+1	Dilerim	dile	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	3	obj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	1	punct	_	_
 3	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -41770,7 +41770,7 @@
 
 # sent_id = mst-4664
 # text = Sanırım dinsel anlatımlara benzemiyor.
-1	Sanırım	san	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Sanırım	san	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 2	dinsel	dinsel	ADJ	Adj	_	3	amod	_	_
 3	anlatımlara	anlatım	NOUN	Noun	Case=Dat|Number=Plur|Person=3	4	obl	_	_
 4	benzemiyor	benze	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
@@ -41868,7 +41868,7 @@
 2	Evet	evet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	5	punct	_	_
 4	meslektaş	meslektaş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
-5	sayılırız	say	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor|Voice=Pass	1	conj	_	SpaceAfter=No
+5	sayılırız	say	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres|Voice=Pass	1	conj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4675
@@ -41881,7 +41881,7 @@
 6	kol	kol	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obj	_	_
 7	ve	ve	CCONJ	Conj	_	8	cc	_	_
 8	yaprak	yaprak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	conj	_	_
-9	verirler	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+9	verirler	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-4677
@@ -41938,13 +41938,13 @@
 # text = Potaya girerken arkadan gelen bir diğeri onları vurabilir.
 # Fixed 2.2/dev: original sentence ID: 001422111080/2
 1	Potaya	pota	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
-2	girerken	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	8	advcl	_	_
+2	girerken	gir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	8	advcl	_	_
 3	arkadan	arkadan	ADV	Adverb	_	4	advmod	_	_
 4	gelen	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	acl	_	_
 5	bir	bir	NUM	ANum	NumType=Card	6	det	_	_
 6	diğeri	diğer	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nsubj	_	_
 7	onları	o	PRON	Demons	Case=Acc|Number=Plur|Person=3|PronType=Dem	8	obj	_	_
-8	vurabilir	vur	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+8	vurabilir	vur	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-4683
@@ -41988,7 +41988,7 @@
 3	bu	bu	DET	Det	_	5	det	_	_
 4	kadar	kadar	ADP	PCNom	_	3	case	_	_
 5	Milano	Milano	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
-6	yeter	yet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+6	yeter	yet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-4689
@@ -42072,7 +42072,7 @@
 8	,	,	PUNCT	Punc	_	6	punct	_	_
 9	kentin	kent	NOUN	Noun	Case=Gen|Number=Sing|Person=3	10	nmod:poss	_	_
 10	merkezine	merkez	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obl	_	_
-11	ineriz	in	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	2	conj	_	SpaceAfter=No
+11	ineriz	in	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	2	conj	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-4699
@@ -42197,7 +42197,7 @@
 5	tamirat	tamirat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
 6	sa	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	5	cop	_	_
 7	Celal	Celal	PROPN	Prop	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
-8	yapıverir	yap	VERB	Verb	Aspect=Rapid|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	10	obj	_	SpaceAfter=No
+8	yapıverir	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	10	obj	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
@@ -42206,12 +42206,12 @@
 # text = Sen diye başlarlar, Atila diye devam ederler.
 1	Sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	3	obl	_	_
 2	diye	diye	ADP	PCNom	_	1	case	_	_
-3	başlarlar	başla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	başlarlar	başla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	8	punct	_	_
 5	Atila	Atila	PROPN	Prop	Case=Nom|Number=Sing|Person=3	8	obl	_	_
 6	diye	diye	ADP	PCNom	_	5	case	_	_
 7	devam	devam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8	ederler	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+8	ederler	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-4718
@@ -42369,7 +42369,7 @@
 7	ona	o	PRON	Demons	Case=Dat|Number=Sing|Person=3|PronType=Dem	10	obl	_	_
 8	herkesten	herkes	NOUN	Noun	Case=Abl|Number=Sing|Person=3	9	nmod	_	_
 9	iyi	iyi	ADJ	Adj	_	10	amod	_	_
-10	bakar	bak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+10	bakar	bak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-4738
@@ -42392,10 +42392,10 @@
 8	çıkarak	çık	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	compound	_	_
 9	bir	bir	NUM	ANum	NumType=Card	10	det	_	_
 10	teoremi	teorem	NOUN	Noun	Case=Acc|Number=Sing|Person=3	11	obj	_	_
-11	kanıtlarsınız	kanıtla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	_
+11	kanıtlarsınız	kanıtla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	_
 12	ve	ve	CCONJ	Conj	_	11	cc	_	_
 13	dosya	dosya	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	obj	_	_
-14	kapanır	kapa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	11	conj	_	SpaceAfter=No
+14	kapanır	kapa	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	11	conj	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-4741
@@ -42443,7 +42443,7 @@
 7	mantıkla	mantık	NOUN	Noun	Case=Ins|Number=Sing|Person=3	8	obl	_	_
 8	donanmış	donan	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	10	acl	_	_
 9	olarak	olarak	ADP	PCNom	_	8	case	_	_
-10	doğmazlar	doğ	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+10	doğmazlar	doğ	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-4748
@@ -42527,7 +42527,7 @@
 # sent_id = mst-4761
 # text = Belli olmaz.
 1	Belli	belli	ADJ	Adj	_	2	obj	_	_
-2	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+2	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-4763
@@ -42551,7 +42551,7 @@
 # sent_id = mst-4765
 # text = Ne kaybedersiniz?
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	2	obj	_	_
-2	kaybedersiniz	kaybet	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	kaybedersiniz	kaybet	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	?	?	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-4766
@@ -42589,7 +42589,7 @@
 19	olgunluğa	olgunluk	NOUN	Noun	Case=Dat|Number=Sing|Person=3	20	obl	_	_
 20	ulaşmış	ulaş	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	21	obj	_	_
 21	olmasını	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	22	obj	_	_
-22	gerektirir	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	1	conj	_	SpaceAfter=No
+22	gerektirir	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Cau	1	conj	_	SpaceAfter=No
 23	.	.	PUNCT	Punc	_	22	punct	_	_
 
 # sent_id = mst-4770
@@ -42682,7 +42682,7 @@
 2	kışkırtmasıyla	kışkırtma	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 3	iç	iç	ADJ	Adj	_	4	amod	_	_
 4	karışıklık	karışıklık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
-5	çıkabilir	çık	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	çıkabilir	çık	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-4782
@@ -42767,7 +42767,7 @@
 3	kağıt	kağıt	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	1	flat	_	_
 4	lık	lik	ADP	Ness	Case=Nom|Number=Sing|Person=3	1	case	_	_
 5	sigaradan	sigara	NOUN	Noun	Case=Abl|Number=Sing|Person=3	6	obl	_	_
-6	içmem	iç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	8	obj	_	SpaceAfter=No
+6	içmem	iç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	8	obj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
 8	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
@@ -42810,7 +42810,7 @@
 11	kadar	kadar	ADP	PCDat	_	10	case	_	_
 12	bir	bir	NUM	ANum	NumType=Card	13	det	_	_
 13	kondu	kon	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	14	obj	_	_
-14	alabilir	al	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+14	alabilir	al	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 15	miyiz	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Tense=Pres	14	aux:q	_	SpaceAfter=No
 16	?	?	PUNCT	Punc	_	14	punct	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	14	punct	_	_
@@ -42887,7 +42887,7 @@
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	kuramın	kuram	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
 3-4	yanlışlanabilirliği	_	_	_	_	_	_	_	_
-3	yanlışlanabilir	yanlışla	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	11	nsubj	_	_
+3	yanlışlanabilir	yanlışla	VERB	Verb	Aspect=Hab|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=Pass	11	nsubj	_	_
 4	liği	lik	ADP	Ness	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	case	_	_
 5	o	o	DET	Det	_	6	det	_	_
 6	kuramın	kuram	NOUN	Noun	Case=Gen|Number=Sing|Person=3	15	nmod:poss	_	_
@@ -42903,7 +42903,7 @@
 16	,	,	PUNCT	Punc	_	17	punct	_	_
 17	doğurganlığına	doğurganlık	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	conj	_	_
 18	işaret	işaret	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	conj	_	_
-19	eder	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	18	compound:lvc	_	SpaceAfter=No
+19	eder	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	18	compound:lvc	_	SpaceAfter=No
 20	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-4803
@@ -42922,7 +42922,7 @@
 12	uzun	uzun	ADJ	Adj	_	13	amod	_	_
 13	hedeflerinde	hedef	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	15	obl	_	_
 14	mantıklarını	mantık	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	15	obj	_	_
-15	kullanırlar	kullan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+15	kullanırlar	kullan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-4805
@@ -43055,7 +43055,7 @@
 7	insanların	insan	NOUN	Noun	Case=Gen|Number=Plur|Person=3	16	nmod:poss	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	18	punct	_	_
 9	başkalarına	başka	ADJ	NAdj	Case=Dat|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	15	amod	_	_
-10	inanılmaz	inan	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor|Voice=Pass	12	nmod	_	SpaceAfter=No
+10	inanılmaz	inan	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres|Voice=Pass	12	nmod	_	SpaceAfter=No
 11	,	,	PUNCT	Punc	_	10	punct	_	_
 12	tuhaf	tuhaf	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	obl	_	_
 13	ve	ve	CCONJ	Conj	_	12	cc	_	_
@@ -43070,7 +43070,7 @@
 
 # sent_id = mst-4819
 # text = Anlatırım tabii Ayhan.
-1	Anlatırım	anlat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Anlatırım	anlat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 2	tabii	tabii	ADJ	Adj	_	1	conj	_	_
 3	Ayhan	Ayhan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	conj	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -43082,7 +43082,7 @@
 3	uçak	uçak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
 4	piste	pist	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
 5	doğru	doğru	ADP	PCDat	_	4	case	_	_
-6	gelirken	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	15	nmod	_	_
+6	gelirken	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	15	nmod	_	_
 7	pilota	pilot	NOUN	Noun	Case=Dat|Number=Sing|Person=3	15	obl	_	_
 8	"	"	PUNCT	Punc	_	12	punct	_	_
 9	Yaklaşma	yaklaş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	10	nmod:poss	_	_
@@ -43196,7 +43196,7 @@
 17	bir	bir	NUM	ANum	NumType=Card	18	det	_	_
 18	deney	deney	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	obl	_	_
 19	olarak	olarak	ADP	PCNom	_	18	case	_	_
-20	sunabilirler	sun	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+20	sunabilirler	sun	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 21	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	20	aux:q	_	SpaceAfter=No
 22	?	?	PUNCT	Punc	_	20	punct	_	_
 23	(	(	PUNCT	Punc	_	24	punct	_	SpaceAfter=No
@@ -43451,7 +43451,7 @@
 11	geri	geri	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	12	amod	_	_
 12	plana	plan	NOUN	Noun	Case=Dat|Number=Sing|Person=3	13	obl	_	_
 13	itildiğini	it	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	14	obj	_	_
-14	gözlemleyebiliriz	gözlemle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+14	gözlemleyebiliriz	gözlemle	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-4852
@@ -43645,7 +43645,7 @@
 6	da	da	CCONJ	Conj	_	4	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	9	punct	_	_
 8	Recep	Recep	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
-9	kahrolur	kahrol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+9	kahrolur	kahrol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	19	punct	_	_
 11	darbukasına	darbuka	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	obl	_	_
 12	hırsla	hırs	NOUN	Noun	Case=Ins|Number=Sing|Person=3	13	obl	_	_
@@ -43685,7 +43685,7 @@
 # text = Öyle kolay gelmez ki o.
 1	Öyle	öyle	ADV	Adverb	_	2	advmod	_	_
 2	kolay	kolay	ADJ	Adj	_	3	amod	_	_
-3	gelmez	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	_
+3	gelmez	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
 4	ki	ki	CCONJ	Conj	_	3	advmod:emph	_	_
 5	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -43702,7 +43702,7 @@
 
 # sent_id = mst-4880
 # text = Çalışamaz olmuş.
-1	Çalışamaz	çalış	VERB	Verb	Aspect=Imp|Mood=Pot|Polarity=Neg|Tense=Aor|VerbForm=Part	2	obj	_	_
+1	Çalışamaz	çalış	VERB	Verb	Aspect=Hab|Mood=Pot|Polarity=Neg|Tense=Pres|VerbForm=Part	2	obj	_	_
 2	olmuş	ol	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -43729,7 +43729,7 @@
 5	kalmış	kal	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	4	compound	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	10	punct	_	_
 7	uyuşturucu	uyuşturucu	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8	alırken	al	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	10	nmod	_	_
+8	alırken	al	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	10	nmod	_	_
 9	duygularını	duygu	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	10	obj	_	_
 10	öldürmüş	öl	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Cau	4	conj	_	_
 11	yetişkin	yetişkin	ADJ	Adj	_	12	amod	_	_
@@ -43776,7 +43776,7 @@
 1	Beyazına	beyaz	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	amod	_	_
 2	sakız	sakız	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 3	da	da	CCONJ	Conj	_	2	advmod:emph	_	_
-4	denir	de	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+4	denir	de	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4890
@@ -43836,7 +43836,7 @@
 4	sizin	siz	PRON	Pers	Case=Gen|Number=Plur|Person=2|PronType=Prs	7	obl	_	_
 5	için	için	ADP	PCNom	_	4	case	_	_
 6	problem	problem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
-7	yaratır	yarat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+7	yaratır	yarat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 8	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	7	aux:q	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	7	punct	_	_
 
@@ -43881,7 +43881,7 @@
 # sent_id = mst-4902
 # text = Çevreyi araştırırlar.
 1	Çevreyi	çevre	NOUN	Noun	Case=Acc|Number=Sing|Person=3	2	obj	_	_
-2	araştırırlar	araştır	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	araştırırlar	araştır	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-4903
@@ -43963,7 +43963,7 @@
 11	müfettişleri	müfettiş	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=3	12	nmod:poss	_	_
 12	üzerinde	üzer	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	nmod	_	_
 13	baskı	baskı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nmod:poss	_	_
-14	yaratır	yarat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	13	compound	_	_
+14	yaratır	yarat	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	13	compound	_	_
 15	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	13	aux:q	_	SpaceAfter=No
 16	?	?	PUNCT	Punc	_	23	punct	_	_
 17	"	"	PUNCT	Punc	_	13	punct	_	_
@@ -44087,11 +44087,11 @@
 
 # sent_id = mst-4925
 # text = Gidersiniz, sonra geri gidersiniz Erkekler Parkı'na.
-1	Gidersiniz	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+1	Gidersiniz	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	5	punct	_	_
 3	sonra	sonra	ADV	Adverb	_	5	advmod	_	_
 4	geri	geri	ADV	Adverb	_	5	advmod	_	_
-5	gidersiniz	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	1	conj	_	_
+5	gidersiniz	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	1	conj	_	_
 6	Erkekler	erkek	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	5	amod	_	_
 7	Parkı'na	park	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	flat	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	5	punct	_	_
@@ -44168,9 +44168,9 @@
 8	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	SpaceAfter=No
 9	;	;	PUNCT	Punc	_	11	punct	_	_
 10	eroine	eroin	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	conj	_	_
-11	alışır	alış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	13	nmod	_	_
+11	alışır	alış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	13	nmod	_	_
 12	gibi	gibi	ADP	PCNom	_	11	case	_	_
-13	alışır	alış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+13	alışır	alış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 14	insan	insan	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	nsubj	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	13	punct	_	_
 
@@ -44215,7 +44215,7 @@
 12	dile	dile	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	16	punct	_	_
 14	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	15	obl	_	_
-15	dilersen	dile	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	16	nmod	_	_
+15	dilersen	dile	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	16	nmod	_	_
 16	dile	dile	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	1	conj	_	_
 17	it	it	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	nmod	_	_
 18	herif	herif	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nsubj	_	SpaceAfter=No
@@ -44232,14 +44232,14 @@
 2	alışmıştım	alış	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pqp	0	root	_	_
 3	Kahve'ye	Kahve	PROPN	Prop	Case=Dat|Number=Sing|Person=3	2	obl	_	_
 4	belki	belki	ADV	Adverb	_	5	advmod	_	_
-5	vazgeçersin	vazgeç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	13	obj	_	_
+5	vazgeçersin	vazgeç	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	13	obj	_	_
 6	almaktan	al	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
 8	annem	anne	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	10	nsubj	_	_
 9	de	de	CCONJ	Conj	_	8	advmod:emph	_	_
 10	alıştığı	alış	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	12	acl	_	_
 11	için	için	ADP	PCNom	_	10	case	_	_
-12	kalır	kal	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	5	conj	_	_
+12	kalır	kal	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	5	conj	_	_
 13	diyordum	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Past	2	conj	_	_
 14	kendi	kendi	PRON	Reflex	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	13	obl	_	_
 15	kendime	kendi	PRON	Reflex	Case=Dat|Number=Sing|Number[psor]=Sing|Person=1|Person[psor]=1|Reflex=Yes	14	compound:redup	_	SpaceAfter=No
@@ -44290,7 +44290,7 @@
 
 # sent_id = mst-4947
 # text = Görürüz bakalım, yarın o arabayı kim silecek, diye tehditler savurarak uzaklaştı diğer siliciler.
-1	Görürüz	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	11	nmod	_	_
+1	Görürüz	gör	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	11	nmod	_	_
 2	bakalım	bak	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	8	punct	_	_
 4	yarın	yarın	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
@@ -44400,7 +44400,7 @@
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	heyecana	heyecan	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
 3	nasıl	nasıl	ADV	Adverb	_	4	advmod	_	_
-4	dayanabilirim	dayan	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	7	nmod	_	SpaceAfter=No
+4	dayanabilirim	dayan	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	7	nmod	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 6	diye	diye	ADP	PCNom	_	4	case	_	_
 7	mırıldandı	mırıldan	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
@@ -44470,7 +44470,7 @@
 4	ile	ile	CCONJ	Conj	_	3	cc	_	_
 5	de	de	CCONJ	Conj	_	3	advmod:emph	_	_
 6	boşluklar	boşluk	NOUN	Noun	Case=Nom|Number=Plur|Person=3	7	obj	_	_
-7	mekanlaşabilir	mekanlaş	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+7	mekanlaşabilir	mekanlaş	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-4969
@@ -44480,7 +44480,7 @@
 3	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	6	obj	_	_
 4	daha	daha	ADV	Adverb	_	5	advmod	_	_
 5	mutlu	mutlu	ADJ	Adj	_	6	amod	_	_
-6	eder	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	8	obj	_	SpaceAfter=No
+6	eder	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	obj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
 8	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
@@ -44512,7 +44512,7 @@
 2	hiç	hiç	ADV	Adverb	_	3	advmod	_	_
 3	anlamıyorlarmış	anla	VERB	Verb	Aspect=Prog|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Polite=Infm|Tense=Past	5	nmod	_	_
 4	gibi	gibi	ADP	PCNom	_	3	case	_	_
-5	gelirken	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	16	nmod	_	_
+5	gelirken	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	16	nmod	_	_
 6	birden	birden	ADV	Adverb	_	16	advmod	_	_
 7	en	en	ADV	Adverb	_	9	advmod	_	_
 8	can	can	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	obl	_	_
@@ -44523,7 +44523,7 @@
 13	olup	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	16	nmod	_	_
 14	da	da	CCONJ	Conj	_	13	advmod:emph	_	_
 15	bulup	bul	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	13	conj	_	_
-16	sorabilirler	sor	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+16	sorabilirler	sor	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-4974
@@ -44684,7 +44684,7 @@
 # text = Soru da sormazlar.
 1	Soru	soru	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 2	da	da	CCONJ	Conj	_	1	advmod:emph	_	_
-3	sormazlar	sor	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+3	sormazlar	sor	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-4993
@@ -45021,7 +45021,7 @@
 11	Erbakan	Erbakan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	14	nsubj	_	_
 12	'	'	PUNCT	Punc	_	11	punct	_	_
 13	şeyler	şey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	14	obj	_	_
-14	söyler	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+14	söyler	söyle	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 15	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-5030
@@ -45063,7 +45063,7 @@
 13	veya	veya	CCONJ	Conj	_	14	cc	_	_
 14	benzeşiyor	benzeş	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	12	conj	_	_
 15	olması	ol	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	conj	_	_
-16	gerekmez	gerek	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+16	gerekmez	gerek	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-5035
@@ -45138,7 +45138,7 @@
 17	umutsuzluğunu	umutsuzluk	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	obj	_	SpaceAfter=No
 18	,	,	PUNCT	Punc	_	19	punct	_	_
 19	çaresizliğini	çaresizlik	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	conj	_	_
-20	düşünürsünüz	düşün	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+20	düşünürsünüz	düşün	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 21	.	.	PUNCT	Punc	_	20	punct	_	_
 
 # sent_id = mst-5043
@@ -45297,7 +45297,7 @@
 # sent_id = mst-5065
 # text = Kabul eder.
 1	Kabul	kabul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	eder	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	compound:lvc	_	SpaceAfter=No
+2	eder	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	compound:lvc	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-5066
@@ -45339,7 +45339,7 @@
 # text = Üstüne karabiber koyarlar.
 1	Üstüne	üst	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	amod	_	_
 2	karabiber	karabiber	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
-3	koyarlar	koy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	koyarlar	koy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-5071
@@ -45426,7 +45426,7 @@
 9	yükselen	yüksel	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	acl	_	_
 10	yeni	yeni	ADJ	Adj	_	11	amod	_	_
 11	kuramlara	kuram	NOUN	Noun	Case=Dat|Number=Plur|Person=3	4	conj	_	_
-12	götürür	götür	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+12	götürür	götür	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
 
 # sent_id = mst-5083
@@ -45526,10 +45526,10 @@
 # text = Sezer veto edebilir, referanduma getirebilir.
 1	Sezer	Sezer	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
 2	veto	veto	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-3	edebilir	et	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	compound:lvc	_	SpaceAfter=No
+3	edebilir	et	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	compound:lvc	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	6	punct	_	_
 5	referanduma	referandum	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
-6	getirebilir	getir	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	2	conj	_	SpaceAfter=No
+6	getirebilir	getir	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	2	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-5098
@@ -45626,14 +45626,14 @@
 # sent_id = mst-5108
 # text = Onlara uyarsan, büyük amcan gibi sokaklarda geberip gidersin.
 1	Onlara	o	PRON	Pers	Case=Dat|Number=Plur|Person=3|PronType=Prs	2	obl	_	_
-2	uyarsan	uy	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	9	nmod	_	SpaceAfter=No
+2	uyarsan	uy	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	9	nmod	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	2	punct	_	_
 4	büyük	büyük	ADJ	Adj	_	5	amod	_	_
 5	amcan	amca	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	8	obl	_	_
 6	gibi	gibi	ADP	PCNom	_	5	case	_	_
 7	sokaklarda	sokak	NOUN	Noun	Case=Loc|Number=Plur|Person=3	8	obl	_	_
 8	geberip	geber	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	9	nmod	_	_
-9	gidersin	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+9	gidersin	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-5109
@@ -45715,7 +45715,7 @@
 24	önem	önem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	26	nmod	_	_
 25	li	li	ADP	With	_	24	case	_	_
 26	rica	rica	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-27	ederim	et	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	26	conj	_	SpaceAfter=No
+27	ederim	et	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	26	conj	_	SpaceAfter=No
 28	.	.	PUNCT	Punc	_	26	punct	_	_
 
 # sent_id = mst-5120
@@ -45765,7 +45765,7 @@
 # text = Merdiveni geri çıkarken başımı Hülya'nın sırtına yasladım.
 1	Merdiveni	merdiven	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	obj	_	_
 2	geri	geri	ADV	Adverb	_	3	advmod	_	_
-3	çıkarken	çık	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	7	nmod	_	_
+3	çıkarken	çık	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	_
 4	başımı	baş	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	7	obj	_	_
 5	Hülya'nın	Hülya	PROPN	Prop	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
 6	sırtına	sırt	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obl	_	_
@@ -45918,7 +45918,7 @@
 5	kafayla	kafa	NOUN	Noun	Case=Ins|Number=Sing|Person=3	8	obl	_	_
 6	bekar	bekar	ADJ	Adj	_	7	amod	_	_
 7	evine	ev	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	obl	_	_
-8	göndermem	gönder	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+8	göndermem	gönder	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-5147
@@ -46048,7 +46048,7 @@
 10	borsada	borsa	NOUN	Noun	Case=Loc|Number=Sing|Person=3	13	obl	_	_
 11	bir	bir	NUM	ANum	NumType=Card	12	det	_	_
 12	hareketlilik	hareketlilik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obj	_	_
-13	beklenebilir	bekle	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	SpaceAfter=No
+13	beklenebilir	bekle	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-5167
@@ -46057,7 +46057,7 @@
 2	başı	baş	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	obl	_	_
 3	önünde	ön	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	amod	_	_
 4	yerine	yer	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
-5	yürürken	yürü	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	9	nmod	_	_
+5	yürürken	yürü	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	9	nmod	_	_
 6	Ramiz'e	Ramiz	PROPN	Prop	Case=Dat|Number=Sing|Person=3	9	nmod	_	_
 7	kaçamak	kaçamak	ADJ	Adj	_	9	amod	_	_
 8	bir	bir	NUM	ANum	NumType=Card	9	det	_	_
@@ -46156,9 +46156,9 @@
 # sent_id = mst-5182
 # text = Ceviz koyarlar ismi değişir.
 1	Ceviz	ceviz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	obj	_	_
-2	koyarlar	koy	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	4	nmod	_	_
+2	koyarlar	koy	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	4	nmod	_	_
 3	ismi	isim	NOUN	Noun	Case=Acc|Number=Sing|Person=3	4	nsubj	_	_
-4	değişir	değiş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	değişir	değiş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-5184
@@ -46205,11 +46205,11 @@
 2	kızdığım	kız	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	3	acl	_	_
 3	insanla	insan	NOUN	Noun	Case=Ins|Number=Sing|Person=3	4	obl	_	_
 4-5	halleşmezsem	_	_	_	_	_	_	_	_
-4	halleşmez	hâlleş	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	8	ccomp	_	_
+4	halleşmez	hâlleş	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	8	ccomp	_	_
 5	sem	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=1|Tense=Pres	4	cop	_	_
 6	imkanı	imkan	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obj	_	_
 7	yok	yok	ADV	Adverb	_	8	advmod	_	_
-8	rahatlamam	rahatla	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+8	rahatlamam	rahatla	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-5190
@@ -46450,7 +46450,7 @@
 3	beri	beri	ADV	Adverb	_	7	advmod	_	_
 4	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	6	obl	_	_
 5	seyrek	seyrek	ADV	Adverb	_	6	advmod	_	_
-6	gelir	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	nmod	_	_
+6	gelir	gel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	nmod	_	_
 7	oldun	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
@@ -46664,7 +46664,7 @@
 8	hız	hız	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nmod:poss	_	_
 9	kazanması	kazan	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	compound	_	_
 10	durumunda	durum	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	obl	_	_
-11	sarkabilir	sark	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+11	sarkabilir	sark	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 12	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-5251
@@ -46676,7 +46676,7 @@
 5	değişik	değişik	ADJ	Adj	_	7	amod	_	_
 6	bir	bir	NUM	ANum	NumType=Card	7	det	_	_
 7	peynir	peynir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8	yiyebilirsin	ye	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+8	yiyebilirsin	ye	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-5253
@@ -46696,7 +46696,7 @@
 2	her	her	DET	Det	_	5	det	_	_
 3	zaman	zaman	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound	_	_
 4	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	5	obj	_	_
-5	düşünür	düşün	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+5	düşünür	düşün	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-5257
@@ -46705,13 +46705,13 @@
 2	sorun	sorun	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 3	çözme	çöz	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	nmod	_	_
 4	diye	diye	ADP	PCNom	_	3	case	_	_
-5	bakamazsınız	bak	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+5	bakamazsınız	bak	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=2|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-5258
 # text = Birbirimize bakarız.
 1	Birbirimize	birbiri	PRON	Quant	Case=Dat|Number=Plur|Number[psor]=Plur|Person=1|Person[psor]=1|PronType=Ind	2	obl	_	_
-2	bakarız	bak	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	bakarız	bak	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-5259
@@ -46733,7 +46733,7 @@
 1	Tanışmadınız	tanış	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Polarity=Neg|Tense=Past	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	4	punct	_	_
 3	görsen	gör	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	4	nmod	_	_
-4	şaşarsın	şaş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	1	conj	_	SpaceAfter=No
+4	şaşarsın	şaş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	1	conj	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	7	punct	_	_
 6	çok	çok	ADV	Adverb	_	7	advmod	_	_
 7	zeki	zeki	ADJ	Adj	_	1	conj	_	SpaceAfter=No
@@ -46796,7 +46796,7 @@
 1	Pilaki	pilaki	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 2	ile	ile	CCONJ	Conj	_	3	cc	_	_
 3	Piyaz	piyaz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	conj	_	_
-4	yarışırlar	yarış	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+4	yarışırlar	yarış	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-5269
@@ -46843,7 +46843,7 @@
 1	Hayat	hayat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 2	hiç	hiç	ADV	Adverb	_	4	advmod	_	_
 3	belli	belli	ADJ	Adj	_	4	amod	_	_
-4	olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+4	olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-5274
@@ -46941,7 +46941,7 @@
 
 # sent_id = mst-5288
 # text = Yapamam.
-1	Yapamam	yap	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
+1	Yapamam	yap	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-5289
@@ -47146,13 +47146,13 @@
 3	a	a	INTJ	Interj	_	6	discourse	_	_
 4	noktasından	nokta	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	_
 5	noktasına	nokta	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	_
-6	gidebilirler	git	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	gidebilirler	git	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-5314
 # text = Fırında pişer.
 1	Fırında	fırın	NOUN	Noun	Case=Loc|Number=Sing|Person=3	2	obl	_	_
-2	pişer	piş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+2	pişer	piş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-5315
@@ -47262,7 +47262,7 @@
 12	,	,	PUNCT	Punc	_	13	punct	_	_
 13	Magazine	magazin	NOUN	Noun	Case=Dat|Number=Sing|Person=3	10	conj	_	_
 14	Montenapoleone'de	Montenapoleone	PROPN	Prop	Case=Loc|Number=Sing|Person=3	13	flat	_	_
-15	bulabilirsiniz	bul	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+15	bulabilirsiniz	bul	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	15	punct	_	_
 
 # sent_id = mst-5327
@@ -47409,7 +47409,7 @@
 3	yaşından	yaş	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	amod	_	_
 4	itibaren	itibaren	ADP	PCAbl	_	3	case	_	_
 5	devreye	devre	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
-6	girer	gir	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+6	girer	gir	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-5348
@@ -47474,11 +47474,11 @@
 # text = Ya dayak yerseniz, ya karakola gidersiniz.
 1	Ya	ya	CCONJ	Conj	_	3	nmod	_	_
 2	dayak	dayak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
-3	yerseniz	ye	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	yerseniz	ye	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	7	punct	_	_
 5	ya	ya	CCONJ	Conj	_	1	conj	_	_
 6	karakola	karakol	NOUN	Noun	Case=Dat|Number=Sing|Person=3	7	obl	_	_
-7	gidersiniz	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	3	conj	_	SpaceAfter=No
+7	gidersiniz	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-5356
@@ -47497,7 +47497,7 @@
 # text = , Bonham'a gidemem, Hülya'nın yanında kalmalıyım; ya da arkasında, cephe gerisinde...
 1	,	,	PUNCT	Punc	_	0	root	_	_
 2	Bonham'a	Bonham	PROPN	Prop	Case=Dat|Number=Sing|Person=3	3	obl	_	_
-3	gidemem	git	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	1	conj	_	SpaceAfter=No
+3	gidemem	git	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	1	conj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	7	punct	_	_
 5	Hülya'nın	Hülya	PROPN	Prop	Case=Gen|Number=Sing|Person=3	6	nmod:poss	_	_
 6	yanında	yan	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	amod	_	_
@@ -47540,7 +47540,7 @@
 6	Sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	9	nsubj	_	_
 7	kömür	kömür	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	9	obj	_	_
 8	sobasını	soba	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	compound	_	_
-9	beceremezsin	becer	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Tense=Aor	4	conj	_	SpaceAfter=No
+9	beceremezsin	becer	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=2|Polarity=Neg|Tense=Pres	4	conj	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	16	punct	_	_
 11	yan	yan	ADJ	Adj	_	12	amod	_	_
 12	odadan	oda	NOUN	Noun	Case=Abl|Number=Sing|Person=3	16	obl	_	_
@@ -47579,7 +47579,7 @@
 # text = Ne rengi benzer, ne biçimi.
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	5	cc	_	_
 2	rengi	renk	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	obj	_	_
-3	benzer	benze	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
+3	benzer	benze	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	6	punct	_	_
 5	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	6	obj	_	_
 6	biçimi	biçim	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	conj	_	SpaceAfter=No
@@ -47625,7 +47625,7 @@
 7	aralığı	aralık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nmod:poss	_	_
 8	bandında	bant	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	nmod	_	_
 9	hareket	hareket	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-10	edebilir	et	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	9	compound:lvc	_	SpaceAfter=No
+10	edebilir	et	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	compound:lvc	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-5367
@@ -47824,7 +47824,7 @@
 15	ve	ve	CCONJ	Conj	_	16	cc	_	_
 16	komisyon	komisyon	NOUN	Noun	Case=Nom|Number=Sing|Person=3	14	conj	_	_
 17	almak	al	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	18	obj	_	_
-18	ister	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	0	root	_	SpaceAfter=No
+18	ister	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	0	root	_	SpaceAfter=No
 19	.	.	PUNCT	Punc	_	1	conj	_	_
 
 # sent_id = mst-5380
@@ -47912,10 +47912,10 @@
 3	sırada	sıra	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
 4	Hülya	Hülya	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
 5	birisiyle	biri	PRON	Quant	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	6	obl	_	_
-6	gelebilir	gel	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+6	gelebilir	gel	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 7	ve	ve	CCONJ	Conj	_	9	cc	_	_
 8	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	9	obj	_	_
-9	görebilir	gör	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	6	conj	_	_
+9	görebilir	gör	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	6	conj	_	_
 10	diye	diye	ADP	PCNom	_	6	case	_	SpaceAfter=No
 11	...	...	PUNCT	Punc	_	6	punct	_	_
 
@@ -48058,7 +48058,7 @@
 29	bölümünü	bölüm	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	30	obj	_	_
 30	okumalarını	oku	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	31	obj	_	_
 31	salık	salık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	9	conj	_	_
-32	veririm	ver	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	31	compound	_	SpaceAfter=No
+32	veririm	ver	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	31	compound	_	SpaceAfter=No
 33	.	.	PUNCT	Punc	_	31	punct	_	_
 
 # sent_id = mst-5397
@@ -48202,11 +48202,11 @@
 1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 2	yavrumdan	yavru	ADJ	NAdj	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	4	amod	_	_
 3	nasıl	nasıl	ADV	Adverb	_	4	advmod	_	_
-4	ayrılırım	ayrıl	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	12	nmod	_	SpaceAfter=No
+4	ayrılırım	ayrıl	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	12	nmod	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	8	punct	_	_
 6	Onu	o	PRON	Pers	Case=Acc|Number=Sing|Person=3|PronType=Prs	8	obj	_	_
 7	nerelere	nere	PRON	Ques	Case=Dat|Number=Plur|Person=3	8	obl	_	_
-8	gönderirim	gönder	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	4	conj	_	SpaceAfter=No
+8	gönderirim	gönder	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	4	conj	_	SpaceAfter=No
 9	?	?	PUNCT	Punc	_	8	punct	_	_
 10	diye	diye	ADP	PCNom	_	4	case	_	_
 11	adamın	adam	NOUN	Noun	Case=Gen|Number=Sing|Person=3	12	nmod:poss	_	_
@@ -48218,8 +48218,8 @@
 
 # sent_id = mst-5413
 # text = Olmaz olur mu? Âşıkları, hayranları...
-1	Olmaz	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	2	nmod	_	_
-2	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Olmaz	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	2	nmod	_	_
+2	olur	ol	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 3	mu	mu	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	2	aux:q	_	SpaceAfter=No
 4	?	?	PUNCT	Punc	_	2	punct	_	_
 5	Âşıkları	aşık	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	2	obj	_	SpaceAfter=No
@@ -48424,7 +48424,7 @@
 3	fırladı	fırla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	2	compound	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	8	punct	_	_
 5	telefona	telefon	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
-6	koşarken	koş	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	8	nmod	_	_
+6	koşarken	koş	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	8	nmod	_	_
 7	kapı	kapı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
 8	vuruldu	vurul	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	2	conj	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	8	punct	_	_
@@ -48596,7 +48596,7 @@
 2	arkasını	arka	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	obj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	1	punct	_	_
 4	burnunu	burun	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
-5	siler	sil	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	7	nmod	_	_
+5	siler	sil	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	7	nmod	_	_
 6	gibi	gibi	ADP	PCNom	_	5	case	_	_
 7	yapıyor	yap	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
@@ -48678,7 +48678,7 @@
 2	,	,	PUNCT	Punc	_	3	punct	_	_
 3	yok	yok	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	1	conj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	5	punct	_	_
-5	bilmez	bil	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part	1	conj	_	_
+5	bilmez	bil	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	1	conj	_	_
 6	değilim	değil	VERB	Neg	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	5	cop	_	SpaceAfter=No
 7	:	:	PUNCT	Punc	_	20	punct	_	_
 8	birçok	birçok	DET	Det	_	10	det	_	_
@@ -48693,7 +48693,7 @@
 17	öykücükler	öykücük	NOUN	Noun	Case=Nom|Number=Plur|Person=3	12	conj	_	_
 18	de	de	CCONJ	Conj	_	17	advmod:emph	_	_
 19	söylemek	söyle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	20	obj	_	_
-20	ister	iste	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	1	conj	_	_
+20	ister	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	1	conj	_	_
 21	bunu	bu	PRON	Demons	Case=Acc|Number=Sing|Person=3|PronType=Dem	19	obj	_	SpaceAfter=No
 22	;	;	PUNCT	Punc	_	19	punct	_	_
 23	ama	ama	CCONJ	Conj	_	21	cc	_	_
@@ -48807,7 +48807,7 @@
 
 # sent_id = mst-5479
 # text = Sürünür şimdi.
-1	Sürünür	sürün	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	_
+1	Sürünür	sürün	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 2	şimdi	şimdi	ADV	Adverb	_	1	advmod	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	1	punct	_	_
 
@@ -48842,7 +48842,7 @@
 
 # sent_id = mst-5481
 # text = Sevinmez mi?
-1	Sevinmez	sevin	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	0	root	_	_
+1	Sevinmez	sevin	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
 2	mi	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	1	aux:q	_	SpaceAfter=No
 3	?	?	PUNCT	Punc	_	1	punct	_	_
 
@@ -49046,7 +49046,7 @@
 6	izlenimlerimi	izlenim	NOUN	Noun	Case=Acc|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=1	7	obj	_	_
 7	yazacağım	yaz	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Fut	0	root	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	9	punct	_	_
-9	isterseniz	iste	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	7	conj	_	SpaceAfter=No
+9	isterseniz	iste	VERB	Verb	Aspect=Hab|Mood=Cnd|Number=Plur|Person=2|Polarity=Pos|Tense=Pres	7	conj	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	14	punct	_	_
 11	bu	bu	DET	Det	_	12	det	_	_
 12	söylediklerinizi	söyle	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=2|Polarity=Pos|Tense=Past|VerbForm=Part	14	obj	_	_
@@ -49198,7 +49198,7 @@
 3	,	,	PUNCT	Punc	_	6	punct	_	_
 4	şişko	şişko	ADJ	Adj	_	5	amod	_	_
 5	bile	bile	ADV	Adverb	_	6	advmod	_	_
-6	denebilir	de	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|Voice=Pass	0	root	_	_
+6	denebilir	de	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	0	root	_	_
 7	neredeyse	neredeyse	ADV	Adverb	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	6	punct	_	_
 
@@ -49212,7 +49212,7 @@
 6	biri	biri	PRON	Quant	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	9	nsubj	_	_
 7	büyük	büyük	ADJ	Adj	_	8	amod	_	_
 8	amcalarına	amca	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	9	obl	_	_
-9	benzer	benze	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	3	nmod	_	_
+9	benzer	benze	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	nmod	_	_
 10	diye	diye	ADP	PCNom	_	9	case	_	SpaceAfter=No
 11	;	;	PUNCT	Punc	_	9	punct	_	_
 12	ama	ama	CCONJ	Conj	_	9	cc	_	_
@@ -49358,7 +49358,7 @@
 # sent_id = mst-5544
 # text = Nasıl çıkabilirim oraya.
 1	Nasıl	nasıl	ADV	Adverb	_	2	advmod	_	_
-2	çıkabilirim	çık	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
+2	çıkabilirim	çık	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 3	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	2	compound	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -49495,7 +49495,7 @@
 12	bir	bir	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	14	nmod:poss	_	_
 13	ikisinin	iki	NUM	NNum	Case=Gen|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=3	12	compound	_	_
 14	gözleri	göz	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
-15	takılır	takıl	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	14	compound	_	_
+15	takılır	takıl	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	14	compound	_	_
 16-17	kenardakilere	_	_	_	_	_	_	_	SpaceAfter=No
 16	kenarda	kenar	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	14	amod	_	_
 17	kilere	ki	ADP	Rel	Case=Dat|Number=Plur|Person=3	16	case	_	_
@@ -49517,13 +49517,13 @@
 12	takım	takım	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	compound	_	_
 13	elbiseleri	elbise	NOUN	Noun	Case=Acc|Number=Plur|Person=3	21	obl	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	18	punct	_	_
-15	inanılmaz	inan	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Neg|Tense=Aor|VerbForm=Part|Voice=Pass	16	acl	_	_
+15	inanılmaz	inan	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part|Voice=Pass	16	acl	_	_
 16	derecede	derece	NOUN	Noun	Case=Loc|Number=Sing|Person=3	17	obl	_	_
 17	parlak	parlak	ADJ	Adj	_	18	amod	_	_
 18	kravatlarıyla	kravat	NOUN	Noun	Case=Ins|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	13	conj	_	_
 19	öğlen	öğlen	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nmod:poss	_	_
 20	yemeğine	yemek	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	21	obl	_	_
-21	giderken	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	24	nmod	_	_
+21	giderken	git	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	24	nmod	_	_
 22	kapıdan	kapı	NOUN	Noun	Case=Abl|Number=Sing|Person=3	24	obl	_	_
 23	kafasını	kafa	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	24	nmod	_	_
 24	uzatıp	uza	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	28	nmod	_	_
@@ -49581,7 +49581,7 @@
 33	aynı	aynı	ADJ	Adj	_	34	amod	_	_
 34	şarkının	şarkı	NOUN	Noun	Case=Gen|Number=Sing|Person=3	35	nmod:poss	_	_
 35	dinlenmesine	dinle	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	36	nmod	_	_
-36	benzer	benze	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	37	acl	_	_
+36	benzer	benze	VERB	Verb	Aspect=Hab|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	37	acl	_	_
 37	biçimde	biçim	NOUN	Noun	Case=Loc|Number=Sing|Person=3	42	obl	_	SpaceAfter=No
 38	,	,	PUNCT	Punc	_	42	punct	_	_
 39	Politzer	Politzer	PROPN	Prop	Case=Nom|Number=Sing|Person=3	42	nsubj	_	_
@@ -49594,7 +49594,7 @@
 # text = Bunlar olup biterken küçük sarışın çocuk, kucağında, bacaklarının arasına sıkıştırdığı darbukaya sol eliyle hiç ses çıkarmadan, okşarcasına vuruyor, sağ eliyle de tabağındakileri ağzına tıkıştırıyordu.
 1	Bunlar	bu	PRON	Demons	Case=Nom|Number=Plur|Person=3|PronType=Dem	2	nsubj	_	_
 2	olup	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	21	nmod	_	_
-3	biterken	bit	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	2	compound	_	_
+3	biterken	bit	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	2	compound	_	_
 4	küçük	küçük	ADJ	Adj	_	6	amod	_	_
 5	sarışın	sarışın	ADJ	Adj	_	6	amod	_	_
 6	çocuk	çocuk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	nsubj	_	SpaceAfter=No
@@ -49611,7 +49611,7 @@
 17	ses	ses	NOUN	Noun	Case=Nom|Number=Sing|Person=3	18	obj	_	_
 18	çıkarmadan	çıkar	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	21	nmod	_	SpaceAfter=No
 19	,	,	PUNCT	Punc	_	18	punct	_	_
-20	okşarcasına	okşa	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor|VerbForm=Conv	21	nmod	_	_
+20	okşarcasına	okşa	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Conv	21	nmod	_	_
 21	vuruyor	vur	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 22	,	,	PUNCT	Punc	_	29	punct	_	_
 23	sağ	sağ	ADJ	Adj	_	24	amod	_	_
@@ -49679,7 +49679,7 @@
 1	Bunları	bu	PRON	Demons	Case=Acc|Number=Plur|Person=3|PronType=Dem	2	obj	_	_
 2	yazan	yaz	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	nsubj	_	_
 3	Su	su	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obl	_	_
-4	olamaz	ol	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	6	nmod	_	_
+4	olamaz	ol	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	6	nmod	_	_
 5	diye	diye	ADP	PCNom	_	4	case	_	_
 6	geçirdim	geçir	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
 7	aklımdan	akıl	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	6	compound	_	SpaceAfter=No
@@ -49748,7 +49748,7 @@
 5	olsa	ol	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	8	nmod	_	_
 6	altın	altın	ADJ	Adj	_	7	amod	_	_
 7	bilezik	bilezik	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
-8	alabiliriz	al	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	10	obj	_	SpaceAfter=No
+8	alabiliriz	al	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	10	obj	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10	diyor	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
@@ -49794,7 +49794,7 @@
 4	defa	defa	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	compound	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	2	punct	_	_
 6	biraz	biraz	ADV	Adverb	_	7	advmod	_	_
-7	düzelir	düzel	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	9	nmod	_	_
+7	düzelir	düzel	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	9	nmod	_	_
 8	gibi	gibi	ADP	PCNom	_	7	case	_	_
 9	oluyor	ol	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	2	conj	_	SpaceAfter=No
 10	,	,	PUNCT	Punc	_	13	punct	_	_

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -1581,7 +1581,8 @@
 
 # sent_id = mst-0206
 # text = Kaç gündür bu böyle.
-1	Kaç	kaç	ADJ	Adj	_	2	amod	_	_
+# Change 2.2/dev: mark 'kaç' as NUM
+1	Kaç	kaç	NUM	Adj	NumType=Card	2	nummod	_	_
 2-3	gündür	_	_	_	_	_	_	_	_
 2	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 3	dür	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	2	cop	_	_
@@ -2742,7 +2743,7 @@
 3	da	da	CCONJ	Conj	_	1	advmod:emph	_	_
 4	Kahve'nin	Kahve	PROPN	Prop	Case=Gen|Number=Sing|Person=3	8	nmod	_	_
 5	günde	gün	NOUN	Noun	Case=Loc|Number=Sing|Person=3	7	nmod	_	_
-6	kaç	kaç	ADJ	Adj	_	7	det	_	_
+6	kaç	kaç	NUM	Adj	NumType=Card	7	nummod	_	_
 7	öğün	öğün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nmod	_	_
 8	yemek	yemek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	27	obj	_	_
 9	yiyeceğini	yiyecek	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	compound	_	SpaceAfter=No
@@ -3487,11 +3488,12 @@
 
 # sent_id = mst-0393
 # text = Ee kolay değil oğlum kaç aydır bakıyorlar alışır insan ne kadar olsa.
+# Change 2.2/dev: mark 'kaç' as NUM
 1	Ee	e	INTJ	Interj	_	2	discourse	_	_
 2	kolay	kolay	ADJ	Adj	_	0	root	_	_
 3	değil	değil	VERB	Neg	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	2	cop	_	_
 4	oğlum	oğul	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	2	nmod	_	_
-5	kaç	kaç	ADJ	Adj	_	6	det	_	_
+5	kaç	kaç	NUM	Adj	NumType=Card	6	nummod	_	_
 6-7	aydır	_	_	_	_	_	_	_	_
 6	ay	ay	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obl	_	_
 7	dır	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	6	cop	_	_
@@ -6403,9 +6405,10 @@
 
 # sent_id = mst-0732
 # text = Ezberlediği bir kaç cümleyi robot gibi tekrarlıyordu; Bayan lütfen bir flaster alın.
+# Change 2.2/dev: mark 'kaç' as NUM
 1	Ezberlediği	ezberle	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	4	acl	_	_
 2	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
-3	kaç	kaç	ADJ	Adj	_	2	compound	_	_
+3	kaç	kaç	NUM	Adj	NumType=Card	2	compound	_	_
 4	cümleyi	cümle	NOUN	Noun	Case=Acc|Number=Sing|Person=3	7	obj	_	_
 5	robot	robot	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obl	_	_
 6	gibi	gibi	ADP	PCNom	_	5	case	_	_
@@ -9142,7 +9145,8 @@
 
 # sent_id = mst-1019
 # text = Kaç kez denemişti; iki türküden sonra balıkçılar, utangaç hallerinden sıyrılıp, tarihin değil, doğanın kendilerine verdiği niteliği yeğleyerek, masalarda oturan yabancı kadınlara göz süzmeye başlıyorlardı.
-1	Kaç	kaç	ADJ	Adj	_	2	det	_	_
+# Change 2.2/dev: mark 'kaç' as NUM
+1	Kaç	kaç	NUM	Adj	NumType=Card	2	nummod	_	_
 2	kez	kez	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obl	_	_
 3	denemişti	dene	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	0	root	_	SpaceAfter=No
 4	;	;	PUNCT	Punc	_	12	punct	_	_
@@ -23464,8 +23468,9 @@
 
 # sent_id = mst-2602
 # text = Melek kaç tane sattın? diye yaklaştı Memo.
+# Change 2.2/dev: mark 'kaç' as NUM
 1	Melek	Melek	PROPN	Prop	Case=Nom|Number=Sing|Person=3	0	root	_	_
-2	kaç	kaç	ADJ	Adj	_	3	amod	_	_
+2	kaç	kaç	NUM	Adj	NumType=Card	3	nummod	_	_
 3	tane	tane	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	obj	_	_
 4	sattın	sat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Past	7	nmod	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	4	punct	_	_
@@ -32159,12 +32164,13 @@
 
 # sent_id = mst-3602
 # text = Kazadaki adamın sinirleri kaç kişiye bağlansa bunların hepsi, aynı Politzer gibi, kazayı başından sonuna kadar yaşayacaktır.
+# Change 2.2/dev: mark 'kaç' as NUM
 1-2	Kazadaki	_	_	_	_	_	_	_	_
 1	Kazada	kaza	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	nmod	_	_
 2	ki	ki	ADP	Rel	_	1	case	_	_
 3	adamın	adam	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod:poss	_	_
 4	sinirleri	sinir	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	7	nsubj	_	_
-5	kaç	kaç	ADJ	Adj	_	6	det	_	_
+5	kaç	kaç	NUM	Adj	NumType=Card	6	nummod	_	_
 6	kişiye	kişi	NOUN	Noun	Case=Dat|Number=Sing|Person=3	7	obl	_	_
 7	bağlansa	bağla	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|Voice=Pass	19	nmod	_	_
 8	bunların	bu	PRON	Demons	Case=Gen|Number=Plur|Person=3|PronType=Dem	9	nmod:poss	_	_
@@ -39933,6 +39939,7 @@
 
 # sent_id = mst-4449
 # text = İşi şakaya vurdum, iyi ya, dedim, Ceza'nın cezası da bitse keşke; kimbilir daha kaç tanker şarap içmem gerekecek.
+# Change 2.2/dev: mark 'kaç' as NUM
 1	İşi	iş	NOUN	Noun	Case=Acc|Number=Sing|Person=3	0	root	_	_
 2	şakaya	şaka	NOUN	Noun	Case=Dat|Number=Sing|Person=3	1	compound	_	_
 3	vurdum	vur	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	1	compound	_	SpaceAfter=No
@@ -39950,7 +39957,7 @@
 15	;	;	PUNCT	Punc	_	13	punct	_	_
 16	kimbilir	kimbilir	ADJ	Adj	_	22	amod	_	_
 17	daha	daha	ADV	Adverb	_	18	advmod	_	_
-18	kaç	kaç	ADJ	Adj	_	19	amod	_	_
+18	kaç	kaç	NUM	Adj	NumType=Card	19	nummod	_	_
 19	tanker	tanker	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nmod	_	_
 20	şarap	şarap	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	obj	_	_
 21	içmem	iç	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	22	nsubj	_	_
@@ -40280,8 +40287,9 @@
 
 # sent_id = mst-4485
 # text = -Kaçıncı kata çıkıyorsun.
+# Change 2.2/dev: mark 'kaç' as NUM
 1	-	-	PUNCT	Punc	_	0	root	_	SpaceAfter=No
-2	Kaçıncı	kaçıncı	ADJ	Adj	_	3	amod	_	_
+2	Kaçıncı	kaç	NUM	Adj	NumType=Ord	3	nummod	_	_
 3	kata	kat	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
 4	çıkıyorsun	çık	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
@@ -49462,7 +49470,7 @@
 22	kapıdan	kapı	NOUN	Noun	Case=Abl|Number=Sing|Person=3	24	obl	_	_
 23	kafasını	kafa	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	24	nmod	_	_
 24	uzatıp	uza	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Cau	28	nmod	_	_
-25	Kaç	kaç	ADJ	Adj	_	28	amod	_	SpaceAfter=No
+25	Kaç	kaç	NUM	Adj	NumType=Card	28	ccomp	_	SpaceAfter=No
 26	?	?	PUNCT	Punc	_	28	punct	_	_
 27	diye	diye	ADP	PCNom	_	25	case	_	_
 28	soruyordu	sor	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	SpaceAfter=No
@@ -49725,7 +49733,7 @@
 # text = Hastaneye yatırmışlar kaç defa, biraz düzelir gibi oluyor, ay geçmeden başlıyor daha beter içmeye.
 1	Hastaneye	hastane	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
 2	yatırmışlar	yatır	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
-3	kaç	kaç	ADJ	Adj	_	2	amod	_	_
+3	kaç	kaç	NUM	Adj	NumType=Card	2	nummod	_	_
 4	defa	defa	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	compound	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	2	punct	_	_
 6	biraz	biraz	ADV	Adverb	_	7	advmod	_	_

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -92,7 +92,7 @@
 # Change 2.2/dev: merge -(y)An
 1	"	"	PUNCT	Punc	_	12	punct	_	_
 2-3	Buradaki	_	_	_	_	_	_	_	_
-2	Burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	nmod	_	_
+2	Burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	6	nmod	_	_
 3	ki	ki	ADP	Rel	_	2	case	_	_
 4	üst	üst	ADJ	Adj	_	5	amod	_	_
 5	düzey	düzey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
@@ -404,7 +404,7 @@
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	defasında	defa	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 3	laf	laf	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
-4	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
+4	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
 5	gelir	gel	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part	7	acl	_	_
 6	gibi	gibi	ADP	PCNom	_	5	case	_	_
 7	oldu	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -1157,8 +1157,8 @@
 # text = Şimdi birini oradan oraya alarak tayin edeceksiniz, öbürünü açığa alacaksınız, öbürünü sorgulayacaksınız.
 1	Şimdi	şimdi	ADV	Adverb	_	6	advmod	_	_
 2	birini	bir	NUM	NNum	Case=Acc|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=3	6	obj	_	_
-3	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	5	obl	_	_
-4	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	3	compound:redup	_	_
+3	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	5	obl	_	_
+4	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	3	compound:redup	_	_
 5	alarak	al	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
 6	tayin	tayin	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 7	edeceksiniz	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Fut	6	compound:lvc	_	SpaceAfter=No
@@ -2444,7 +2444,7 @@
 # sent_id = mst-0302
 # text = Ancak burada üretilen elektron-pozitron çifti hiç yoktan yaratılmamış, gama fotonundan üretilmiştir.
 1	Ancak	ancak	CCONJ	Conj	_	0	root	_	_
-2	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
+2	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
 3	üretilen	üre	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part|Voice=CauPass	7	acl	_	_
 4	elektron	elektron	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	SpaceAfter=No
 5	-	-	PUNCT	Punc	_	4	conj	_	SpaceAfter=No
@@ -2714,7 +2714,7 @@
 # sent_id = mst-0319
 # text = Ana'nın orada olmadığını söyledikten sonra ben, buna ne inanırmış, ne de inanmazmış gibi bir tavır takındım.
 1	Ana'nın	Ana	PROPN	Prop	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
-2	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
+2	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
 3	olmadığını	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Neg|Tense=Past|VerbForm=Part	4	obj	_	_
 4	söyledikten	söyle	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	17	acl	_	_
 5	sonra	sonra	ADP	PCAbl	_	4	case	_	_
@@ -2909,7 +2909,7 @@
 # sent_id = mst-0335
 # text = Kurtulup buraya gelmeyi başardım.
 1	Kurtulup	kurtul	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	3	nmod	_	_
-2	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
+2	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
 3	gelmeyi	gel	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	nmod	_	_
 4	başardım	başar	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
@@ -3108,7 +3108,7 @@
 9	çekici	çekici	ADJ	Adj	_	11	amod	_	_
 10	bir	bir	NUM	ANum	NumType=Card	11	det	_	_
 11	yer	yer	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-12	orası	ora	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	nsubj	_	SpaceAfter=No
+12	orası	ora	PRON	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	nsubj	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	11	punct	_	_
 
 # sent_id = mst-0358
@@ -3191,7 +3191,7 @@
 # text = Şimdi varırız oraya, dedi Kerem.
 1	Şimdi	şimdi	ADV	Adverb	_	2	advmod	_	_
 2	varırız	var	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Aor	5	obj	_	_
-3	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	SpaceAfter=No
+3	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	2	punct	_	_
 5	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 6	Kerem	Kerem	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nsubj	_	SpaceAfter=No
@@ -4117,7 +4117,7 @@
 # text = Zor şey oraya yeniden girebilmek.
 1	Zor	zor	ADJ	Adj	_	2	amod	_	_
 2	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
-3	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
+3	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
 4	yeniden	yeniden	ADV	Adverb	_	5	advmod	_	_
 5	girebilmek	gir	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
@@ -4342,7 +4342,7 @@
 2	an	an	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
 3	önce	önce	ADV	Adverb	_	1	advmod	_	_
 4	dönmeliyim	dön	VERB	Verb	Aspect=Perf|Mood=Nec|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
-5	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	SpaceAfter=No
+5	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-0484
@@ -4774,7 +4774,7 @@
 # sent_id = mst-0529
 # text = Ya orayı bir daha bulamazsam?
 1	Ya	ya	CCONJ	Conj	_	5	nmod	_	_
-2	orayı	ora	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	obj	_	_
+2	orayı	ora	PRON	Noun	Case=Acc|Number=Sing|Person=3	5	obj	_	_
 3	bir	bir	ADV	Adverb	_	5	advmod	_	_
 4	daha	daha	ADV	Adverb	_	3	advmod	_	_
 5	bulamazsam	bul	VERB	Verb	Aspect=Imp|Mood=CndPot|Number=Sing|Person=1|Polarity=Neg|Tense=Aor	0	root	_	SpaceAfter=No
@@ -5541,7 +5541,7 @@
 3	entellektüel	entellektüel	ADJ	Adj	_	4	amod	_	_
 4	züppeler	züppe	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	5	nsubj	_	_
 5-6	oradalar	_	_	_	_	_	_	_	SpaceAfter=No
-5	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	1	conj	_	_
+5	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	1	conj	_	_
 6	lar	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Tense=Pres	5	cop	_	_
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
@@ -7643,8 +7643,8 @@
 10	içine	iç	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	11	amod	_	_
 11	soktu	sok	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	17	punct	_	_
-13	orasına	ora	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obl	_	_
-14	burasına	bura	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	compound:redup	_	_
+13	orasına	ora	PRON	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	15	obl	_	_
+14	burasına	bura	PRON	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	compound:redup	_	_
 15	yapışmış	yapış	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	16	acl	_	_
 16	kumları	kum	NOUN	Noun	Case=Acc|Number=Plur|Person=3	17	obj	_	_
 17	temizledi	temizle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	11	conj	_	SpaceAfter=No
@@ -7845,7 +7845,7 @@
 
 # sent_id = mst-0885
 # text = Orda bana bir şiir okudu, Allah taş etsin tek kelimesini anlamadım.
-1	Orda	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
+1	Orda	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
 2	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	5	obl	_	_
 3	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
 4	şiir	şiir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
@@ -8813,7 +8813,7 @@
 # text = Gene gittin oraya.
 1	Gene	gene	ADV	Adverb	_	2	advmod	_	_
 2	gittin	git	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Past	0	root	_	_
-3	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	SpaceAfter=No
+3	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0985
@@ -8963,7 +8963,7 @@
 # text = Niçin geldim buraya bilmiyorum.
 1	Niçin	niçin	ADV	Adverb	_	2	advmod	_	_
 2	geldim	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	4	obj	_	_
-3	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
+3	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
 4	bilmiyorum	bil	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -9461,7 +9461,7 @@
 8	defa	defa	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
 9	o	o	DET	Det	_	10	det	_	_
 10	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod	_	_
-11	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	nmod	_	_
+11	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	6	nmod	_	_
 12	ettim	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	6	compound:lvc	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	6	punct	_	_
 
@@ -10107,7 +10107,7 @@
 
 # sent_id = mst-1123
 # text = Oraya nasıl ulaşılacağını, nereden gidileceğini hiç bilmiyorum.
-1	Oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
+1	Oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
 2	nasıl	nasıl	ADV	Adverb	_	3	advmod	_	_
 3	ulaşılacağını	ulaş	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	8	obj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	3	punct	_	_
@@ -10374,7 +10374,7 @@
 
 # sent_id = mst-1154
 # text = Oraya saptık.
-1	Oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
+1	Oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
 2	saptık	sap	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -11295,7 +11295,7 @@
 14	bulunabilmek	bul	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Pot|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	8	conj	_	_
 15	için	için	ADP	PCNom	_	8	case	_	SpaceAfter=No
 16	,	,	PUNCT	Punc	_	8	punct	_	_
-17	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	18	nmod	_	_
+17	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	18	nmod	_	_
 18	sözünü	söz	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	20	nmod	_	_
 19	ettiğimiz	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Plur|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	18	compound:lvc	_	_
 20	ilişkilerin	ilişki	NOUN	Noun	Case=Gen|Number=Plur|Person=3	23	nmod:poss	_	_
@@ -11495,7 +11495,7 @@
 # Change 2.2/dev: merge -(y)An
 1	Ama	ama	CCONJ	Conj	_	9	cc	_	_
 2	zaten	zaten	ADV	Adverb	_	9	advmod	_	_
-3	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
+3	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
 4	daha	daha	ADV	Adverb	_	5	advmod	_	_
 5	çok	çok	ADV	Adverb	_	8	advmod	_	_
 6	klasik	klasik	ADJ	Adj	_	7	amod	_	_
@@ -13066,7 +13066,7 @@
 
 # sent_id = mst-1460
 # text = Buranın yerlisi o.
-1	Buranın	bura	NOUN	Noun	Case=Gen|Number=Sing|Person=3	2	nmod:poss	_	_
+1	Buranın	bura	PRON	Noun	Case=Gen|Number=Sing|Person=3	2	nmod:poss	_	_
 2	yerlisi	yerli	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	nsubj	_	_
 3	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -13427,7 +13427,7 @@
 # text = Biz de oradan almışız.
 1	Biz	biz	PRON	Pers	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	_	_
 2	de	de	CCONJ	Conj	_	1	advmod:emph	_	_
-3	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	4	obl	_	_
+3	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	4	obl	_	_
 4	almışız	al	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -13736,7 +13736,7 @@
 # sent_id = mst-1531
 # text = Oradaki, kalemdeki görevlilerin kaprisiyle de karşılaştık.
 1-2	Oradaki	_	_	_	_	_	_	_	SpaceAfter=No
-1	Orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
+1	Orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
 2	ki	ki	ADP	Rel	_	1	case	_	_
 3	,	,	PUNCT	Punc	_	4	punct	_	_
 4-5	kalemdeki	_	_	_	_	_	_	_	_
@@ -13897,7 +13897,7 @@
 # text = Evet, buraya bir şey anlatmak için gelmiştim, dedi Kerem.
 1	Evet	evet	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	10	punct	_	_
-3	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
+3	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
 4	bir	bir	NUM	ANum	NumType=Card	6	obj	_	_
 5	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	compound	_	_
 6	anlatmak	anlat	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nmod	_	_
@@ -14423,7 +14423,7 @@
 # text = Mahmut Bey burada yok, dedi ses.
 1	Mahmut	Mahmut	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 2	Bey	bey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	1	compound	_	_
-3	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	nmod	_	_
+3	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	nmod	_	_
 4	yok	yok	ADV	Adverb	_	6	advmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	6	punct	_	_
 6	dedi	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
@@ -14460,7 +14460,7 @@
 25	şişesine	şişe	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	conj	_	SpaceAfter=No
 26	,	,	PUNCT	Punc	_	33	punct	_	_
 27-28	oradaki	_	_	_	_	_	_	_	_
-27	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	30	nmod	_	_
+27	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	30	nmod	_	_
 28	ki	ki	ADP	Rel	_	27	case	_	_
 29	küçük	küçük	ADJ	Adj	_	30	amod	_	_
 30	masada	masa	NOUN	Noun	Case=Loc|Number=Sing|Person=3	32	obl	_	_
@@ -14651,7 +14651,7 @@
 21-22	dağlarıydı	_	_	_	_	_	_	_	_
 21	dağları	dağ	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	0	root	_	_
 22	ydı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	21	cop	_	_
-23	buralar	bura	NOUN	Noun	Case=Nom|Number=Plur|Person=3	21	nmod	_	SpaceAfter=No
+23	buralar	bura	PRON	Noun	Case=Nom|Number=Plur|Person=3	21	nmod	_	SpaceAfter=No
 24	.	.	PUNCT	Punc	_	21	punct	_	_
 
 # sent_id = mst-1638
@@ -16317,7 +16317,7 @@
 
 # sent_id = mst-1827
 # text = Buraya bir şeyler anlatmaya geldiniz.
-1	Buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
+1	Buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
 2	bir	bir	NUM	ANum	NumType=Card	3	det	_	_
 3	şeyler	şey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	4	obj	_	_
 4	anlatmaya	anlat	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	5	nmod	_	_
@@ -17030,7 +17030,7 @@
 1	Yanlışlanan	Yanlışlan	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	2	nmod	_	_
 2	kuramın	kuram	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
 3	doğurganlığı	doğurganlık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obj	_	_
-4	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
+4	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
 5	yatar	yat	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	5	punct	_	_
 
@@ -17801,7 +17801,7 @@
 6	alıp	al	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	_
 7	götürsün	götür	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	3	conj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	7	punct	_	_
-9	şuradan	şura	NOUN	Noun	Case=Abl|Number=Sing|Person=3	7	obl	_	_
+9	şuradan	şura	PRON	Noun	Case=Abl|Number=Sing|Person=3	7	obl	_	_
 10	Lou	Lou	PROPN	Prop	Case=Nom|Number=Sing|Person=3	12	nmod:poss	_	_
 11	Reed	Reed	PROPN	Prop	Case=Nom|Number=Sing|Person=3	10	flat	_	_
 12	kasetini	kaset	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	obj	_	SpaceAfter=No
@@ -18256,7 +18256,7 @@
 4	işte	işte	ADV	Adverb	_	6	advmod	_	SpaceAfter=No
 5	!	!	PUNCT	Punc	_	7	punct	_	_
 6	Hepsi	hepsi	PRON	Quant	Case=Nom|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3|PronType=Ind	7	nmod	_	_
-7	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	0	root	_	SpaceAfter=No
+7	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-2026
@@ -18778,7 +18778,7 @@
 4	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
 5	geliyor	gel	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	_
 6	artık	artık	ADV	Adverb	_	5	advmod	_	_
-7	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
+7	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-2083
@@ -18901,7 +18901,7 @@
 4	bir	bir	NUM	ANum	NumType=Card	5	det	_	_
 5	umut	umut	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
 6	var	var	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	1	conj	_	_
-7	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	SpaceAfter=No
+7	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	SpaceAfter=No
 8	...	...	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-2097
@@ -20799,7 +20799,7 @@
 
 # sent_id = mst-2306
 # text = Burası Birinci Ada.
-1	Burası	bura	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	det	_	_
+1	Burası	bura	PRON	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	det	_	_
 2	Birinci	Birinci	PROPN	Prop	Case=Nom|Number=Sing|Person=3	3	nmod	_	_
 3	Ada	ada	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -20817,7 +20817,7 @@
 3	seni	sen	PRON	Pers	Case=Acc|Number=Sing|Person=2|PronType=Prs	7	obj	_	_
 4	aldatmak	aldat	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	nmod	_	_
 5	için	için	ADP	PCNom	_	4	case	_	_
-6	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	7	obl	_	_
+6	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	7	obl	_	_
 7	yerleştirilmiş	yerleş	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=CauPass	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
@@ -22577,7 +22577,7 @@
 1	Dışarda	dışarı	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
 2	aki	ki	ADP	Rel	_	1	case	_	_
 3	çadırda	çadır	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
-4	Şura	şura	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
+4	Şura	Şura	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
 5	ekmek	ekmek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obj	_	_
 6	hazırlıyor	hazırla	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
@@ -22644,7 +22644,7 @@
 
 # sent_id = mst-2532
 # text = Burada herkesin dükkanı var.
-1	Burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
+1	Burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 2	herkesin	herkes	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
 3	dükkanı	dükkan	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
 4	var	var	ADJ	Adj	_	0	root	_	SpaceAfter=No
@@ -22806,7 +22806,7 @@
 7	bakın	bakı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	1	conj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	15	punct	_	_
 9	üstelik	üstelik	ADV	Adverb	_	14	advmod	_	_
-10	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	14	obl	_	_
+10	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	14	obl	_	_
 11	benim	ben	PRON	Pers	Case=Gen|Number=Sing|Person=1|PronType=Prs	13	nmod:poss	_	_
 12	bir	bir	NUM	ANum	NumType=Card	13	det	_	_
 13	günahım	günah	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	14	obj	_	_
@@ -23032,7 +23032,7 @@
 16	akraba	akraba	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	compound:redup	_	_
 17	hep	hep	ADV	Adverb	_	18	advmod	_	_
 18-19	oradaydı	_	_	_	_	_	_	_	SpaceAfter=No
-18	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	conj	_	_
+18	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	5	conj	_	_
 19	ydı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	18	cop	_	_
 20	,	,	PUNCT	Punc	_	18	punct	_	_
 21	ama	ama	CCONJ	Conj	_	18	cc	_	_
@@ -23672,7 +23672,7 @@
 2	akşam	akşam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nmod	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	20	punct	_	_
 4	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	8	obl	_	_
-5	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	8	obl	_	_
+5	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	8	obl	_	_
 6	kaldığım	kal	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	7	acl	_	_
 7	evi	ev	NOUN	Noun	Case=Acc|Number=Sing|Person=3	8	obj	_	_
 8	bulan	bul	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	17	acl	_	SpaceAfter=No
@@ -23981,7 +23981,7 @@
 2	döven	döv	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	3	nmod	_	_
 3	adam	adam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
 4	da	da	CCONJ	Conj	_	3	nmod	_	_
-5	şurada	şura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	9	obl	_	SpaceAfter=No
+5	şurada	şura	PRON	Noun	Case=Loc|Number=Sing|Person=3	9	obl	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	9	punct	_	_
 7	şu	şu	PRON	Demons	Case=Nom|Number=Sing|Person=3|PronType=Dem	8	compound	_	_
 8	ağacın	ağaç	NOUN	Noun	Case=Gen|Number=Sing|Person=3	9	nmod:poss	_	_
@@ -24132,7 +24132,7 @@
 9	yıllar	yıl	NOUN	Noun	Case=Nom|Number=Plur|Person=3	11	nmod	_	_
 10	dır	dir	ADP	Since	_	9	case	_	_
 11-12	buradaymışım	_	_	_	_	_	_	_	SpaceAfter=No
-11	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	23	obl	_	_
+11	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	23	obl	_	_
 12	ymışım	i	AUX	Zero	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=1|Tense=Past	11	cop	_	_
 13	,	,	PUNCT	Punc	_	21	punct	_	_
 14	hep	hep	ADV	Adverb	_	21	advmod	_	_
@@ -24229,7 +24229,7 @@
 # text = Zor kurtuldum oradan.
 1	Zor	zor	ADJ	Adj	_	2	amod	_	_
 2	kurtuldum	kurtul	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	_
-3	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	2	obl	_	SpaceAfter=No
+3	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	2	obl	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-2683
@@ -24340,7 +24340,7 @@
 
 # sent_id = mst-2696
 # text = Orada olmalıyım şimdi.
-1	Orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	2	obl	_	_
+1	Orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	2	obl	_	_
 2	olmalıyım	ol	VERB	Verb	Aspect=Perf|Mood=Nec|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 3	şimdi	şimdi	ADV	Adverb	_	2	advmod	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
@@ -24424,8 +24424,8 @@
 4	balığı	balık	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	amod	_	_
 5	gibi	gibi	ADP	PCNom	_	4	case	_	_
 6	kendinizi	kendi	PRON	Reflex	Case=Acc|Number=Plur|Number[psor]=Plur|Person=2|Person[psor]=2|Reflex=Yes	9	obj	_	_
-7	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	8	nmod	_	_
-8	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
+7	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	8	nmod	_	_
+8	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	9	obl	_	_
 9	atarsınız	at	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
@@ -24559,7 +24559,7 @@
 6	olarak	olarak	ADP	PCNom	_	5	case	_	_
 7	şeyler	şey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	8	obj	_	_
 8	yazıldı	yaz	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	0	root	_	_
-9	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	8	obl	_	SpaceAfter=No
+9	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	8	obl	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-2721
@@ -24639,7 +24639,7 @@
 # text = Kapının orda hafifçe sendeledi.
 # Change 2.2/dev: merge -CA
 1	Kapının	kapı	NOUN	Noun	Case=Gen|Number=Sing|Person=3	2	nmod	_	_
-2	orda	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
+2	orda	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 3	hafifçe	hafifçe	ADV	Adverb	_	4	advmod	_	_
 4	sendeledi	sendele	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
@@ -24974,7 +24974,7 @@
 1	Ama	ama	CCONJ	Conj	_	0	root	_	_
 2	benim	ben	PRON	Pers	Case=Gen|Number=Sing|Person=1|PronType=Prs	5	nmod	_	_
 3-4	buradaki	_	_	_	_	_	_	_	_
-3	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	nmod	_	_
+3	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	5	nmod	_	_
 4	ki	ki	ADP	Rel	_	3	case	_	_
 5	büyükelçim	büyükelçi	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	7	nsubj	_	_
 6	Çince	Çince	PROPN	Prop	Case=Nom|Number=Sing|Person=3	7	obl	_	_
@@ -24983,7 +24983,7 @@
 9	?	?	PUNCT	Punc	_	19	punct	_	_
 10	Benim	ben	PRON	Pers	Case=Gen|Number=Sing|Person=1|PronType=Prs	13	nmod	_	_
 11-12	buradaki	_	_	_	_	_	_	_	_
-11	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	13	nmod	_	_
+11	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	13	nmod	_	_
 12	ki	ki	ADP	Rel	_	11	case	_	_
 13	büyükelçim	büyükelçi	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	19	nsubj	_	_
 14	de	de	CCONJ	Conj	_	13	advmod:emph	_	SpaceAfter=No
@@ -25395,7 +25395,7 @@
 
 # sent_id = mst-2812
 # text = Buradan pozisyon açan yatırımcı, 1.Şub yıl içinde İMKB yuz Endeksi'nin yuzon sente gelmesi durumunda dolar bazında yüzde yuz reel getiri sağlayabilir.
-1	Buradan	bura	NOUN	Noun	Case=Abl|Number=Sing|Person=3	3	obl	_	_
+1	Buradan	bura	PRON	Noun	Case=Abl|Number=Sing|Person=3	3	obl	_	_
 2	pozisyon	pozisyon	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 3	açan	aç	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	4	acl	_	_
 4	yatırımcı	yatırımcı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	22	nsubj	_	SpaceAfter=No
@@ -25575,7 +25575,7 @@
 # sent_id = mst-2834
 # text = Doğrusu burada çok rahatım.
 1	Doğrusu	doğru	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	amod	_	_
-2	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
+2	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 3	çok	çok	ADV	Adverb	_	4	advmod	_	_
 4-5	rahatım	_	_	_	_	_	_	_	SpaceAfter=No
 4	rahat	rahat	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
@@ -25731,7 +25731,7 @@
 # sent_id = mst-2855
 # text = Türkçeye buradan girmiş.
 1	Türkçeye	Türkçe	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	3	amod	_	_
-2	buradan	bura	NOUN	Noun	Case=Abl|Number=Sing|Person=3	3	obl	_	_
+2	buradan	bura	PRON	Noun	Case=Abl|Number=Sing|Person=3	3	obl	_	_
 3	girmiş	gir	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -26329,7 +26329,7 @@
 
 # sent_id = mst-2931
 # text = Buradan hareketle Askeri Savcılığın takipsizlik kararına itiraz etti.
-1	Buradan	bura	NOUN	Noun	Case=Abl|Number=Sing|Person=3	2	nmod	_	_
+1	Buradan	bura	PRON	Noun	Case=Abl|Number=Sing|Person=3	2	nmod	_	_
 2	hareketle	hareket	NOUN	Noun	Case=Ins|Number=Sing|Person=3	7	nmod	_	_
 3	Askeri	askeri	ADJ	Adj	_	6	nmod:poss	_	_
 4	Savcılığın	savcılık	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	flat	_	_
@@ -27283,7 +27283,7 @@
 
 # sent_id = mst-3040
 # text = Orada şöyle ,bir şey dikkatimi çekti.
-1	Orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	nmod	_	_
+1	Orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	5	nmod	_	_
 2	şöyle	şöyle	ADV	Adverb	_	5	advmod	_	_
 3	,bir	bir	NUM	ANum	NumType=Card	4	det	_	_
 4	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
@@ -27791,7 +27791,7 @@
 3	daha	daha	ADV	Adverb	_	2	advmod	_	_
 4	hiç	hiç	ADV	Adverb	_	5	advmod	_	_
 5	giremeyeceğim	gir	VERB	Verb	Aspect=Perf|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Fut	0	root	_	_
-6	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
+6	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-3110
@@ -28078,7 +28078,7 @@
 6	istemedim	iste	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Past	4	compound	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	9	punct	_	_
 8	şunun	şu	PRON	Demons	Case=Gen|Number=Sing|Person=3|PronType=Dem	9	nmod:poss	_	_
-9	şurasında	şura	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	conj	_	_
+9	şurasında	şura	PRON	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	conj	_	_
 10	birlikte	birlikte	ADV	Adverb	_	11	advmod	_	_
 11	yaşamaya	yaşa	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	conj	_	_
 12	başlayalı	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	4	conj	_	_
@@ -28094,7 +28094,7 @@
 # sent_id = mst-3132
 # text = Ancak burada söz konusu olan, bilinçli bir soyutlamadan çok, sürekli yinelenen bir deneme-yanılma sürecidir.
 1	Ancak	ancak	CCONJ	Conj	_	0	root	_	_
-2	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
+2	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
 3	söz	söz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
 4	konusu	konu	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	compound	_	_
 5	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	18	nsubj	_	SpaceAfter=No
@@ -28870,7 +28870,7 @@
 1	Kaçtım	kaç	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	6	obj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	3	punct	_	_
 3	kurtuldum	kurtul	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	1	conj	_	_
-4	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	3	obl	_	SpaceAfter=No
+4	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	3	obl	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	3	punct	_	_
 6	diyordunuz	de	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Polite=Infm|Tense=Past	8	obj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
@@ -29197,7 +29197,7 @@
 1	NA'nın	Na	PROPN	Prop	Case=Gen|Number=Sing|Person=3	2	nmod:poss	_	_
 2	işlevi	işlev	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nsubj	_	_
 3	de	de	CCONJ	Conj	_	2	advmod:emph	_	_
-4	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
+4	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
 5	devreye	devre	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
 6	giriyor	gir	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
@@ -29434,7 +29434,7 @@
 3	dır	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	2	cop	_	_
 4	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	2	aux:q	_	_
 5	gidersiniz	git	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Aor	0	root	_	_
-6	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
+6	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-3277
@@ -29568,7 +29568,7 @@
 3	şey	şey	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	compound	_	_
 4	anlatamadan	anlat	VERB	Verb	Aspect=Perf|Mood=Pot|Polarity=Neg|Tense=Pres|VerbForm=Conv	5	nmod	_	_
 5	gideceğim	git	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Fut	9	nmod	_	_
-6	buradan	bura	NOUN	Noun	Case=Abl|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
+6	buradan	bura	PRON	Noun	Case=Abl|Number=Sing|Person=3	5	obl	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	5	punct	_	_
 8	diye	diye	ADP	PCNom	_	5	case	_	_
 9	mırıldandı	mırıldan	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -30358,7 +30358,7 @@
 8	ki	ki	ADP	Rel	_	7	case	_	_
 9	fark	fark	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
 10-11	buradaydı	_	_	_	_	_	_	_	SpaceAfter=No
-10	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	1	conj	_	_
+10	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	1	conj	_	_
 11	ydı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	10	cop	_	_
 12	.	.	PUNCT	Punc	_	10	punct	_	_
 
@@ -30541,7 +30541,7 @@
 
 # sent_id = mst-3403
 # text = Buraya kadar geldiniz.
-1	Buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
+1	Buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
 2	kadar	kadar	ADP	PCNom	_	1	case	_	_
 3	geldiniz	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
@@ -30924,7 +30924,7 @@
 2	önce	önce	ADV	Adverb	_	17	advmod	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	17	punct	_	_
 4	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	_
-5	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
+5	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
 6	taşınıyorum	taşı	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Polite=Infm|Tense=Pres|Voice=Pass	17	nmod	_	_
 7	artık	artık	ADV	Adverb	_	6	advmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	6	punct	_	_
@@ -31807,7 +31807,7 @@
 6	Okulu'na	okul	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	flat	_	_
 7	gidiyor	git	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	_
 8	ve	ve	CCONJ	Conj	_	11	cc	_	_
-9	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	11	nmod	_	_
+9	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	11	nmod	_	_
 10	bir	bir	NUM	ANum	NumType=Card	11	det	_	_
 11	demeç	demeç	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	conj	_	_
 12	veriyor	ver	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	11	compound	_	SpaceAfter=No
@@ -32412,7 +32412,7 @@
 12	iniliyordu	in	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
 13	,	,	PUNCT	Punc	_	14	punct	_	_
 14-15	oradaydı	_	_	_	_	_	_	_	_
-14	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	12	conj	_	_
+14	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	12	conj	_	_
 15	ydı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	14	cop	_	_
 16	bu	bu	DET	Det	_	17	det	_	_
 17	geniş	geniş	ADJ	Adj	_	14	obj	_	SpaceAfter=No
@@ -32810,7 +32810,7 @@
 2	bu	bu	DET	Det	_	3	det	_	_
 3	düşünceleri	düşünce	NOUN	Noun	Case=Acc|Number=Plur|Person=3	6	obj	_	_
 4	neden	ne	PRON	Ques	Case=Abl|Number=Sing|Person=3	5	nmod	_	_
-5	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
+5	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
 6	aktardığım	aktar	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	9	obj	_	SpaceAfter=No
 7	,	,	PUNCT	Punc	_	6	punct	_	_
 8	elbette	elbette	ADV	Adverb	_	9	advmod	_	_
@@ -32869,7 +32869,7 @@
 # sent_id = mst-3674
 # text = Ama orada gayet normal hareket eden insanların çoğu, yandaki salona geçtiğinde şoka giriyorsunuz; Resmen hard seks yapıyorlar.
 1	Ama	ama	CCONJ	Conj	_	0	root	_	_
-2	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	nmod	_	_
+2	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	5	nmod	_	_
 3	gayet	gayet	ADV	Adverb	_	4	advmod	_	_
 4	normal	normal	ADJ	Adj	_	5	amod	_	_
 5	hareket	hareket	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
@@ -33025,7 +33025,7 @@
 26	konu	konu	NOUN	Noun	Case=Nom|Number=Sing|Person=3	27	obj	_	_
 27	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	28	acl	_	_
 28	belgeleri	belge	NOUN	Noun	Case=Acc|Number=Plur|Person=3	16	conj	_	_
-29	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	30	obl	_	_
+29	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	30	obl	_	_
 30	getirtmek	getirt	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	32	nsubj	_	_
 31	mümkün	mümkün	ADJ	Adj	_	32	obj	_	_
 32	olur	ol	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Aor	35	nmod	_	_
@@ -33274,7 +33274,7 @@
 
 # sent_id = mst-3702
 # text = Orası sahipsiz bir yer değildir.
-1	Orası	ora	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
+1	Orası	ora	PRON	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
 2	sahipsiz	sahipsiz	ADJ	Adj	_	4	amod	_	_
 3	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
 4	yer	yer	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
@@ -33295,7 +33295,7 @@
 10	elektronik	elektronik	ADJ	Adj	_	11	amod	_	_
 11	cihazlara	cihaz	NOUN	Noun	Case=Dat|Number=Plur|Person=3	23	obl	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	15	punct	_	_
-13	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	16	obl	_	_
+13	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	16	obl	_	_
 14	da	da	CCONJ	Conj	_	13	advmod:emph	_	_
 15	havaya	hava	NOUN	Noun	Case=Dat|Number=Sing|Person=3	11	conj	_	_
 16	yayılıp	yay	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv|Voice=Pass	9	conj	_	SpaceAfter=No
@@ -34220,7 +34220,7 @@
 3	bir	bir	ADV	Adverb	_	5	advmod	_	_
 4	daha	daha	ADV	Adverb	_	3	advmod	_	_
 5	bulamayacağım	bul	VERB	Verb	Aspect=Perf|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Fut	0	root	_	_
-6	orayı	ora	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	obj	_	SpaceAfter=No
+6	orayı	ora	PRON	Noun	Case=Acc|Number=Sing|Person=3	5	obj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-3805
@@ -34633,7 +34633,7 @@
 1	Turgut	Turgut	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 2	Özal	Özal	PROPN	Prop	Case=Nom|Number=Sing|Person=3	1	flat	_	_
 3	da	da	CCONJ	Conj	_	1	advmod:emph	_	_
-4	buradan	bura	NOUN	Noun	Case=Abl|Number=Sing|Person=3	0	root	_	SpaceAfter=No
+4	buradan	bura	PRON	Noun	Case=Abl|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-3849
@@ -34929,7 +34929,7 @@
 # sent_id = mst-3879
 # text = Orada, denizi gören yamaçlarda, ağaçların altına uzanıyor, piknik yapıyor, sonra da sonsuzca öpüşmelere başlıyorduk.
 # Change 2.2/dev: merge -CA
-1	Orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	9	obl	_	SpaceAfter=No
+1	Orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	9	obl	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	5	punct	_	_
 3	denizi	deniz	NOUN	Noun	Case=Acc|Number=Sing|Person=3	4	obj	_	_
 4	gören	gör	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	5	acl	_	_
@@ -35256,7 +35256,7 @@
 # text = İstersen önce oraya gidelim.
 1	İstersen	iste	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Sing|Person=2|Polarity=Pos|Tense=Aor	4	nmod	_	_
 2	önce	önce	ADV	Adverb	_	4	advmod	_	_
-3	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
+3	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
 4	gidelim	git	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -35563,7 +35563,7 @@
 
 # sent_id = mst-3950
 # text = Buralarda bekledim.
-1	Buralarda	bura	NOUN	Noun	Case=Loc|Number=Plur|Person=3	2	obl	_	_
+1	Buralarda	bura	PRON	Noun	Case=Loc|Number=Plur|Person=3	2	obl	_	_
 2	bekledim	bekle	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
@@ -36768,7 +36768,7 @@
 # text = Kumru'nun ablası orada çalışıyor.
 1	Kumru'nun	Kumru	PROPN	Prop	Case=Gen|Number=Sing|Person=3	2	nmod:poss	_	_
 2	ablası	abla	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
-3	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
+3	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 4	çalışıyor	çalış	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -37313,7 +37313,7 @@
 2	bir	bir	NUM	ANum	NumType=Card	3	det	_	_
 3	bağımlılıktan	bağımlılık	NOUN	Noun	Case=Abl|Number=Sing|Person=3	4	obl	_	_
 4	kurtarıp	kurtar	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	6	nmod	_	_
-5	buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
+5	buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	6	obl	_	_
 6	geldiniz	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
@@ -37471,7 +37471,7 @@
 # sent_id = mst-4195
 # text = Ama burada sorumluluk kişiye düşüyor.
 1	Ama	ama	CCONJ	Conj	_	0	root	_	_
-2	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
+2	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	5	obl	_	_
 3	sorumluluk	sorumluluk	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
 4	kişiye	kişi	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obl	_	_
 5	düşüyor	düş	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
@@ -38443,7 +38443,7 @@
 # sent_id = mst-4289
 # text = Sen buralarda ne geziyorsun aylak aylak.
 1	Sen	sen	PRON	Pers	Case=Nom|Number=Sing|Person=2|PronType=Prs	4	nsubj	_	_
-2	buralarda	bura	NOUN	Noun	Case=Loc|Number=Plur|Person=3	4	obl	_	_
+2	buralarda	bura	PRON	Noun	Case=Loc|Number=Plur|Person=3	4	obl	_	_
 3	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	4	obl	_	_
 4	geziyorsun	gez	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	_
 5	aylak	aylak	ADJ	Adj	_	4	amod	_	_
@@ -39171,7 +39171,7 @@
 2	araba	araba	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
 3	her	her	DET	Det	_	7	obl	_	_
 4	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	fixed	_	_
-5	oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	7	obl	_	_
+5	oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	7	obl	_	_
 6	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	5	aux:q	_	_
 7	geçecek	geç	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	21	obj	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	17	punct	_	_
@@ -40315,7 +40315,7 @@
 # sent_id = mst-4496
 # text = Ama orada bulundum.
 1	Ama	ama	CCONJ	Conj	_	0	root	_	_
-2	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
+2	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
 3	bulundum	bulun	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
@@ -41975,7 +41975,7 @@
 
 # sent_id = mst-4696
 # text = Buraya uğra, bir kadeh içtikten sonra, kentin merkezine ineriz.
-1	Buraya	bura	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
+1	Buraya	bura	PRON	Noun	Case=Dat|Number=Sing|Person=3	2	obl	_	_
 2	uğra	uğra	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	2	punct	_	_
 4	bir	bir	NUM	ANum	NumType=Card	5	det	_	_
@@ -42151,7 +42151,7 @@
 1	Lan	la	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=2	0	root	_	_
 2	Miskoye	Miskoye	PROPN	Prop	Case=Nom|Number=Sing|Person=3	1	conj	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	6	punct	_	_
-4	burda	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
+4	burda	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	_
 5	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	6	obj	_	_
 6	yapıyon	yap	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Polite=Infm|Tense=Pres	1	conj	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
@@ -43727,7 +43727,7 @@
 11	de	de	CCONJ	Conj	_	10	advmod:emph	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	19	punct	_	_
 13	işte	işte	ADV	Adverb	_	14	advmod:emph	_	_
-14	orada	ora	NOUN	Noun	Case=Loc|Number=Sing|Person=3	15	obl	_	_
+14	orada	ora	PRON	Noun	Case=Loc|Number=Sing|Person=3	15	obl	_	_
 15	duracaksın	dur	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Tense=Fut	16	nmod:poss	_	_
 16	anlamında	anlam	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	19	obl	_	_
 17	ileri	ileri	ADJ	Adj	_	18	amod	_	_
@@ -43899,7 +43899,7 @@
 7	daire	daire	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	obj	_	_
 8	çizerek	çiz	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	14	punct	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	8	conj	_	_
-10	Şuramda	şura	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	14	obl	_	_
+10	Şuramda	şura	PRON	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	14	obl	_	_
 11	kocaman	kocaman	ADJ	Adj	_	13	amod	_	_
 12	bir	bir	NUM	ANum	NumType=Card	13	det	_	_
 13	delik	delik	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	14	nsubj	_	_
@@ -45060,7 +45060,7 @@
 
 # sent_id = mst-5044
 # text = Burada iki noktaya değinmek istiyorum.
-1	Burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	nmod	_	_
+1	Burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	3	nmod	_	_
 2	iki	iki	NUM	ANum	NumType=Card	3	nummod	_	_
 3	noktaya	nokta	NOUN	Noun	Case=Dat|Number=Sing|Person=3	5	obj	_	_
 4	değinmek	değin	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	3	compound	_	_
@@ -45143,7 +45143,7 @@
 11	duyanlar	duy	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Part	10	compound	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	25	punct	_	_
 13-14	buradaki	_	_	_	_	_	_	_	_
-13	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	15	nmod	_	_
+13	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	15	nmod	_	_
 14	ki	ki	ADP	Rel	_	13	case	_	_
 15	insanların	insan	NOUN	Noun	Case=Gen|Number=Plur|Person=3	24	nmod:poss	_	_
 16	birkaç	birkaç	DET	Det	_	17	det	_	_
@@ -46653,7 +46653,7 @@
 # sent_id = mst-5263
 # text = Henüz oraya varmadan önceki ara sokaklardan birinde, göstermek istediğim küçük bir bar vardı.
 1	Henüz	henüz	ADV	Adverb	_	3	advmod	_	_
-2	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
+2	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	3	obl	_	_
 3	varmadan	var	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	4	nmod	_	_
 4-5	önceki	_	_	_	_	_	_	_	_
 4	önce	önce	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
@@ -47559,7 +47559,7 @@
 7	var	var	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	1	conj	_	_
 8	dı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	7	cop	_	_
 9	;	;	PUNCT	Punc	_	10	punct	_	_
-10	burada	bura	NOUN	Noun	Case=Loc|Number=Sing|Person=3	1	conj	_	SpaceAfter=No
+10	burada	bura	PRON	Noun	Case=Loc|Number=Sing|Person=3	1	conj	_	SpaceAfter=No
 11	,	,	PUNCT	Punc	_	16	punct	_	_
 12	yabancısı	yabancı	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	13	amod	_	_
 13	olduğum	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	1	conj	_	_
@@ -47679,8 +47679,8 @@
 
 # sent_id = mst-5376
 # text = Oradan oraya seğirtmelerim bitecek, bitip de baş başa kalacak, baş başa kalınca da uzun uzun hayatlarımızın özetlerini çıkarıp bu hayatların görünen ucuna doğru birbirimize el verecek durumda değilim.
-1	Oradan	ora	NOUN	Noun	Case=Abl|Number=Sing|Person=3	3	obl	_	_
-2	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	1	compound	_	_
+1	Oradan	ora	PRON	Noun	Case=Abl|Number=Sing|Person=3	3	obl	_	_
+2	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	1	compound	_	_
 3	seğirtmelerim	seğir	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	4	nsubj	_	_
 4	bitecek	bit	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	29	acl	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	8	punct	_	_
@@ -48012,7 +48012,7 @@
 # text = Tartışma yeri burası değil.
 1	Tartışma	tartış	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	2	nmod:poss	_	_
 2	yeri	yer	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
-3	burası	bura	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nmod	_	_
+3	burası	bura	PRON	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nmod	_	_
 4	değil	değil	CCONJ	Conj	_	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -49265,7 +49265,7 @@
 # text = Nasıl çıkabilirim oraya.
 1	Nasıl	nasıl	ADV	Adverb	_	2	advmod	_	_
 2	çıkabilirim	çık	VERB	Verb	Aspect=Imp|Mood=Pot|Number=Sing|Person=1|Polarity=Pos|Tense=Aor	0	root	_	_
-3	oraya	ora	NOUN	Noun	Case=Dat|Number=Sing|Person=3	2	compound	_	SpaceAfter=No
+3	oraya	ora	PRON	Noun	Case=Dat|Number=Sing|Person=3	2	compound	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-5545

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -290,10 +290,9 @@
 15	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-0042
-# text = Niye?.
+# text = Niye?
 1	Niye	niye	ADV	Adverb	_	0	root	_	SpaceAfter=No
 2	?	?	PUNCT	Punc	_	1	punct	_	SpaceAfter=No
-3	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-0043
 # text = Tombul dizleri, masanın altından Mahmut'un dizlerine yapışmıştı.
@@ -3609,11 +3608,10 @@
 4	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-0406
-# text = Kim o?.
+# text = Kim o?
 1	Kim	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
 2	o	o	PRON	Pers	Case=Nom|Number=Sing|Person=3|PronType=Prs	1	nsubj	_	SpaceAfter=No
 3	?	?	PUNCT	Punc	_	1	punct	_	SpaceAfter=No
-4	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-0407
 # text = Tibet'in tek hayranı ben değilim.
@@ -7990,13 +7988,12 @@
 5	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-0897
-# text = Kim tamir edecekti beni?.
+# text = Kim tamir edecekti beni?
 1	Kim	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
 2	tamir	tamir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 3	edecekti	et	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	2	compound:lvc	_	_
 4	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	2	punct	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0898
 # text = Kumru sabah akşam sarılıyormuş telefona.
@@ -12431,13 +12428,12 @@
 8	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-1402
-# text = Sana olacağını nereden çıkarıyorsun?.
+# text = Sana olacağını nereden çıkarıyorsun?
 1	Sana	sen	PRON	Pers	Case=Dat|Number=Sing|Person=2|PronType=Prs	2	obl	_	_
 2	olacağını	olacak	ADJ	NAdj	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
 3	nereden	nere	PRON	Ques	Case=Abl|Number=Sing|Person=3	4	obl	_	_
 4	çıkarıyorsun	çıkar	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Polite=Infm|Tense=Pres	0	root	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	4	punct	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-1404
 # text = EN SON ANNESİNİ ARADI.
@@ -13824,7 +13820,7 @@
 20	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-1540
-# text = Ben: Azıcık pencereyi açayım mı?.
+# text = Ben: Azıcık pencereyi açayım mı?
 1	Ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	SpaceAfter=No
 2	:	:	PUNCT	Punc	_	5	punct	_	_
 3	Azıcık	azıcık	ADV	Adverb	_	5	advmod	_	_
@@ -13832,7 +13828,6 @@
 5	açayım	aç	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Sing|Person=1|Polarity=Pos|Tense=Pres	0	root	_	_
 6	mı	mı	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Pres	5	aux:q	_	SpaceAfter=No
 7	?	?	PUNCT	Punc	_	5	punct	_	SpaceAfter=No
-8	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1542
 # text = ATO Başkanı Sinan Aygün, altı bankanın temerrüt faizini düşüreceğini, diğer bankalarla da görüşmelerin halen devam ettiğini söyledi.
@@ -14293,14 +14288,14 @@
 8	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-1597
-# text = Koşarak ona yaklaştı heyecanla Abi!.
+# text = Koşarak ona yaklaştı heyecanla Abi!...
 1	Koşarak	koş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	3	nmod	_	_
 2	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	3	obj	_	_
 3	yaklaştı	yaklaş	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
 4	heyecanla	heyecan	NOUN	Noun	Case=Ins|Number=Sing|Person=3	3	obl	_	_
 5	Abi	abi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	conj	_	SpaceAfter=No
 6	!	!	PUNCT	Punc	_	5	punct	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	5	punct	_	_
+7	...	...	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-1599
 # text = Ama diye devam etti, Köpek kahverengiymiş, bazı yerleri beyaza daha yakınmış, Kahve onun için daha uygun bir isim.
@@ -16374,7 +16369,7 @@
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-1829
-# text = Orhan ümitle ona baktı, Sen bir şeyler düşünüyorsun?.
+# text = Orhan ümitle ona baktı, Sen bir şeyler düşünüyorsun?
 1	Orhan	Orhan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 2	ümitle	ümit	NOUN	Noun	Case=Ins|Number=Sing|Person=3	4	obl	_	_
 3	ona	o	PRON	Pers	Case=Dat|Number=Sing|Person=3|PronType=Prs	4	obl	_	_
@@ -16385,7 +16380,6 @@
 8	şeyler	şey	NOUN	Noun	Case=Nom|Number=Plur|Person=3	9	obj	_	_
 9	düşünüyorsun	düşün	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=2|Polarity=Pos|Polite=Infm|Tense=Pres	4	conj	_	SpaceAfter=No
 10	?	?	PUNCT	Punc	_	9	punct	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-1832
 # text = Eğer ilk anda şarlamazsanız, size ciddi ciddi şunu öneriyorum: Aramızdan birini tesbit edelim.
@@ -20260,13 +20254,12 @@
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2232
-# text = Onları sekiz maddede tanıyalım!.
+# text = Onları sekiz maddede tanıyalım!
 1	Onları	o	PRON	Pers	Case=Acc|Number=Plur|Person=3|PronType=Prs	4	obj	_	_
 2	sekiz	sekiz	NUM	ANum	NumType=Card	3	nummod	_	_
 3	maddede	madde	NOUN	Noun	Case=Loc|Number=Sing|Person=3	4	obl	_	_
 4	tanıyalım	tanı	VERB	Verb	Aspect=Perf|Mood=Opt|Number=Plur|Person=1|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	Punc	_	4	punct	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2234
 # text = Uyandım ve sabah rolü bana verdiklerine dair telefon alacağımı bilerek tekrar uyudum.
@@ -23805,7 +23798,7 @@
 10	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-2636
-# text = Niye susmuştunuz ben dönüp baktığımda!?.
+# text = Niye susmuştunuz ben dönüp baktığımda!?
 1	Niye	niye	ADV	Adverb	_	2	advmod	_	_
 2	susmuştunuz	sus	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=2|Polarity=Pos|Tense=Pqp	0	root	_	_
 3	ben	ben	PRON	Pers	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
@@ -23813,7 +23806,6 @@
 5	baktığımda	bak	VERB	Verb	Aspect=Perf|Case=Loc|Mood=Ind|Number[psor]=Sing|Person[psor]=1|Polarity=Pos|Tense=Past|VerbForm=Part	2	acl	_	SpaceAfter=No
 6	!	!	PUNCT	Punc	_	5	punct	_	SpaceAfter=No
 7	?	?	PUNCT	Punc	_	5	punct	_	SpaceAfter=No
-8	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-2637
 # text = Gördün mü el konulduk bile.
@@ -25339,13 +25331,12 @@
 2	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-2800
-# text = Memurlar ne kadar alacak?.
+# text = Memurlar ne kadar alacak?
 1	Memurlar	memur	NOUN	Noun	Case=Nom|Number=Plur|Person=3	4	nsubj	_	_
 2	ne	ne	ADJ	Adj	_	4	amod	_	_
 3	kadar	kadar	ADP	PCDat	_	2	case	_	_
 4	alacak	al	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	4	punct	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2801
 # text = Dikkatimi çeken herkesin bizim gibi özenli giyimiydi.
@@ -28517,12 +28508,11 @@
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-3168
-# text = Gözünü kapa Melek!.
+# text = Gözünü kapa Melek!
 1	Gözünü	göz	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	2	obj	_	_
 2	kapa	kapa	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	_
 3	Melek	Melek	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	obj	_	SpaceAfter=No
 4	!	!	PUNCT	Punc	_	2	punct	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-3169
 # text = Saatine baktı.
@@ -29387,13 +29377,12 @@
 49	.	.	PUNCT	Punc	_	48	punct	_	_
 
 # sent_id = mst-3264
-# text = Yahu nasıl yaptırırız zorla?.
+# text = Yahu nasıl yaptırırız zorla?
 1	Yahu	yahu	INTJ	Interj	_	3	discourse	_	_
 2	nasıl	nasıl	ADV	Adverb	_	3	advmod	_	_
 3	yaptırırız	yap	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Pres|Voice=Cau	0	root	_	_
 4	zorla	zor	ADJ	NAdj	Case=Ins|Number=Sing|Person=3	3	amod	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	3	punct	_	SpaceAfter=No
-6	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3265
 # text = Koha kentinde işçiler için, hiçbir süsü olmayan, içinde ise oturacakların tüm gereksinimlerinin düşünüldüğü evler yaptı.
@@ -34111,7 +34100,7 @@
 7	.	.	PUNCT	Punc	_	5	punct	_	_
 
 # sent_id = mst-3786
-# text = Bana bak, geliyorum yanına ha, kalk haydi!.
+# text = Bana bak, geliyorum yanına ha, kalk haydi!
 1	Bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	2	obj	_	_
 2	bak	bak	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	4	punct	_	_
@@ -34122,7 +34111,6 @@
 8	kalk	kalk	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	2	conj	_	_
 9	haydi	haydi	INTJ	Interj	_	6	discourse	_	SpaceAfter=No
 10	!	!	PUNCT	Punc	_	9	punct	_	SpaceAfter=No
-11	.	.	PUNCT	Punc	_	9	punct	_	_
 
 # sent_id = mst-3787
 # text = Öyle...
@@ -35510,12 +35498,11 @@
 19	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-3935
-# text = Müşteri neyi sever?.
+# text = Müşteri neyi sever?
 1	Müşteri	müşteri	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	neyi	ne	PRON	Ques	Case=Acc|Number=Sing|Person=3	3	obj	_	_
 3	sever	sev	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	?	?	PUNCT	Punc	_	3	punct	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-3937
 # text = Algılanan dış dünyadaki herşey tanrı tarafından yaratılmıştır.
@@ -35931,7 +35918,7 @@
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-3991
-# text = Alışveriş bilimi neyi inceler?.
+# text = Alışveriş bilimi neyi inceler?
 1	Alışveriş	alışveriş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nmod	_	_
 2	bilimi	bilim	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
 3	neyi	ne	PRON	Ques	Case=Acc|Number=Sing|Person=3	4	obj	_	_
@@ -35939,7 +35926,6 @@
 4	ince	ince	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
 5	ler	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Tense=Pres	4	cop	_	_
 6	?	?	PUNCT	Punc	_	4	punct	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-3993
 # text = Ama şimdi duramıyorum.
@@ -37303,12 +37289,11 @@
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-4164
-# text = Kadınlar ne ister?.
+# text = Kadınlar ne ister?
 1	Kadınlar	kadın	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	3	nsubj	_	_
 2	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 3	ister	iste	VERB	Verb	Aspect=Hab|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	SpaceAfter=No
 4	?	?	PUNCT	Punc	_	3	punct	_	SpaceAfter=No
-5	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-4165
 # text = Çocukları yok.
@@ -40647,7 +40632,7 @@
 9	.	.	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-4522
-# text = Alışverişlerde çocukların etkisi nedir?.
+# text = Alışverişlerde çocukların etkisi nedir?
 # Fixed 2.2/dev: original sentence ID: 20210000-3/1
 1	Alışverişlerde	alışveriş	NOUN	Noun	Case=Loc|Number=Plur|Person=3	4	nmod	_	_
 2	çocukların	çocuk	NOUN	Noun	Case=Gen|Number=Plur|Person=3	3	nmod:poss	_	_
@@ -40656,7 +40641,6 @@
 4	ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
 5	dir	i	AUX	Zero	Aspect=Perf|Mood=Gen|Number=Sing|Person=3|Tense=Pres	4	cop	_	_
 6	?	?	PUNCT	Punc	_	4	punct	_	SpaceAfter=No
-7	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4523
 # text = Önceki gün saat onaltıotuz'da beni aradı.
@@ -42795,7 +42779,7 @@
 19	.	.	PUNCT	Punc	_	18	punct	_	_
 
 # sent_id = mst-4796
-# text = Melek her gün yüz bin lira kazansam, kış gelene kadar bir kondu alabilir miyiz?.
+# text = Melek her gün yüz bin lira kazansam, kış gelene kadar bir kondu alabilir miyiz?
 # Change 2.2/dev: merge -(y)An
 1	Melek	Melek	PROPN	Prop	Case=Nom|Number=Sing|Person=3	14	vocative	_	_
 2	her	her	DET	Det	_	7	det	_	_
@@ -42813,7 +42797,6 @@
 14	alabilir	al	VERB	Verb	Aspect=Hab|Mood=Pot|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	0	root	_	_
 15	miyiz	mi	AUX	Ques	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Tense=Pres	14	aux:q	_	SpaceAfter=No
 16	?	?	PUNCT	Punc	_	14	punct	_	SpaceAfter=No
-17	.	.	PUNCT	Punc	_	14	punct	_	_
 
 # sent_id = mst-4797
 # text = Ben Erbakan'ın yanında onun yanlışlarına ortak olsaydım kırk defa bakan olurdum, elli defa genel başkan olurdum.
@@ -47023,11 +47006,10 @@
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-5299
-# text = Ne malum?.
+# text = Ne malum?
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	0	root	_	_
 2	malum	malum	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	1	compound	_	SpaceAfter=No
 3	?	?	PUNCT	Punc	_	1	punct	_	SpaceAfter=No
-4	.	.	PUNCT	Punc	_	1	punct	_	_
 
 # sent_id = mst-5300
 # text = Artık rehberimden utandığım için bağırıp kervanı durdurmasını istemiyor, hızlı planjonlarla, kızağa yeniden tırmanıyordum.

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -2474,6 +2474,7 @@
 # sent_id = mst-0305
 # text = Tahvilin ikinci kuponu ve bu kupona ilişkin yapılacak olan referans bono ihalesi ise doksan gün vadeli olacak.
 # Change 2.2/dev: fix ordinal number
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Tahvilin	tahvil	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
 2	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	3	amod	_	_
 3	kuponu	kupon	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	18	nsubj	_	_
@@ -2486,7 +2487,7 @@
 10	referans	referans	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nsubj	_	_
 11	bono	bono	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nmod:poss	_	_
 12	ihalesi	ihale	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	3	conj	_	_
-13	ise	ise	CCONJ	Conj	_	12	discourse	_	_
+13	ise	i	AUX	Conj	_	12	discourse	_	_
 14	doksan	doksan	NUM	ANum	NumType=Card	15	nummod	_	_
 15	gün	gün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nmod	_	_
 16-17	vadeli	_	_	_	_	_	_	_	_
@@ -3709,8 +3710,9 @@
 
 # sent_id = mst-0416
 # text = Ev ise, barınağı da içine alan, hayata ilişkin daha yoğun ve daha geniş kapsamlı, mekansal bir ifadedir.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Ev	ev	NOUN	Noun	Case=Nom|Number=Sing|Person=3	21	nsubj	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	SpaceAfter=No
+2	ise	i	AUX	Conj	_	1	discourse	_	SpaceAfter=No
 3	,	,	PUNCT	Punc	_	21	punct	_	_
 4	barınağı	barınak	NOUN	Noun	Case=Acc|Number=Sing|Person=3	6	obj	_	_
 5	da	da	CCONJ	Conj	_	4	advmod:emph	_	_
@@ -7610,6 +7612,7 @@
 
 # sent_id = mst-0865
 # text = Yine cevap vermesine fırsat bırakmadan, Bir erkek gibi değil yani, erkekler yalnızca sevişebilmek için yalan söyleyebilir, ama seviştikten sonra sevebilir, bundan sonra ise yalan söylemez.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Yine	yine	ADV	Adverb	_	5	advmod	_	_
 2	cevap	cevap	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obj	_	_
 3	vermesine	ver	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	2	compound	_	_
@@ -7636,7 +7639,7 @@
 24	,	,	PUNCT	Punc	_	28	punct	_	_
 25	bundan	bu	PRON	Demons	Case=Abl|Number=Sing|Person=3|PronType=Dem	28	obl	_	_
 26	sonra	sonra	ADP	PCAbl	_	25	case	_	_
-27	ise	ise	CCONJ	Conj	_	25	discourse	_	_
+27	ise	i	AUX	Conj	_	25	discourse	_	_
 28	yalan	yalan	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	5	conj	_	_
 29	söylemez	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Aor	5	conj	_	SpaceAfter=No
 30	.	.	PUNCT	Punc	_	28	punct	_	_
@@ -9076,9 +9079,10 @@
 
 # sent_id = mst-1010
 # text = Kendi darbukası ise en pahalı, en iyi kalite darbukaydı.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Kendi	kendi	PRON	Reflex	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|Reflex=Yes	2	nmod	_	_
 2	darbukası	darbuka	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	nsubj	_	_
-3	ise	ise	CCONJ	Conj	_	2	discourse	_	_
+3	ise	i	AUX	Conj	_	2	discourse	_	_
 4	en	en	ADV	Adverb	_	5	advmod	_	_
 5	pahalı	pahalı	ADJ	Adj	_	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	10	punct	_	_
@@ -9134,11 +9138,12 @@
 
 # sent_id = mst-1017
 # text = Kuzey Halkları Enstitüsü'nün kurulması ise Evenlerin sorunlarının bilimsel platformlara taşınmasını sağladı.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Kuzey	Kuzey	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 2	Halkları	halk	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	1	flat	_	_
 3	Enstitüsü'nün	enstitü	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	flat	_	_
 4	kurulması	kur	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Pass	11	nsubj	_	_
-5	ise	ise	CCONJ	Conj	_	4	discourse	_	_
+5	ise	i	AUX	Conj	_	4	discourse	_	_
 6	Evenlerin	Evenler	PROPN	Prop	Case=Gen|Number=Sing|Person=3	7	nmod:poss	_	_
 7	sorunlarının	sorun	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	10	nmod:poss	_	_
 8	bilimsel	bilimsel	ADJ	Adj	_	9	amod	_	_
@@ -10222,13 +10227,14 @@
 
 # sent_id = mst-1135
 # text = Bu partiler arasındaki DYP'de ise gözle görülür bir hareketlilik var.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	partiler	parti	NOUN	Noun	Case=Nom|Number=Plur|Person=3	3	nmod:poss	_	_
 3-4	arasındaki	_	_	_	_	_	_	_	_
 3	arasında	ara	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	amod	_	_
 4	ki	ki	ADP	Rel	_	3	case	_	_
 5	DYP'de	Dyp	NOUN	Abr	Abbr=Yes|Case=Loc|Number=Sing|Person=3	11	obl	_	_
-6	ise	ise	CCONJ	Conj	_	5	discourse	_	_
+6	ise	i	AUX	Conj	_	5	discourse	_	_
 7	gözle	göz	NOUN	Noun	Case=Ins|Number=Sing|Person=3	10	nmod	_	_
 8	görülür	gör	VERB	Verb	Aspect=Imp|Mood=Ind|Polarity=Pos|Tense=Aor|VerbForm=Part|Voice=Pass	7	compound	_	_
 9	bir	bir	NUM	ANum	NumType=Card	10	det	_	_
@@ -10279,6 +10285,7 @@
 
 # sent_id = mst-1141
 # text = Katı, otoriter ve ilgisiz bir doktorla evli olan kadın, acısını uyuşturucu haplarla dindiriyor, yaşamındaki sevgi boşluğunu ise hayatını oğluna adayarak gidermeye çalışıyordu.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Katı	katı	ADJ	Adj	_	7	amod	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	15	punct	_	_
 3	otoriter	otoriter	ADJ	Adj	_	7	amod	_	_
@@ -10300,7 +10307,7 @@
 18	ki	ki	ADP	Rel	_	17	case	_	_
 19	sevgi	sevgi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	20	nmod:poss	_	_
 20	boşluğunu	boşluk	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	25	obj	_	_
-21	ise	ise	CCONJ	Conj	_	20	discourse	_	_
+21	ise	i	AUX	Conj	_	20	discourse	_	_
 22	hayatını	hayat	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	24	obj	_	_
 23	oğluna	oğul	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	24	obl	_	_
 24	adayarak	ada	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	25	nmod	_	_
@@ -10807,6 +10814,7 @@
 
 # sent_id = mst-1208
 # text = Programda konser veren bin bağlamacının 500'ü Türkiye'den, 500'ü ise Avrupa'dan geldi.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Programda	program	NOUN	Noun	Case=Loc|Number=Sing|Person=3	3	obl	_	_
 2	konser	konser	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 3	veren	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	12	obj	_	_
@@ -10816,7 +10824,7 @@
 7	Türkiye'den	Türkiye	PROPN	Prop	Case=Abl|Number=Sing|Person=3	12	obl	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	11	punct	_	_
 9	500'ü	500	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Card|Person=3|Person[psor]=3	6	conj	_	_
-10	ise	ise	CCONJ	Conj	_	9	discourse	_	_
+10	ise	i	AUX	Conj	_	9	discourse	_	_
 11	Avrupa'dan	Avrupa	PROPN	Prop	Case=Abl|Number=Sing|Person=3	7	conj	_	_
 12	geldi	gel	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	12	punct	_	_
@@ -12571,10 +12579,11 @@
 # sent_id = mst-1419
 # text = Niye mutsuz olduklarını ise söylemezlerdi, mutsuzluklarının nedenini siz keşfetmek zorundaydınız, bunu keşfedemezseniz biraz daha düşmanlaşırlardı; bu düşmanlık gerçek değildi, yalnızca mutsuzluklarının üstüne örtmeye çalıştıkları yakıcı bir örtüydü.
 # Change 2.2/dev: merge -(y)IcI
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Niye	niye	ADV	Adverb	_	3	advmod	_	_
 2	mutsuz	mutsuz	ADJ	Adj	_	3	amod	_	_
 3	olduklarını	ol	VERB	Verb	Aspect=Perf|Case=Acc|Mood=Ind|Number[psor]=Plur|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	5	obj	_	_
-4	ise	ise	CCONJ	Conj	_	3	discourse	_	_
+4	ise	i	AUX	Conj	_	3	discourse	_	_
 5	söylemezlerdi	söyle	VERB	Verb	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Polarity=Neg|Tense=AorPast	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	11	punct	_	_
 7	mutsuzluklarının	mutsuzluk	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	8	nmod:poss	_	_
@@ -13462,8 +13471,9 @@
 
 # sent_id = mst-1505
 # text = Evlerde ise tıpkı dünkü gibi eşyalar, kürkler çuvallara dolduruluyordu.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Evlerde	ev	NOUN	Noun	Case=Loc|Number=Plur|Person=3	11	obl	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+2	ise	i	AUX	Conj	_	1	discourse	_	_
 3	tıpkı	tıpkı	ADV	Adverb	_	4	advmod	_	_
 4-5	dünkü	_	_	_	_	_	_	_	_
 4	dün	dün	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nmod	_	_
@@ -13902,8 +13912,9 @@
 
 # sent_id = mst-1551
 # text = Tibet ise içine kapanık, sessiz bir çocuk.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Tibet	Tibet	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+2	ise	i	AUX	Conj	_	1	discourse	_	_
 3	içine	iç	ADJ	NAdj	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	amod	_	_
 4	kapanık	kapanık	ADJ	Adj	_	3	compound	_	SpaceAfter=No
 5	,	,	PUNCT	Punc	_	6	punct	_	_
@@ -14146,8 +14157,9 @@
 
 # sent_id = mst-1580
 # text = Ulaşmak ise imkansızdı.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Ulaşmak	ulaş	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	3	nsubj	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+2	ise	i	AUX	Conj	_	1	discourse	_	_
 3-4	imkansızdı	_	_	_	_	_	_	_	SpaceAfter=No
 3	imkansız	imkânsız	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	0	root	_	_
 4	dı	i	AUX	Zero	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Tense=Past	3	cop	_	_
@@ -14218,13 +14230,14 @@
 # sent_id = mst-1589
 # text = Dosyamızın esas unsuru olan ikinci bölümde ise sona eren bin yılın en büyük bilim ve düşün devrimlerini yansıtmaya çalıştık.
 # Change 2.2/dev: fix ordinal number
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Dosyamızın	dosya	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	3	nmod:poss	_	_
 2	esas	esas	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	3	amod	_	_
 3	unsuru	unsur	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	obj	_	_
 4	olan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	6	acl	_	_
 5	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	6	amod	_	_
 6	bölümde	bölüm	NOUN	Noun	Case=Loc|Number=Sing|Person=3	7	nmod	_	_
-7	ise	ise	CCONJ	Conj	_	18	nmod	_	_
+7	ise	i	AUX	Conj	_	18	nmod	_	_
 8	sona	son	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	9	amod	_	_
 9	eren	er	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	11	acl	_	_
 10	bin	bin	NUM	ANum	NumType=Card	11	nummod	_	_
@@ -18562,6 +18575,7 @@
 
 # sent_id = mst-2061
 # text = Konuya ilişkin ücretli işçi ile kapitalist arasındaki ilişki ne ise, kiracı ile evsahibi arasındaki ilişki de odur yargısını yıllar önce, Friedrich Engels şöyle eleştirmiş.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Konuya	konu	NOUN	Noun	Case=Dat|Number=Sing|Person=3	9	nmod	_	_
 2	ilişkin	ilişkin	ADP	PCDat	_	1	case	_	_
 3	ücretli	ücretli	ADJ	Adj	_	4	amod	_	_
@@ -18573,7 +18587,7 @@
 8	ki	ki	ADP	Rel	_	7	case	_	_
 9	ilişki	ilişki	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
 10	ne	ne	CCONJ	Conj	_	20	nmod	_	_
-11	ise	ise	ADP	Postp	Mood=Cnd|Number=Sing|Person=3	10	case	_	SpaceAfter=No
+11	ise	i	AUX	Postp	Mood=Cnd|Number=Sing|Person=3	10	case	_	SpaceAfter=No
 12	,	,	PUNCT	Punc	_	29	punct	_	_
 13	kiracı	kiracı	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	nmod:poss	_	_
 14	ile	ile	CCONJ	Conj	_	15	cc	_	_
@@ -19485,6 +19499,7 @@
 # sent_id = mst-2159
 # text = Chp'lilerin tarım ve sağlık sektörüne destek amacıyla verdiği önergeler ise " gider Başesgioğlu " olduğu gerekçesiyle kabul edilmedi.
 # Change 2.2/dev: merge li + lerin
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1-2	Chp'lilerin	_	_	_	_	_	_	_	_
 1	Chp	Chp	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	9	nmod:poss	_	_
 2	'lilerin	li	ADP	With	Case=Gen|Number=Plur|Person=3	1	case	_	_
@@ -19496,7 +19511,7 @@
 8	amacıyla	amaç	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
 9	verdiği	ver	VERB	Verb	Aspect=Perf|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part	10	nmod	_	_
 10	önergeler	önerge	NOUN	Noun	Case=Nom|Number=Plur|Person=3	11	nmod	_	_
-11	ise	ise	CCONJ	Conj	_	18	nmod	_	_
+11	ise	i	AUX	Conj	_	18	nmod	_	_
 12	"	"	PUNCT	Punc	_	13	punct	_	_
 13	gider	gider	NOUN	Noun	Case=Nom|Number=Sing|Person=3	16	obj	_	_
 14	Başesgioğlu	Başesgioğlu	PROPN	Prop	Case=Nom|Number=Sing|Person=3	13	compound	_	_
@@ -19948,8 +19963,9 @@
 
 # sent_id = mst-2204
 # text = Ayhan ise grubu yurtseverce kurmuş.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Ayhan	Ayhan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	5	nsubj	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+2	ise	i	AUX	Conj	_	1	discourse	_	_
 3	grubu	grup	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	obj	_	_
 4	yurtseverce	yurtsever	ADJ	NAdj	Case=Equ|Number=Sing|Person=3	5	amod	_	_
 5	kurmuş	kur	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	SpaceAfter=No
@@ -21747,8 +21763,9 @@
 
 # sent_id = mst-2416
 # text = Peyniri ise dünya çapında ünlü.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Peyniri	peynir	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	nsubj	_	_
-2	ise	ise	CCONJ	Conj	_	1	cc	_	_
+2	ise	i	AUX	Conj	_	1	cc	_	_
 3	dünya	dünya	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 4	çapında	çap	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	5	obl	_	_
 5	ünlü	ünlü	ADJ	Adj	_	0	root	_	SpaceAfter=No
@@ -22345,10 +22362,11 @@
 # sent_id = mst-2492
 # text = Rapor'un üçüncü sayfasında ise Takriben saat on.
 # Change 2.2/dev: fix ordinal number
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Rapor'un	Rapor	PROPN	Prop	Case=Gen|Number=Sing|Person=3	2	nmod	_	_
 2	üçüncü	üç	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	3	nmod:poss	_	_
 3	sayfasında	sayfa	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nmod	_	_
-4	ise	ise	CCONJ	Conj	_	7	nmod	_	_
+4	ise	i	AUX	Conj	_	7	nmod	_	_
 5	Takriben	takriben	ADV	Adverb	_	7	advmod	_	_
 6	saat	saat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	obj	_	_
 7	on	on	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
@@ -26038,10 +26056,11 @@
 
 # sent_id = mst-2889
 # text = Bir ineğin sütü ise sekiz koyunun sütüyle aynı.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Bir	bir	NUM	ANum	NumType=Card	2	det	_	_
 2	ineğin	inek	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
 3	sütü	süt	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nmod	_	_
-4	ise	ise	CCONJ	Conj	_	8	nmod	_	_
+4	ise	i	AUX	Conj	_	8	nmod	_	_
 5	sekiz	sekiz	NUM	ANum	NumType=Card	6	nummod	_	_
 6	koyunun	koyun	NOUN	Noun	Case=Gen|Number=Sing|Person=3	7	nmod:poss	_	_
 7	sütüyle	süt	NOUN	Noun	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	8	nsubj	_	_
@@ -27907,8 +27926,9 @@
 
 # sent_id = mst-3116
 # text = Akşit ise Çin seyahatinden en kazançlı turizm sektörünün çıktığını kaydederek, şöyle konuştu:.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Akşit	Akşit	PROPN	Prop	Case=Nom|Number=Sing|Person=3	14	nsubj	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+2	ise	i	AUX	Conj	_	1	discourse	_	_
 3	Çin	Çin	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 4	seyahatinden	seyahat	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	10	obl	_	_
 5	en	en	ADV	Adverb	_	6	advmod	_	_
@@ -28443,6 +28463,7 @@
 # sent_id = mst-3163
 # text = Ayrıca bunlardan birincisi, daha çok yüzyılın ilk yarısında gerçekleşmiş, ikincisi ise, yüzyılın ikinci yarısında zirvesine ulaşmıştır.
 # Change 2.2/dev: fix ordinal number
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Ayrıca	ayrıca	ADV	Adverb	_	0	root	_	_
 2	bunlardan	bu	PRON	Demons	Case=Abl|Number=Plur|Person=3|PronType=Dem	3	nmod:poss	_	_
 3	birincisi	bir	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	10	nsubj	_	SpaceAfter=No
@@ -28455,7 +28476,7 @@
 10	gerçekleşmiş	gerçekleş	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	1	conj	_	SpaceAfter=No
 11	,	,	PUNCT	Punc	_	19	punct	_	_
 12	ikincisi	iki	NUM	NNum	Case=Nom|Number=Sing|Number[psor]=Sing|NumType=Ord|Person=3|Person[psor]=3	19	nsubj	_	_
-13	ise	ise	CCONJ	Conj	_	12	cc	_	SpaceAfter=No
+13	ise	i	AUX	Conj	_	12	cc	_	SpaceAfter=No
 14	,	,	PUNCT	Punc	_	19	punct	_	_
 15	yüzyılın	yüzyıl	NOUN	Noun	Case=Gen|Number=Sing|Person=3	17	nmod:poss	_	_
 16	ikinci	iki	NUM	NNum	Case=Nom|Number=Sing|NumType=Ord|Person=3	17	amod	_	_
@@ -29375,6 +29396,7 @@
 
 # sent_id = mst-3265
 # text = Koha kentinde işçiler için, hiçbir süsü olmayan, içinde ise oturacakların tüm gereksinimlerinin düşünüldüğü evler yaptı.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Koha	Koha	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	nmod:poss	_	_
 2	kentinde	kent	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	17	obl	_	_
 3	işçiler	işçi	NOUN	Noun	Case=Nom|Number=Plur|Person=3	17	obl	_	_
@@ -29385,7 +29407,7 @@
 8	olmayan	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Part	16	acl	_	SpaceAfter=No
 9	,	,	PUNCT	Punc	_	8	punct	_	_
 10	içinde	iç	ADJ	NAdj	Case=Loc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	12	amod	_	_
-11	ise	ise	CCONJ	Conj	_	10	discourse	_	_
+11	ise	i	AUX	Conj	_	10	discourse	_	_
 12	oturacakların	otur	VERB	Verb	Aspect=Perf|Case=Gen|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part	14	nmod:poss	_	_
 13	tüm	tüm	DET	Det	_	14	det	_	_
 14	gereksinimlerinin	gereksinim	NOUN	Noun	Case=Gen|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	15	nmod:poss	_	_
@@ -30004,11 +30026,12 @@
 
 # sent_id = mst-3330
 # text = Ve dil varlığın evi ise, ev de dilin doğumevidir.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Ve	ve	CCONJ	Conj	_	0	root	_	_
 2	dil	dil	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nsubj	_	_
 3	varlığın	varlık	NOUN	Noun	Case=Gen|Number=Sing|Person=3	4	nmod	_	_
 4	evi	ev	NOUN	Noun	Case=Acc|Number=Sing|Person=3	1	conj	_	_
-5	ise	ise	ADP	Postp	Mood=Cnd|Number=Sing|Person=3	4	case	_	SpaceAfter=No
+5	ise	i	AUX	Postp	Mood=Cnd|Number=Sing|Person=3	4	case	_	SpaceAfter=No
 6	,	,	PUNCT	Punc	_	10	punct	_	_
 7	ev	ev	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
 8	de	de	CCONJ	Conj	_	7	advmod:emph	_	_
@@ -34336,9 +34359,10 @@
 
 # sent_id = mst-3813
 # text = Eski kulübeyi ise mutfak haline getirmişti.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Eski	eski	ADJ	Adj	_	2	amod	_	_
 2	kulübeyi	kulübe	NOUN	Noun	Case=Acc|Number=Sing|Person=3	5	obj	_	_
-3	ise	ise	CCONJ	Conj	_	2	discourse	_	_
+3	ise	i	AUX	Conj	_	2	discourse	_	_
 4	mutfak	mutfak	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
 5	haline	hal	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
 6	getirmişti	getir	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pqp	5	compound	_	SpaceAfter=No
@@ -34440,6 +34464,7 @@
 
 # sent_id = mst-3826
 # text = Bu oran aynı coğrafyada yaşayan Evenkler için yüzde sekiz, Yukagirler için ise yüzde dört.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Bu	bu	DET	Det	_	2	det	_	_
 2	oran	oran	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
 3	aynı	aynı	ADJ	Adj	_	4	amod	_	_
@@ -34452,7 +34477,7 @@
 10	,	,	PUNCT	Punc	_	14	punct	_	_
 11	Yukagirler	Yukagir	PROPN	Prop	Case=Nom|Number=Plur|Person=3	6	conj	_	_
 12	için	için	ADP	PCNom	_	11	case	_	_
-13	ise	ise	CCONJ	Conj	_	11	discourse	_	_
+13	ise	i	AUX	Conj	_	11	discourse	_	_
 14	yüzde	yüz	NUM	NNum	Case=Loc|Number=Sing|NumType=Card|Person=3	8	conj	_	_
 15	dört	dört	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	14	flat	_	SpaceAfter=No
 16	.	.	PUNCT	Punc	_	14	punct	_	_
@@ -34878,8 +34903,9 @@
 # sent_id = mst-3872
 # text = Günümüzde ise bu ilişki bütünüyle tersine dönmüş, bilim adeta tümüyle bir üretici güç haline indirgenmiştir.
 # Change 2.2/dev: merge -(y)IcI
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Günümüzde	gün	NOUN	Noun	Case=Loc|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	7	obl	_	_
-2	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+2	ise	i	AUX	Conj	_	1	discourse	_	_
 3	bu	bu	DET	Det	_	4	det	_	_
 4	ilişki	ilişki	NOUN	Noun	Case=Nom|Number=Sing|Person=3	7	nsubj	_	_
 5	bütünüyle	bütün	ADJ	NAdj	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	amod	_	_
@@ -34995,11 +35021,12 @@
 
 # sent_id = mst-3880
 # text = Dosya elimize geçtikten sonra ise olay aydınlanmaya başladı bizim açımızdan.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Dosya	dosya	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
 2	elimize	el	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Plur|Person=3|Person[psor]=1	8	obl	_	_
 3	geçtikten	geç	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	2	compound	_	_
 4	sonra	sonra	ADP	PCAbl	_	2	case	_	_
-5	ise	ise	CCONJ	Conj	_	2	discourse	_	_
+5	ise	i	AUX	Conj	_	2	discourse	_	_
 6	olay	olay	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	nsubj	_	_
 7	aydınlanmaya	aydınlan	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	8	nmod	_	_
 8	başladı	başla	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
@@ -38139,10 +38166,11 @@
 
 # sent_id = mst-4257
 # text = yirmibeş cesedin kimliğinin ise DNA incelemesiyle belirleneceği bildirildi.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	yirmibeş	yirmibeş	NUM	ANum	NumType=Card	2	nummod	_	_
 2	cesedin	ceset	NOUN	Noun	Case=Gen|Number=Sing|Person=3	3	nmod:poss	_	_
 3	kimliğinin	kimlik	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nmod:poss	_	_
-4	ise	ise	CCONJ	Conj	_	3	discourse	_	_
+4	ise	i	AUX	Conj	_	3	discourse	_	_
 5	DNA	dna	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 6	incelemesiyle	incele	VERB	Verb	Aspect=Perf|Case=Ins|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	7	nmod	_	_
 7	belirleneceği	belirle	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	8	nsubj	_	_
@@ -38686,6 +38714,7 @@
 
 # sent_id = mst-4311
 # text = En yüksek memur maaşı Başbakanlık müsteşarınınnki kabul edildiğinde ise yapılacak zam yüzsekiz milyon üçyüzseksendört bin beşyüz lira olacak.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	En	en	ADV	Adverb	_	2	advmod	_	_
 2	yüksek	yüksek	ADJ	Adj	_	4	amod	_	_
 3	memur	memur	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
@@ -38696,7 +38725,7 @@
 7	nki	ki	ADP	Rel	Case=Nom|Number=Sing|Person=3	6	case	_	_
 8	kabul	kabul	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	obl	_	_
 9	edildiğinde	et	VERB	Verb	Aspect=Perf|Case=Loc|Mood=Ind|Number[psor]=Sing|Person[psor]=3|Polarity=Pos|Tense=Past|VerbForm=Part|Voice=Pass	8	compound:lvc	_	_
-10	ise	ise	CCONJ	Conj	_	8	discourse	_	_
+10	ise	i	AUX	Conj	_	8	discourse	_	_
 11	yapılacak	yap	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Fut|VerbForm=Part|Voice=Pass	12	acl	_	_
 12	zam	zam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	19	nsubj	_	_
 13	yüzsekiz	yüzsekiz	NUM	ANum	NumType=Card	19	obj	_	_
@@ -38909,10 +38938,11 @@
 
 # sent_id = mst-4334
 # text = Ali Talip Özdemir ise kongrenin çok büyük olacağını vurguladı.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Ali	Ali	PROPN	Prop	Case=Nom|Number=Sing|Person=3	9	nsubj	_	_
 2	Talip	Talip	PROPN	Prop	Case=Nom|Number=Sing|Person=3	1	flat	_	_
 3	Özdemir	Özdemir	PROPN	Prop	Case=Nom|Number=Sing|Person=3	1	flat	_	_
-4	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+4	ise	i	AUX	Conj	_	1	discourse	_	_
 5	kongrenin	kongre	NOUN	Noun	Case=Gen|Number=Sing|Person=3	8	nmod:poss	_	_
 6	çok	çok	ADV	Adverb	_	7	advmod	_	_
 7	büyük	büyük	ADJ	Adj	_	8	amod	_	_
@@ -38958,13 +38988,14 @@
 
 # sent_id = mst-4339
 # text = Velhasıl, gevşek bir İhtilal Harekatı idi.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Velhasıl	velhasıl	ADV	Adverb	_	6	advmod	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	6	punct	_	_
 3	gevşek	gevşek	ADJ	Adj	_	6	amod	_	_
 4	bir	bir	NUM	ANum	NumType=Card	6	det	_	_
 5	İhtilal	ihtilal	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 6	Harekatı	harekat	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	0	root	_	_
-7	idi	idi	ADP	Postp	Number=Sing|Person=3|Tense=Past	6	case	_	SpaceAfter=No
+7	idi	i	AUX	Postp	Number=Sing|Person=3|Tense=Past	6	case	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-4341
@@ -39054,10 +39085,11 @@
 
 # sent_id = mst-4351
 # text = İnceleme bittikten sonra ise ellerindeki belgelerle notları birleştirip olayı bir kez daha yaşamaya başladılar.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	İnceleme	incele	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	2	nsubj	_	_
 2	bittikten	bit	VERB	Verb	Aspect=Perf|Case=Abl|Mood=Ind|Polarity=Pos|Tense=Past|VerbForm=Part	15	acl	_	_
 3	sonra	sonra	ADP	PCAbl	_	2	case	_	_
-4	ise	ise	CCONJ	Conj	_	2	discourse	_	_
+4	ise	i	AUX	Conj	_	2	discourse	_	_
 5-6	ellerindeki	_	_	_	_	_	_	_	_
 5	ellerinde	el	NOUN	Noun	Case=Loc|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	7	nmod	_	_
 6	ki	ki	ADP	Rel	_	5	case	_	_
@@ -39319,13 +39351,14 @@
 
 # sent_id = mst-4380
 # text = Bemka genel ekonomi ile ilgili önerileri ise şunlar:.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Bemka	Bemka	PROPN	Prop	Case=Nom|Number=Sing|Person=3	6	nmod:poss	_	_
 2	genel	genel	ADJ	Adj	_	3	amod	_	_
 3	ekonomi	ekonomi	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	obl	_	_
 4	ile	ile	ADP	PCNom	_	3	case	_	_
 5	ilgili	ilgili	ADJ	Adj	_	6	amod	_	_
 6	önerileri	öneri	NOUN	Noun	Case=Nom|Number=Plur|Number[psor]=Sing|Person=3|Person[psor]=3	8	nsubj	_	_
-7	ise	ise	CCONJ	Conj	_	6	discourse	_	_
+7	ise	i	AUX	Conj	_	6	discourse	_	_
 8	şunlar	şu	PRON	Demons	Case=Nom|Number=Plur|Person=3|PronType=Dem	0	root	_	SpaceAfter=No
 9	:	:	PUNCT	Punc	_	8	punct	_	SpaceAfter=No
 10	.	.	PUNCT	Punc	_	8	punct	_	_
@@ -39404,12 +39437,13 @@
 
 # sent_id = mst-4390
 # text = Lam deniz demek, ut ise Türkçedeki ci eki.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Lam	lam	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	nsubj	_	_
 2	deniz	deniz	NOUN	Noun	Case=Nom|Number=Sing|Person=3	3	obj	_	_
 3	demek	de	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	10	punct	_	_
 5	ut	ut	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	nsubj	_	_
-6	ise	ise	CCONJ	Conj	_	5	discourse	_	_
+6	ise	i	AUX	Conj	_	5	discourse	_	_
 7-8	Türkçedeki	_	_	_	_	_	_	_	_
 7	Türkçede	Türkçe	ADJ	NAdj	Case=Loc|Number=Sing|Person=3	10	amod	_	_
 8	ki	ki	ADP	Rel	_	7	case	_	_
@@ -39919,12 +39953,13 @@
 
 # sent_id = mst-4444
 # text = SP Genel Başkanı Recai Kutan ise iktidara gelirlerse ilk yapacakları icraatın IMF ile yapılan anlaşmaları yırtıp atmak olacağını kaydetti.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	SP	SP	NOUN	Abr	Abbr=Yes|Case=Nom|Number=Sing|Person=3	2	compound	_	_
 2	Genel	genel	ADJ	Adj	_	3	amod	_	_
 3	Başkanı	başkan	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	compound	_	_
 4	Recai	Recai	PROPN	Prop	Case=Nom|Number=Sing|Person=3	19	nsubj	_	_
 5	Kutan	Kutan	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	flat	_	_
-6	ise	ise	CCONJ	Conj	_	4	discourse	_	_
+6	ise	i	AUX	Conj	_	4	discourse	_	_
 7	iktidara	iktidar	NOUN	Noun	Case=Dat|Number=Sing|Person=3	8	obl	_	_
 8	gelirlerse	gel	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Aor	18	nmod	_	_
 9	ilk	ilk	ADJ	Adj	_	10	amod	_	_
@@ -42891,11 +42926,12 @@
 
 # sent_id = mst-4805
 # text = PKK Ateş Açtı başlığı ise içerde kullanılmış.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	PKK	Pkk	PROPN	Prop	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
 2	Ateş	Ateş	PROPN	Prop	Case=Nom|Number=Sing|Person=3	4	nmod:poss	_	_
 3	Açtı	aç	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past	2	compound	_	_
 4	başlığı	başlık	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	7	nsubj	_	_
-5	ise	ise	CCONJ	Conj	_	4	discourse	_	_
+5	ise	i	AUX	Conj	_	4	discourse	_	_
 6	içerde	içeri	NOUN	Noun	Case=Loc|Number=Sing|Person=3	7	obl	_	_
 7	kullanılmış	kullan	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	Punc	_	7	punct	_	_
@@ -45044,11 +45080,12 @@
 
 # sent_id = mst-5036
 # text = Duyguları öldürme eşiğinin tavanı ise ölüm.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Duyguları	duygu	NOUN	Noun	Case=Acc|Number=Plur|Person=3	2	obj	_	_
 2	öldürme	öl	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun|Voice=Cau	3	nmod:poss	_	_
 3	eşiğinin	eşik	NOUN	Noun	Case=Gen|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nmod:poss	_	_
 4	tavanı	tavan	ADJ	NAdj	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nsubj	_	_
-5	ise	ise	CCONJ	Conj	_	4	discourse	_	_
+5	ise	i	AUX	Conj	_	4	discourse	_	_
 6	ölüm	ölüm	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
@@ -46127,6 +46164,7 @@
 
 # sent_id = mst-5184
 # text = Bakanlık, davaya müdahil olacak şehit ve yaralı diplomat ailelerine ise maddi ve manevi destek sağlayacak.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Bakanlık	bakanlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	17	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	Punc	_	17	punct	_	_
 3	davaya	dava	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
@@ -46139,7 +46177,7 @@
 9	lı	li	ADP	With	_	8	case	_	_
 10	diplomat	diplomat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	11	nmod:poss	_	_
 11	ailelerine	aile	NOUN	Noun	Case=Dat|Number=Plur|Number[psor]=Plur|Person=3|Person[psor]=3	12	nmod	_	_
-12	ise	ise	CCONJ	Conj	_	17	nmod	_	_
+12	ise	i	AUX	Conj	_	17	nmod	_	_
 13	maddi	maddi	ADJ	Adj	_	16	amod	_	_
 14	ve	ve	CCONJ	Conj	_	15	cc	_	_
 15	manevi	manevi	ADJ	Adj	_	13	conj	_	_
@@ -47013,9 +47051,10 @@
 
 # sent_id = mst-5301
 # text = Çoban salatası ise ayrı bir cümbüş.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Çoban	çoban	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	nsubj	_	_
 2	salatası	salata	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	1	compound	_	_
-3	ise	ise	CCONJ	Conj	_	1	discourse	_	_
+3	ise	i	AUX	Conj	_	1	discourse	_	_
 4	ayrı	ayrı	ADJ	Adj	_	6	amod	_	_
 5	bir	bir	NUM	ANum	NumType=Card	6	det	_	_
 6	cümbüş	cümbüş	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	SpaceAfter=No
@@ -47195,10 +47234,11 @@
 
 # sent_id = mst-5323
 # text = Kazanın üzerinden nerede ise bir yılı aşkın zaman geçmişti.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Kazanın	kaza	NOUN	Noun	Case=Gen|Number=Sing|Person=3	2	nmod	_	_
 2	üzerinden	üzer	NOUN	Noun	Case=Abl|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	9	obl	_	_
 3	nerede	nere	PRON	Ques	Case=Loc|Number=Sing|Person=3	9	obl	_	_
-4	ise	ise	ADP	Postp	Mood=Cnd|Number=Sing|Person=3	3	case	_	_
+4	ise	i	AUX	Postp	Mood=Cnd|Number=Sing|Person=3	3	case	_	_
 5	bir	bir	NUM	ANum	NumType=Card	6	nummod	_	_
 6	yılı	yıl	NOUN	Noun	Case=Acc|Number=Sing|Person=3	8	nmod	_	_
 7	aşkın	aşkın	ADP	PCAcc	_	6	case	_	_
@@ -49842,11 +49882,12 @@
 
 # sent_id = mst-5599
 # text = Tabii bir ayağım Ankara'da idi.
+# Change 2.2/dev: mark i- (ise/imiş/idi/iken) as AUX
 1	Tabii	tabii	ADJ	Adj	_	4	amod	_	_
 2	bir	bir	NUM	ANum	NumType=Card	3	det	_	_
 3	ayağım	ayak	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	4	nsubj	_	_
 4	Ankara'da	Ankara	PROPN	Prop	Case=Loc|Number=Sing|Person=3	0	root	_	_
-5	idi	idi	ADP	Postp	Number=Sing|Person=3|Tense=Past	4	case	_	SpaceAfter=No
+5	idi	i	AUX	Postp	Number=Sing|Person=3|Tense=Past	4	cop	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-5600

--- a/tr_imst-ud-train.conllu
+++ b/tr_imst-ud-train.conllu
@@ -913,7 +913,7 @@
 11-12	sağlıklı	_	_	_	_	_	_	_	_
 11	sağlık	sağlık	NOUN	Noun	Case=Nom|Number=Sing|Person=3	13	obl	_	_
 12	lı	li	ADP	With	_	11	case	_	_
-13	olacaktı	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+13	olacaktı	ol	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 14	.	.	PUNCT	Punc	_	13	punct	_	_
 
 # sent_id = mst-0112
@@ -1049,7 +1049,7 @@
 5	için	için	ADP	PCNom	_	4	case	_	_
 6	se	i	AUX	Zero	Aspect=Perf|Mood=Cnd|Number=Sing|Person=3|Tense=Pres	4	cop	_	_
 7	zamanla	zaman	NOUN	Noun	Case=Ins|Number=Sing|Person=3	8	obl	_	_
-8	yarışacaklardı	yarış	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+8	yarışacaklardı	yarış	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Plur|Person=3|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 9	...	...	PUNCT	Punc	_	8	punct	_	_
 
 # sent_id = mst-0133
@@ -1241,7 +1241,7 @@
 # sent_id = mst-0158
 # text = Ne diyecektik.
 1	Ne	ne	PRON	Ques	Case=Nom|Number=Sing|Person=3	2	obj	_	_
-2	diyecektik	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+2	diyecektik	de	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Punc	_	2	punct	_	_
 
 # sent_id = mst-0159
@@ -1352,7 +1352,7 @@
 # text = Geceyi böylece geçirebilecektik.
 1	Geceyi	gece	NOUN	Noun	Case=Acc|Number=Sing|Person=3	3	obj	_	_
 2	böylece	böylece	ADV	Adverb	_	3	advmod	_	_
-3	geçirebilecektik	geçir	VERB	Verb	Aspect=Perf|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+3	geçirebilecektik	geçir	VERB	Verb	Aspect=Prosp|Mood=Pot|Number=Plur|Person=1|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-0176
@@ -7993,7 +7993,7 @@
 # text = Kim tamir edecekti beni?.
 1	Kim	kim	PRON	Ques	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
 2	tamir	tamir	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-3	edecekti	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	2	compound:lvc	_	_
+3	edecekti	et	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	2	compound:lvc	_	_
 4	beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	_	SpaceAfter=No
 5	?	?	PUNCT	Punc	_	2	punct	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	2	punct	_	_
@@ -11696,7 +11696,7 @@
 # text = Bunlara yeşiller diyecektim.
 1	Bunlara	bu	PRON	Demons	Case=Dat|Number=Plur|Person=3|PronType=Dem	3	obl	_	_
 2	yeşiller	yeşil	ADJ	NAdj	Case=Nom|Number=Plur|Person=3	3	obj	_	_
-3	diyecektim	de	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+3	diyecektim	de	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Punc	_	3	punct	_	_
 
 # sent_id = mst-1307
@@ -12027,7 +12027,7 @@
 5	sevgilimle	sevgili	ADJ	NAdj	Case=Ins|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	6	amod	_	_
 6	buluşup	buluş	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	nmod	_	_
 7	yemek	yemek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
-8	yiyecektim	ye	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=FutPast	7	compound	_	SpaceAfter=No
+8	yiyecektim	ye	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Fut,Past	7	compound	_	SpaceAfter=No
 9	.	.	PUNCT	Punc	_	7	punct	_	_
 
 # sent_id = mst-1353
@@ -14151,7 +14151,7 @@
 7	kalp	kalp	ADJ	NAdj	Case=Nom|Number=Sing|Person=3	10	amod	_	_
 8	krizi	kriz	NOUN	Noun	Case=Acc|Number=Sing|Person=3	7	compound	_	_
 9	geçirip	geçir	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Conv	7	compound	_	_
-10	ölecekti	öl	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+10	ölecekti	öl	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 11	,	,	PUNCT	Punc	_	10	punct	_	_
 12	Paris'te	Paris	PROPN	Prop	Case=Loc|Number=Sing|Person=3	10	obl	_	SpaceAfter=No
 13	.	.	PUNCT	Punc	_	10	punct	_	_
@@ -15888,7 +15888,7 @@
 7	ve	ve	CCONJ	Conj	_	10	cc	_	_
 8	bir	bir	NUM	ANum	NumType=Card	9	det	_	_
 9	yön	yön	NOUN	Noun	Case=Nom|Number=Sing|Person=3	10	obj	_	_
-10	bulabileceklerdi	bul	VERB	Verb	Aspect=Perf|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=FutPast	6	conj	_	SpaceAfter=No
+10	bulabileceklerdi	bul	VERB	Verb	Aspect=Prosp|Mood=Pot|Number=Plur|Person=3|Polarity=Pos|Tense=Fut,Past	6	conj	_	SpaceAfter=No
 11	.	.	PUNCT	Punc	_	10	punct	_	_
 
 # sent_id = mst-1775
@@ -18869,7 +18869,7 @@
 2	anlatmayıp	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Neg|Tense=Pres|VerbForm=Conv	5	obj	_	_
 3	da	da	CCONJ	Conj	_	2	advmod:emph	_	_
 4	kime	kim	PRON	Ques	Case=Dat|Number=Sing|Person=3	5	obl	_	_
-5	anlatacaktım	anlat	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+5	anlatacaktım	anlat	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 6	?	?	PUNCT	Punc	_	7	punct	_	_
 7	Kimim	kim	PRON	Ques	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	5	conj	_	_
 8	kimsem	kimse	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	7	compound	_	_
@@ -21266,7 +21266,7 @@
 1	Ama	ama	CCONJ	Conj	_	0	root	_	_
 2	okuma	oku	VERB	Verb	Aspect=Perf|Case=Nom|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	4	obj	_	_
 3	yazma	yazma	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	conj	_	_
-4	öğrenecekti	öğren	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	1	conj	_	SpaceAfter=No
+4	öğrenecekti	öğren	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	1	conj	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-2360
@@ -24063,7 +24063,7 @@
 1	Beni	ben	PRON	Pers	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	_	_
 2	köşeye	köşe	NOUN	Noun	Case=Dat|Number=Sing|Person=3	4	obl	_	_
 3	sıkıştırırlarsa	sıkış	VERB	Verb	Aspect=Imp|Mood=Cnd|Number=Plur|Person=3|Polarity=Pos|Tense=Aor|Voice=Cau	2	compound	_	_
-4	çıkaracaktım	çıkar	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=FutPast	0	root	_	_
+4	çıkaracaktım	çıkar	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=1|Polarity=Pos|Tense=Fut,Past	0	root	_	_
 5	ortaya	orta	ADJ	NAdj	Case=Dat|Number=Sing|Person=3	4	compound	_	SpaceAfter=No
 6	.	.	PUNCT	Punc	_	4	punct	_	_
 
@@ -25151,7 +25151,7 @@
 13	düellosunu	düello	NOUN	Noun	Case=Acc|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	14	obj	_	_
 14	kazanan	kazan	VERB	Verb	Aspect=Perf|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Part	16	nsubj	_	_
 15	muzaffer	muzaffer	ADJ	Adj	_	16	obj	_	_
-16	olacaktı	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+16	olacaktı	ol	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 17	.	.	PUNCT	Punc	_	16	punct	_	_
 
 # sent_id = mst-2777
@@ -29638,7 +29638,7 @@
 # text = Madem yaşlı olacaktı, yeğenine varsaydım keşke.
 1	Madem	madem	NOUN	Noun	Case=Nom|Number=Sing|Person=3	0	root	_	_
 2	yaşlı	yaşlı	ADJ	Adj	_	3	amod	_	_
-3	olacaktı	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	1	conj	_	SpaceAfter=No
+3	olacaktı	ol	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	1	conj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	6	punct	_	_
 5	yeğenine	yeğen	NOUN	Noun	Case=Dat|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	obl	_	_
 6	varsaydım	var	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=1|Polarity=Pos|Tense=Past	3	conj	_	_
@@ -34164,7 +34164,7 @@
 4	bir	bir	NUM	ANum	NumType=Card	5	det	_	_
 5	açıklamaya	açıkla	VERB	Verb	Aspect=Perf|Case=Dat|Mood=Ind|Polarity=Pos|Tense=Pres|VerbForm=Vnoun	6	nmod	_	_
 6	ihtiyacım	ihtiyaç	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=1	0	root	_	_
-7	olacaktı	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	6	compound:lvc	_	_
+7	olacaktı	ol	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	6	compound:lvc	_	_
 8	belli	belli	ADJ	Adj	_	13	amod	_	_
 9	ki	ki	CCONJ	Conj	_	8	advmod:emph	_	_
 10	Köpek	köpek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	12	nsubj	_	_
@@ -35388,7 +35388,7 @@
 3	bir	bir	NUM	ANum	NumType=Card	4	det	_	_
 4	tazminat	tazminat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod:poss	_	_
 5	davası	dava	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	6	nsubj	_	_
-6	olacaktı	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	0	root	_	SpaceAfter=No
+6	olacaktı	ol	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Punc	_	6	punct	_	_
 
 # sent_id = mst-3920
@@ -40352,7 +40352,7 @@
 1	Sinek	sinek	NOUN	Noun	Case=Nom|Number=Sing|Person=3	2	nsubj	_	_
 2	uçsa	uç	VERB	Verb	Aspect=Perf|Mood=Des|Number=Sing|Person=3|Polarity=Pos|Tense=Pres	4	nmod	_	_
 3	vızıltısı	vızıltı	NOUN	Noun	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3	4	nsubj	_	_
-4	duyulacaktı	duy	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast|Voice=Pass	0	root	_	SpaceAfter=No
+4	duyulacaktı	duy	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past|Voice=Pass	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Punc	_	4	punct	_	_
 
 # sent_id = mst-4488
@@ -43545,7 +43545,7 @@
 2	,	,	PUNCT	Punc	_	3	punct	_	_
 3	hiçbiri	hiçbiri	PRON	Quant	Case=Nom|Number=Sing|Number[psor]=Sing|Person=3|Person[psor]=3|PronType=Ind	1	conj	_	SpaceAfter=No
 4	,	,	PUNCT	Punc	_	3	punct	_	_
-5	bitmeyecekmiş	bit	VERB	Verb	Aspect=Perf|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=FutPast	7	nmod	_	_
+5	bitmeyecekmiş	bit	VERB	Verb	Aspect=Prosp|Evident=Nfh|Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Fut,Past	7	nmod	_	_
 6	gibi	gibi	ADP	PCNom	_	5	case	_	_
 7	geliyordu	gel	VERB	Verb	Aspect=Prog|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Polite=Infm|Tense=Past	0	root	_	_
 8	bana	ben	PRON	Pers	Case=Dat|Number=Sing|Person=1|PronType=Prs	7	obl	_	SpaceAfter=No
@@ -48081,7 +48081,7 @@
 8	yetmiş	yetmiş	NUM	NNum	Case=Nom|Number=Sing|NumType=Card|Person=3	10	obj	_	_
 9	kilometre	kilometre	NOUN	Noun	Case=Nom|Number=Sing|Person=3	8	compound	_	_
 10	kat	kat	NOUN	Noun	Case=Nom|Number=Sing|Person=3	4	parataxis	_	_
-11	edecektik	et	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=FutPast	10	compound	_	SpaceAfter=No
+11	edecektik	et	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Plur|Person=1|Polarity=Pos|Tense=Fut,Past	10	compound	_	SpaceAfter=No
 12	-	-	PUNCT	Punc	_	20	punct	_	SpaceAfter=No
 13	bir	bir	NUM	ANum	NumType=Card	15	nummod	_	_
 14	tek	tek	ADJ	Adj	_	13	compound	_	_
@@ -49075,7 +49075,7 @@
 3	yarım	yarım	ADJ	Adj	_	4	amod	_	_
 4	şişe	şişe	NOUN	Noun	Case=Nom|Number=Sing|Person=3	5	nmod	_	_
 5	viski	viski	NOUN	Noun	Case=Nom|Number=Sing|Person=3	6	obj	_	_
-6	olacaktı	ol	VERB	Verb	Aspect=Perf|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=FutPast	0	root	_	_
+6	olacaktı	ol	VERB	Verb	Aspect=Prosp|Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Fut,Past	0	root	_	_
 7	dolapta	dolap	NOUN	Noun	Case=Loc|Number=Sing|Person=3	6	obl	_	SpaceAfter=No
 8	,	,	PUNCT	Punc	_	6	punct	_	_
 9	getir	getir	VERB	Verb	Aspect=Perf|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Tense=Pres	6	conj	_	_


### PR DESCRIPTION
The changes are mostly about fixing some of the trivial errors introduced by automatic processing. There are also some changes to POS tags and features. Most notably:

- `Tense=Aor*` is replaced with proper Tense/Aspect combinations
- `Tense=FutPast` is now `Tense=Fut,Past|Aspect=Prosp` 
- Merge split case suffixes (often after a participle)
- Merge the suffixes _-CA_, _-(y)IcI_
- Mark locative pronouns as `PRON`
- Unify the analysis of morpheme and clitic versions of _i-_

See the omments on individual commits for more detail.